### PR TITLE
✨ POST /api/v1/analysis 분석 요청 엔드포인트 (#4)

### DIFF
--- a/src/main/java/com/checkmate/web/controller/NewsController.java
+++ b/src/main/java/com/checkmate/web/controller/NewsController.java
@@ -1,0 +1,34 @@
+package com.checkmate.web.controller;
+
+import com.checkmate.web.dto.request.AnalysisRequest;
+import com.checkmate.web.dto.response.AnalysisResponse;
+import com.checkmate.web.service.AnalysisService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 뉴스 기사 분석 컨트롤러 */
+@RestController
+@RequestMapping("/api/v1/analysis")
+@RequiredArgsConstructor
+public class NewsController {
+
+  private final AnalysisService analysisService;
+
+  /**
+   * 뉴스 기사 분석 요청
+   *
+   * @param request 분석할 뉴스 기사 URL
+   * @return 생성된 세션 ID와 상태 (201 Created)
+   */
+  @PostMapping
+  public ResponseEntity<AnalysisResponse> analyze(@Valid @RequestBody AnalysisRequest request) {
+    AnalysisResponse response = analysisService.analyze(request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+}

--- a/src/main/java/com/checkmate/web/converter/AnalysisConverter.java
+++ b/src/main/java/com/checkmate/web/converter/AnalysisConverter.java
@@ -1,0 +1,19 @@
+package com.checkmate.web.converter;
+
+import com.checkmate.web.dto.response.AnalysisResponse;
+import com.checkmate.web.entity.AnalysisSession;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/** AnalysisSession ↔ AnalysisResponse 변환 유틸리티 */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AnalysisConverter {
+
+  /** AnalysisSession → AnalysisResponse 변환 */
+  public static AnalysisResponse toResponse(AnalysisSession session) {
+    return AnalysisResponse.builder()
+        .sessionId(session.getId())
+        .status(session.getStatus().name())
+        .build();
+  }
+}

--- a/src/main/java/com/checkmate/web/dto/request/AnalysisRequest.java
+++ b/src/main/java/com/checkmate/web/dto/request/AnalysisRequest.java
@@ -1,0 +1,6 @@
+package com.checkmate.web.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+/** 뉴스 기사 분석 요청 DTO */
+public record AnalysisRequest(@NotBlank(message = "URL은 필수입니다") String url) {}

--- a/src/main/java/com/checkmate/web/dto/response/AnalysisResponse.java
+++ b/src/main/java/com/checkmate/web/dto/response/AnalysisResponse.java
@@ -1,0 +1,21 @@
+package com.checkmate.web.dto.response;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 뉴스 기사 분석 시작 응답 DTO */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnalysisResponse {
+
+  /** 분석 세션 ID */
+  private UUID sessionId;
+
+  /** 현재 세션 상태 */
+  private String status;
+}

--- a/src/main/java/com/checkmate/web/service/AnalysisService.java
+++ b/src/main/java/com/checkmate/web/service/AnalysisService.java
@@ -1,0 +1,63 @@
+package com.checkmate.web.service;
+
+import com.checkmate.web.converter.AnalysisConverter;
+import com.checkmate.web.dto.request.AnalysisRequest;
+import com.checkmate.web.dto.response.AnalysisResponse;
+import com.checkmate.web.dto.response.ExtractedArticle;
+import com.checkmate.web.entity.AnalysisSession;
+import com.checkmate.web.entity.Article;
+import com.checkmate.web.entity.enums.SessionStatus;
+import com.checkmate.web.repository.AnalysisSessionRepository;
+import com.checkmate.web.repository.ArticleRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 뉴스 기사 분석 오케스트레이션 서비스 */
+@Service
+@RequiredArgsConstructor
+public class AnalysisService {
+
+  private final AnalysisSessionRepository sessionRepository;
+  private final ArticleRepository articleRepository;
+  private final ContentExtractService contentExtractService;
+
+  /**
+   * 뉴스 기사 URL을 받아 분석 세션을 생성하고 본문을 추출한다.
+   *
+   * @param request URL이 담긴 요청 DTO
+   * @return 생성된 세션 ID와 현재 상태
+   */
+  @Transactional
+  public AnalysisResponse analyze(AnalysisRequest request) {
+    // 1. AnalysisSession 생성 (status=PENDING, member=null — 비회원 허용)
+    AnalysisSession session =
+        AnalysisSession.builder()
+            .status(SessionStatus.PENDING)
+            .requestedAt(LocalDateTime.now())
+            .build();
+    sessionRepository.save(session);
+
+    // 2. 기사 본문 추출
+    ExtractedArticle extracted = contentExtractService.extract(request.url());
+
+    // 3. Article 생성
+    Article article =
+        Article.builder()
+            .session(session)
+            .url(request.url())
+            .title(extracted.getTitle())
+            .body(extracted.getBody())
+            .lang(extracted.getLang())
+            .domain(extracted.getDomain())
+            .extractedAt(LocalDateTime.now())
+            .build();
+    articleRepository.save(article);
+
+    // 4. 세션 상태 → EXTRACTING (비즈니스 메서드 사용)
+    session.updateStatus(SessionStatus.EXTRACTING);
+
+    return AnalysisConverter.toResponse(session);
+  }
+}

--- a/src/main/java/com/checkmate/web/service/AnalysisService.java
+++ b/src/main/java/com/checkmate/web/service/AnalysisService.java
@@ -23,30 +23,38 @@ public class AnalysisService {
   private final ArticleRepository articleRepository;
   private final ContentExtractService contentExtractService;
 
-  /**
-   * 뉴스 기사 URL을 받아 분석 세션을 생성하고 본문을 추출한다.
-   *
-   * @param request URL이 담긴 요청 DTO
-   * @return 생성된 세션 ID와 현재 상태
-   */
-  @Transactional
+  /** 뉴스 기사 URL을 받아 분석 세션을 생성하고 본문을 추출한다. 외부 HTTP 호출(Jsoup)은 트랜잭션 밖에서 수행하여 DB 커넥션 점유를 최소화한다. */
   public AnalysisResponse analyze(AnalysisRequest request) {
-    // 1. AnalysisSession 생성 (status=PENDING, member=null — 비회원 허용)
+    // 1. 세션 생성 (트랜잭션 1)
+    AnalysisSession session = createPendingSession();
+
+    // 2. 기사 본문 추출 (트랜잭션 밖 — 외부 HTTP 호출)
+    ExtractedArticle extracted = contentExtractService.extract(request.url());
+
+    // 3. Article 저장 + 상태 업데이트 (트랜잭션 2)
+    persistArticleAndUpdateStatus(session, request.url(), extracted);
+
+    return AnalysisConverter.toResponse(session);
+  }
+
+  @Transactional
+  protected AnalysisSession createPendingSession() {
     AnalysisSession session =
         AnalysisSession.builder()
             .status(SessionStatus.PENDING)
             .requestedAt(LocalDateTime.now())
             .build();
     sessionRepository.save(session);
+    return session;
+  }
 
-    // 2. 기사 본문 추출
-    ExtractedArticle extracted = contentExtractService.extract(request.url());
-
-    // 3. Article 생성
+  @Transactional
+  protected void persistArticleAndUpdateStatus(
+      AnalysisSession session, String url, ExtractedArticle extracted) {
     Article article =
         Article.builder()
             .session(session)
-            .url(request.url())
+            .url(url)
             .title(extracted.getTitle())
             .body(extracted.getBody())
             .lang(extracted.getLang())
@@ -55,9 +63,6 @@ public class AnalysisService {
             .build();
     articleRepository.save(article);
 
-    // 4. 세션 상태 → EXTRACTING (비즈니스 메서드 사용)
     session.updateStatus(SessionStatus.EXTRACTING);
-
-    return AnalysisConverter.toResponse(session);
   }
 }

--- a/src/main/java/com/checkmate/web/service/AnalysisService.java
+++ b/src/main/java/com/checkmate/web/service/AnalysisService.java
@@ -7,9 +7,11 @@ import com.checkmate.web.dto.response.ExtractedArticle;
 import com.checkmate.web.entity.AnalysisSession;
 import com.checkmate.web.entity.Article;
 import com.checkmate.web.entity.enums.SessionStatus;
+import com.checkmate.web.exception.NotFoundException;
 import com.checkmate.web.repository.AnalysisSessionRepository;
 import com.checkmate.web.repository.ArticleRepository;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,32 +27,42 @@ public class AnalysisService {
 
   /** 뉴스 기사 URL을 받아 분석 세션을 생성하고 본문을 추출한다. 외부 HTTP 호출(Jsoup)은 트랜잭션 밖에서 수행하여 DB 커넥션 점유를 최소화한다. */
   public AnalysisResponse analyze(AnalysisRequest request) {
-    // 1. 세션 생성 (트랜잭션 1)
-    AnalysisSession session = createPendingSession();
+    // 1. 세션 생성 (트랜잭션)
+    UUID sessionId = createPendingSession();
 
-    // 2. 기사 본문 추출 (트랜잭션 밖 — 외부 HTTP 호출)
-    ExtractedArticle extracted = contentExtractService.extract(request.url());
+    try {
+      // 2. 기사 본문 추출 (트랜잭션 밖 — 외부 HTTP 호출)
+      ExtractedArticle extracted = contentExtractService.extract(request.url());
 
-    // 3. Article 저장 + 상태 업데이트 (트랜잭션 2)
-    persistArticleAndUpdateStatus(session, request.url(), extracted);
-
-    return AnalysisConverter.toResponse(session);
+      // 3. Article 저장 + 상태 업데이트 (트랜잭션)
+      return persistArticleAndUpdateStatus(sessionId, request.url(), extracted);
+    } catch (RuntimeException ex) {
+      // 4. 실패 시 세션 상태 → FAILED
+      markFailed(sessionId);
+      throw ex;
+    }
   }
 
+  /** 세션 생성 후 ID 반환 — 영속 컨텍스트 독립 */
   @Transactional
-  protected AnalysisSession createPendingSession() {
+  public UUID createPendingSession() {
     AnalysisSession session =
         AnalysisSession.builder()
             .status(SessionStatus.PENDING)
             .requestedAt(LocalDateTime.now())
             .build();
-    sessionRepository.save(session);
-    return session;
+    return sessionRepository.save(session).getId();
   }
 
+  /** Article 저장 + 세션 상태 EXTRACTING으로 전이 */
   @Transactional
-  protected void persistArticleAndUpdateStatus(
-      AnalysisSession session, String url, ExtractedArticle extracted) {
+  public AnalysisResponse persistArticleAndUpdateStatus(
+      UUID sessionId, String url, ExtractedArticle extracted) {
+    AnalysisSession session =
+        sessionRepository
+            .findById(sessionId)
+            .orElseThrow(() -> new NotFoundException("세션을 찾을 수 없습니다"));
+
     Article article =
         Article.builder()
             .session(session)
@@ -64,5 +76,15 @@ public class AnalysisService {
     articleRepository.save(article);
 
     session.updateStatus(SessionStatus.EXTRACTING);
+
+    return AnalysisConverter.toResponse(session);
+  }
+
+  /** 세션 상태를 FAILED로 전이 */
+  @Transactional
+  public void markFailed(UUID sessionId) {
+    sessionRepository
+        .findById(sessionId)
+        .ifPresent(session -> session.updateStatus(SessionStatus.FAILED));
   }
 }

--- a/src/test/java/com/checkmate/web/controller/NewsControllerTest.java
+++ b/src/test/java/com/checkmate/web/controller/NewsControllerTest.java
@@ -1,0 +1,72 @@
+package com.checkmate.web.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.checkmate.web.config.SecurityConfig;
+import com.checkmate.web.dto.request.AnalysisRequest;
+import com.checkmate.web.dto.response.AnalysisResponse;
+import com.checkmate.web.exception.GlobalExceptionHandler;
+import com.checkmate.web.service.AnalysisService;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/** NewsController 단위 테스트 */
+@WebMvcTest(controllers = NewsController.class)
+@Import({GlobalExceptionHandler.class, SecurityConfig.class})
+@ActiveProfiles("test")
+class NewsControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private AnalysisService analysisService;
+
+  @Test
+  @DisplayName("POST /api/v1/analysis — 유효한 URL → 201 반환")
+  void analyze_validUrl_returns201() throws Exception {
+    UUID sessionId = UUID.randomUUID();
+    AnalysisResponse response =
+        AnalysisResponse.builder().sessionId(sessionId).status("EXTRACTING").build();
+
+    given(analysisService.analyze(any(AnalysisRequest.class))).willReturn(response);
+
+    mockMvc
+        .perform(
+            post("/api/v1/analysis")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"url\":\"https://news.naver.com/article/001\"}"))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.sessionId").value(sessionId.toString()))
+        .andExpect(jsonPath("$.status").value("EXTRACTING"));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/analysis — URL 미입력 → 400 반환")
+  void analyze_blankUrl_returns400() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/analysis")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"url\":\"\"}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/analysis — url 필드 누락 → 400 반환")
+  void analyze_missingUrl_returns400() throws Exception {
+    mockMvc
+        .perform(post("/api/v1/analysis").contentType(MediaType.APPLICATION_JSON).content("{}"))
+        .andExpect(status().isBadRequest());
+  }
+}


### PR DESCRIPTION
## Summary
- NewsController: POST /api/v1/analysis → 201 반환
- AnalysisService: 세션 생성 → 본문 추출 → Article 저장
- DTO (AnalysisRequest record, AnalysisResponse) + AnalysisConverter
- @WebMvcTest 단위 테스트 3건

## 이슈
- closes #4

## Test plan
- [x] `./gradlew test` 전체 통과
- [x] `./gradlew build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 뉴스 기사 분석 API 추가 — URL 제출로 분석 세션을 시작하고 HTTP 201로 세션 ID 및 상태를 반환합니다.
  * 요청 유효성 검사 추가 — URL은 필수 입력(빈값/누락 시 400 응답).

* **테스트**
  * 엔드포인트 유효성 및 응답 테스트 추가 (올바른 URL → 201, 빈 URL → 400, 누락된 URL → 400)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->