### PR TITLE
fix(ci): workflow YAML 파싱 오류 수정

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -34,8 +34,10 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "number=${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
+            echo "title=수동 테스트 PR #${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
           else
             echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            echo "title=${{ github.event.pull_request.title }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Get PR diff
@@ -48,6 +50,6 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
-          PR_TITLE: ${{ github.event.pull_request.title || format('수동 테스트 PR #{0}', github.event.inputs.pr_number) }}
+          PR_TITLE: ${{ steps.pr.outputs.title }}
           REPO: ${{ github.repository }}
         run: python .github/scripts/claude_review.py


### PR DESCRIPTION
## Summary
- `format('수동 테스트 PR #{0}', ...)` 내 `}` 가 `${{ }}` 표현식을 조기 종료하는 YAML 파싱 오류 수정
- PR_TITLE을 `Resolve PR number` 스텝 output으로 분리하여 해결

## Test plan
- [ ] 워크플로우 자동 실행 확인 (이 PR 오픈 시 트리거)
- [ ] Claude 리뷰 코멘트 정상 게시 확인