### PR TITLE
✨feat(article): ArticleController + GET/POST endpoints + 통합 테스트 (Phase 21-5 BE)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 	implementation 'org.jsoup:jsoup:1.18.3'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 	implementation 'org.jsoup:jsoup:1.18.3'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/checkmate/web/controller/ArticleController.java
+++ b/src/main/java/com/checkmate/web/controller/ArticleController.java
@@ -3,6 +3,10 @@ package com.checkmate.web.controller;
 import com.checkmate.web.dto.request.AttachToSessionRequest;
 import com.checkmate.web.dto.response.ArticleResponse;
 import com.checkmate.web.service.ArticleService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -16,31 +20,29 @@ import org.springframework.web.bind.annotation.RestController;
 /** Article 조회 및 세션 부착 컨트롤러 */
 @RestController
 @RequestMapping("/api/v1/articles")
+@Tag(name = "Article", description = "기사 조회 및 분석 세션 부착 API")
 @RequiredArgsConstructor
 public class ArticleController {
 
   private final ArticleService articleService;
 
-  /**
-   * Article ID로 조회.
-   *
-   * @return 200 ArticleResponse (없으면 GlobalExceptionHandler가 404)
-   */
+  @Operation(summary = "기사 ID로 조회", description = "추출된 기사를 ID로 조회한다.")
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "조회 성공"),
+    @ApiResponse(responseCode = "404", description = "기사 미존재")
+  })
   @GetMapping("/{id}")
   public ArticleResponse findById(@PathVariable UUID id) {
     return articleService.findById(id);
   }
 
-  /**
-   * Article을 분석 세션에 부착 (action endpoint — state transition 시맨틱).
-   *
-   * @return 200 ArticleResponse
-   *     <ul>
-   *       <li>404 — Article 또는 Session 미존재
-   *       <li>409 — 이미 부착된 Article (재부착 거부, ConflictException)
-   *       <li>400 — sessionId 누락 또는 invalid UUID (PathVariable / body)
-   *     </ul>
-   */
+  @Operation(summary = "기사를 분석 세션에 부착", description = "1회만 부착 가능. 재부착 시 409 반환.")
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "부착 성공"),
+    @ApiResponse(responseCode = "400", description = "sessionId 누락 또는 invalid UUID"),
+    @ApiResponse(responseCode = "404", description = "기사 또는 세션 미존재"),
+    @ApiResponse(responseCode = "409", description = "이미 부착된 기사")
+  })
   @PostMapping("/{id}/attach")
   public ArticleResponse attachToSession(
       @PathVariable UUID id, @Valid @RequestBody AttachToSessionRequest request) {

--- a/src/main/java/com/checkmate/web/controller/ArticleController.java
+++ b/src/main/java/com/checkmate/web/controller/ArticleController.java
@@ -1,0 +1,49 @@
+package com.checkmate.web.controller;
+
+import com.checkmate.web.dto.request.AttachToSessionRequest;
+import com.checkmate.web.dto.response.ArticleResponse;
+import com.checkmate.web.service.ArticleService;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Article 조회 및 세션 부착 컨트롤러 */
+@RestController
+@RequestMapping("/api/v1/articles")
+@RequiredArgsConstructor
+public class ArticleController {
+
+  private final ArticleService articleService;
+
+  /**
+   * Article ID로 조회.
+   *
+   * @return 200 ArticleResponse (없으면 GlobalExceptionHandler가 404)
+   */
+  @GetMapping("/{id}")
+  public ArticleResponse findById(@PathVariable UUID id) {
+    return articleService.findById(id);
+  }
+
+  /**
+   * Article을 분석 세션에 부착 (action endpoint — state transition 시맨틱).
+   *
+   * @return 200 ArticleResponse
+   *     <ul>
+   *       <li>404 — Article 또는 Session 미존재
+   *       <li>409 — 이미 부착된 Article (재부착 거부, ConflictException)
+   *       <li>400 — sessionId 누락 또는 invalid UUID (PathVariable / body)
+   *     </ul>
+   */
+  @PostMapping("/{id}/attach")
+  public ArticleResponse attachToSession(
+      @PathVariable UUID id, @Valid @RequestBody AttachToSessionRequest request) {
+    return articleService.attachToSession(id, request.sessionId());
+  }
+}

--- a/src/main/java/com/checkmate/web/converter/ArticleConverter.java
+++ b/src/main/java/com/checkmate/web/converter/ArticleConverter.java
@@ -1,0 +1,34 @@
+package com.checkmate.web.converter;
+
+import com.checkmate.web.dto.response.ArticleResponse;
+import com.checkmate.web.entity.AnalysisSession;
+import com.checkmate.web.entity.Article;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/** Article ↔ ArticleResponse 변환 유틸리티 */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ArticleConverter {
+
+  /**
+   * Article → ArticleResponse 변환.
+   *
+   * <p>status는 entity에 필드가 없어 session 부착 여부에서 파생: session==null → "EXTRACTED" / session!=null →
+   * "ATTACHED" (FE PLAN rev.6 ArticleStatus 2개와 1:1 매핑).
+   */
+  public static ArticleResponse toResponse(Article article) {
+    AnalysisSession session = article.getSession();
+    return ArticleResponse.builder()
+        .id(article.getId())
+        .url(article.getUrl())
+        .title(article.getTitle())
+        .body(article.getBody())
+        .lang(article.getLang())
+        .domain(article.getDomain())
+        .status(session == null ? "EXTRACTED" : "ATTACHED")
+        .sessionId(session == null ? null : session.getId())
+        .extractedAt(article.getExtractedAt())
+        .createdAt(article.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/checkmate/web/dto/request/AttachToSessionRequest.java
+++ b/src/main/java/com/checkmate/web/dto/request/AttachToSessionRequest.java
@@ -1,0 +1,7 @@
+package com.checkmate.web.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+/** Article을 분석 세션에 부착 요청 DTO */
+public record AttachToSessionRequest(@NotNull(message = "sessionId는 필수입니다") UUID sessionId) {}

--- a/src/main/java/com/checkmate/web/dto/response/ArticleResponse.java
+++ b/src/main/java/com/checkmate/web/dto/response/ArticleResponse.java
@@ -1,0 +1,48 @@
+package com.checkmate.web.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** Article 조회/부착 응답 DTO */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ArticleResponse {
+
+  /** Article ID */
+  private UUID id;
+
+  /** 기사 URL */
+  private String url;
+
+  /** 제목 (추출 단계에 따라 nullable) */
+  private String title;
+
+  /** 본문 (추출 단계에 따라 nullable) */
+  private String body;
+
+  /** 언어 코드 (추출 단계에 따라 nullable) */
+  private String lang;
+
+  /** 도메인 (추출 단계에 따라 nullable) */
+  private String domain;
+
+  /**
+   * 부착 상태 ("EXTRACTED" | "ATTACHED") — Article entity에 status 필드 없음, 파생 계산 (ArticleConverter 참조).
+   */
+  private String status;
+
+  /** 부착된 세션 ID (미부착 시 null — Jackson 기본 INCLUDE.ALWAYS로 null 직렬화) */
+  private UUID sessionId;
+
+  /** 추출 시각 */
+  private LocalDateTime extractedAt;
+
+  /** 생성 시각 (BaseTimeEntity audit) */
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/com/checkmate/web/exception/ConflictException.java
+++ b/src/main/java/com/checkmate/web/exception/ConflictException.java
@@ -1,0 +1,9 @@
+package com.checkmate.web.exception;
+
+/** 리소스 충돌 예외 — 409 상태 코드 */
+public class ConflictException extends AppException {
+
+  public ConflictException(String message) {
+    super(409, message);
+  }
+}

--- a/src/main/java/com/checkmate/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/checkmate/web/exception/GlobalExceptionHandler.java
@@ -3,13 +3,16 @@ package com.checkmate.web.exception;
 import com.checkmate.web.dto.ApiErrorResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 /** 전역 예외 처리 핸들러 */
@@ -30,6 +33,22 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     return ResponseEntity.status(ex.getStatusCode()).body(body);
   }
 
+  /** Article.attachTo 재부착 등 도메인 invariant 위반 → 409 변환 */
+  @ExceptionHandler(IllegalStateException.class)
+  public ResponseEntity<ApiErrorResponse> handleIllegalState(IllegalStateException ex) {
+    ApiErrorResponse body =
+        ApiErrorResponse.builder().status("fail").statusCode(409).message(ex.getMessage()).build();
+    return ResponseEntity.status(409).body(body);
+  }
+
+  /** Article.extract URL invariant 위반 등 → 400 변환 */
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<ApiErrorResponse> handleIllegalArgument(IllegalArgumentException ex) {
+    ApiErrorResponse body =
+        ApiErrorResponse.builder().status("fail").statusCode(400).message(ex.getMessage()).build();
+    return ResponseEntity.status(400).body(body);
+  }
+
   /** 유효성 검사 실패 처리 — 첫 번째 필드 오류 메시지 반환 */
   @Override
   protected ResponseEntity<Object> handleMethodArgumentNotValid(
@@ -45,6 +64,39 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     ApiErrorResponse body =
         ApiErrorResponse.builder().status("fail").statusCode(400).message(message).build();
+    return ResponseEntity.status(400).body(body);
+  }
+
+  /**
+   * @PathVariable UUID 등 type 변환 실패 → ApiErrorResponse 통일
+   */
+  @Override
+  protected ResponseEntity<Object> handleTypeMismatch(
+      TypeMismatchException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+    String paramName =
+        (ex instanceof MethodArgumentTypeMismatchException matm) ? matm.getName() : "parameter";
+    ApiErrorResponse body =
+        ApiErrorResponse.builder()
+            .status("fail")
+            .statusCode(400)
+            .message(paramName + ": 잘못된 값 형식")
+            .build();
+    return ResponseEntity.status(400).body(body);
+  }
+
+  /** malformed JSON body (Bean Validation 전 단계) → ApiErrorResponse 통일 */
+  @Override
+  protected ResponseEntity<Object> handleHttpMessageNotReadable(
+      HttpMessageNotReadableException ex,
+      HttpHeaders headers,
+      HttpStatusCode status,
+      WebRequest request) {
+    ApiErrorResponse body =
+        ApiErrorResponse.builder()
+            .status("fail")
+            .statusCode(400)
+            .message("요청 본문을 파싱할 수 없습니다")
+            .build();
     return ResponseEntity.status(400).body(body);
   }
 

--- a/src/main/java/com/checkmate/web/service/ArticleService.java
+++ b/src/main/java/com/checkmate/web/service/ArticleService.java
@@ -1,0 +1,66 @@
+package com.checkmate.web.service;
+
+import com.checkmate.web.converter.ArticleConverter;
+import com.checkmate.web.dto.response.ArticleResponse;
+import com.checkmate.web.entity.AnalysisSession;
+import com.checkmate.web.entity.Article;
+import com.checkmate.web.exception.ConflictException;
+import com.checkmate.web.exception.NotFoundException;
+import com.checkmate.web.repository.AnalysisSessionRepository;
+import com.checkmate.web.repository.ArticleRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Article 도메인 조회 및 세션 부착 서비스 */
+@Service
+@RequiredArgsConstructor
+public class ArticleService {
+
+  private final ArticleRepository articleRepository;
+  private final AnalysisSessionRepository sessionRepository;
+
+  /**
+   * ID로 Article 조회 후 ArticleResponse 반환. 없으면 404.
+   *
+   * <p>Converter 호출을 트랜잭션 내부로 두어 LAZY @OneToOne session lazy access를 안전하게 처리한다 (open-in-view=false
+   * 가정에서 controller 시점 lazy access 시 LazyInitializationException 회피).
+   */
+  @Transactional(readOnly = true)
+  public ArticleResponse findById(UUID id) {
+    Article article =
+        articleRepository
+            .findById(id)
+            .orElseThrow(() -> new NotFoundException("Article not found: " + id));
+    return ArticleConverter.toResponse(article);
+  }
+
+  /**
+   * Article을 분석 세션에 부착 후 ArticleResponse 반환.
+   *
+   * <p>재부착 시도 시 entity의 attachTo()가 IllegalStateException → Service에서 ConflictException(409)으로 명시적
+   * 변환. GlobalExceptionHandler IllegalStateException 핸들러는 백스톱.
+   *
+   * <p>Hibernate dirty checking이 트랜잭션 commit 시 자동 영속화하므로 saveAndFlush 호출 불필요.
+   */
+  @Transactional
+  public ArticleResponse attachToSession(UUID articleId, UUID sessionId) {
+    Article article =
+        articleRepository
+            .findById(articleId)
+            .orElseThrow(() -> new NotFoundException("Article not found: " + articleId));
+    AnalysisSession session =
+        sessionRepository
+            .findById(sessionId)
+            .orElseThrow(() -> new NotFoundException("Session not found: " + sessionId));
+
+    try {
+      article.attachTo(session);
+    } catch (IllegalStateException ex) {
+      throw new ConflictException(ex.getMessage());
+    }
+
+    return ArticleConverter.toResponse(article);
+  }
+}

--- a/src/test/java/com/checkmate/web/controller/ArticleControllerIntegrationTest.java
+++ b/src/test/java/com/checkmate/web/controller/ArticleControllerIntegrationTest.java
@@ -100,11 +100,17 @@ class ArticleControllerIntegrationTest extends AbstractIntegrationTest {
   void attachToSession_alreadyAttached_returns409() {
     AttachToSessionRequest request = new AttachToSessionRequest(savedSession.getId());
 
-    rest.postForEntity(
-        "/api/v1/articles/" + savedExtractedArticle.getId() + "/attach",
-        request,
-        ArticleResponse.class);
+    // 1차 부착: 명시적 success 검증 — 실패 시 후속 409 검증 무효화 방지 (CodeRabbit 리뷰)
+    ResponseEntity<ArticleResponse> firstAttach =
+        rest.postForEntity(
+            "/api/v1/articles/" + savedExtractedArticle.getId() + "/attach",
+            request,
+            ArticleResponse.class);
+    assertThat(firstAttach.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(firstAttach.getBody()).isNotNull();
+    assertThat(firstAttach.getBody().getStatus()).isEqualTo("ATTACHED");
 
+    // 2차 부착 시도: 재부착 거부 검증
     ResponseEntity<String> response =
         rest.postForEntity(
             "/api/v1/articles/" + savedExtractedArticle.getId() + "/attach", request, String.class);

--- a/src/test/java/com/checkmate/web/controller/ArticleControllerIntegrationTest.java
+++ b/src/test/java/com/checkmate/web/controller/ArticleControllerIntegrationTest.java
@@ -1,0 +1,126 @@
+package com.checkmate.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.checkmate.web.dto.request.AttachToSessionRequest;
+import com.checkmate.web.dto.response.ArticleResponse;
+import com.checkmate.web.entity.AnalysisSession;
+import com.checkmate.web.entity.Article;
+import com.checkmate.web.entity.enums.SessionStatus;
+import com.checkmate.web.repository.AnalysisSessionRepository;
+import com.checkmate.web.repository.ArticleRepository;
+import com.checkmate.web.support.AbstractIntegrationTest;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/** ArticleController 통합 테스트 — Testcontainers PostgreSQL 기반 */
+class ArticleControllerIntegrationTest extends AbstractIntegrationTest {
+
+  @Autowired private TestRestTemplate rest;
+  @Autowired private ArticleRepository articleRepository;
+  @Autowired private AnalysisSessionRepository sessionRepository;
+
+  private Article savedExtractedArticle;
+  private AnalysisSession savedSession;
+
+  @BeforeEach
+  void setup() {
+    // FK 안전 순서: Article(자식) 먼저, Session(부모) 나중
+    articleRepository.deleteAllInBatch();
+    sessionRepository.deleteAllInBatch();
+
+    AnalysisSession session =
+        AnalysisSession.builder()
+            .status(SessionStatus.PENDING)
+            .requestedAt(LocalDateTime.now())
+            .build();
+    savedSession = sessionRepository.saveAndFlush(session);
+
+    Article article =
+        Article.extract(
+            "https://example.com/news/integration", "통합테스트 제목", "통합테스트 본문", "ko", "example.com");
+    savedExtractedArticle = articleRepository.saveAndFlush(article);
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/articles/{id} — happy path: 200 + EXTRACTED 상태")
+  void findById_happyPath() {
+    ResponseEntity<ArticleResponse> response =
+        rest.getForEntity(
+            "/api/v1/articles/" + savedExtractedArticle.getId(), ArticleResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().getId()).isEqualTo(savedExtractedArticle.getId());
+    assertThat(response.getBody().getUrl()).isEqualTo("https://example.com/news/integration");
+    assertThat(response.getBody().getStatus()).isEqualTo("EXTRACTED");
+    assertThat(response.getBody().getSessionId()).isNull();
+    assertThat(response.getBody().getCreatedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/articles/{id} — 미존재 → 404")
+  void findById_notFound() {
+    ResponseEntity<String> response =
+        rest.getForEntity("/api/v1/articles/" + UUID.randomUUID(), String.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/articles/{id}/attach — happy path: EXTRACTED → ATTACHED")
+  void attachToSession_happyPath() {
+    AttachToSessionRequest request = new AttachToSessionRequest(savedSession.getId());
+
+    ResponseEntity<ArticleResponse> response =
+        rest.postForEntity(
+            "/api/v1/articles/" + savedExtractedArticle.getId() + "/attach",
+            request,
+            ArticleResponse.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().getStatus()).isEqualTo("ATTACHED");
+    assertThat(response.getBody().getSessionId()).isEqualTo(savedSession.getId());
+
+    Article persisted = articleRepository.findById(savedExtractedArticle.getId()).orElseThrow();
+    assertThat(persisted.getSession()).isNotNull();
+    assertThat(persisted.getSession().getId()).isEqualTo(savedSession.getId());
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/articles/{id}/attach — 재부착 거부 → 409")
+  void attachToSession_alreadyAttached_returns409() {
+    AttachToSessionRequest request = new AttachToSessionRequest(savedSession.getId());
+
+    rest.postForEntity(
+        "/api/v1/articles/" + savedExtractedArticle.getId() + "/attach",
+        request,
+        ArticleResponse.class);
+
+    ResponseEntity<String> response =
+        rest.postForEntity(
+            "/api/v1/articles/" + savedExtractedArticle.getId() + "/attach", request, String.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/articles/{id}/attach — Session 미존재 → 404")
+  void attachToSession_sessionNotFound_returns404() {
+    AttachToSessionRequest request = new AttachToSessionRequest(UUID.randomUUID());
+
+    ResponseEntity<String> response =
+        rest.postForEntity(
+            "/api/v1/articles/" + savedExtractedArticle.getId() + "/attach", request, String.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+}

--- a/src/test/java/com/checkmate/web/controller/ArticleControllerTest.java
+++ b/src/test/java/com/checkmate/web/controller/ArticleControllerTest.java
@@ -1,0 +1,158 @@
+package com.checkmate.web.controller;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.checkmate.web.config.SecurityConfig;
+import com.checkmate.web.dto.response.ArticleResponse;
+import com.checkmate.web.exception.ConflictException;
+import com.checkmate.web.exception.GlobalExceptionHandler;
+import com.checkmate.web.exception.NotFoundException;
+import com.checkmate.web.service.ArticleService;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/** ArticleController 단위 테스트 (WebMvcTest + Service mock) */
+@WebMvcTest(controllers = ArticleController.class)
+@Import({GlobalExceptionHandler.class, SecurityConfig.class})
+@ActiveProfiles("test")
+class ArticleControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private ArticleService articleService;
+
+  @Test
+  @DisplayName("GET /api/v1/articles/{id} — 200 + ArticleResponse 반환")
+  void findById_returns200() throws Exception {
+    UUID articleId = UUID.randomUUID();
+    ArticleResponse response =
+        ArticleResponse.builder()
+            .id(articleId)
+            .url("https://example.com/news/1")
+            .title("제목")
+            .body("본문")
+            .lang("ko")
+            .domain("example.com")
+            .status("EXTRACTED")
+            .sessionId(null)
+            .extractedAt(LocalDateTime.now())
+            .createdAt(LocalDateTime.now())
+            .build();
+    given(articleService.findById(articleId)).willReturn(response);
+
+    mockMvc
+        .perform(get("/api/v1/articles/" + articleId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(articleId.toString()))
+        .andExpect(jsonPath("$.url").value("https://example.com/news/1"))
+        .andExpect(jsonPath("$.status").value("EXTRACTED"))
+        .andExpect(jsonPath("$.sessionId").value(nullValue()));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/articles/{id} — 미존재 → 404")
+  void findById_notFound_returns404() throws Exception {
+    UUID articleId = UUID.randomUUID();
+    given(articleService.findById(articleId))
+        .willThrow(new NotFoundException("Article not found: " + articleId));
+
+    mockMvc
+        .perform(get("/api/v1/articles/" + articleId))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.statusCode").value(404));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/articles/{id} — invalid UUID PathVariable → 400")
+  void findById_invalidUuidPathVariable_returns400() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/articles/notauuid"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.statusCode").value(400))
+        .andExpect(jsonPath("$.status").value("fail"));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/articles/{id}/attach — 200 + status=ATTACHED 반환")
+  void attachToSession_returns200WithAttached() throws Exception {
+    UUID articleId = UUID.randomUUID();
+    UUID sessionId = UUID.randomUUID();
+    ArticleResponse response =
+        ArticleResponse.builder()
+            .id(articleId)
+            .url("https://example.com/news/2")
+            .status("ATTACHED")
+            .sessionId(sessionId)
+            .build();
+    given(articleService.attachToSession(any(UUID.class), any(UUID.class))).willReturn(response);
+
+    mockMvc
+        .perform(
+            post("/api/v1/articles/" + articleId + "/attach")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"sessionId\":\"" + sessionId + "\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("ATTACHED"))
+        .andExpect(jsonPath("$.sessionId").value(sessionId.toString()));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/articles/{id}/attach — 재부착 → 409")
+  void attachToSession_alreadyAttached_returns409() throws Exception {
+    UUID articleId = UUID.randomUUID();
+    UUID sessionId = UUID.randomUUID();
+    given(articleService.attachToSession(any(UUID.class), any(UUID.class)))
+        .willThrow(new ConflictException("Article은 이미 세션에 부착되었습니다"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/articles/" + articleId + "/attach")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"sessionId\":\"" + sessionId + "\"}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.statusCode").value(409));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/articles/{id}/attach — sessionId null → 400")
+  void attachToSession_missingSessionId_returns400() throws Exception {
+    UUID articleId = UUID.randomUUID();
+
+    mockMvc
+        .perform(
+            post("/api/v1/articles/" + articleId + "/attach")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.statusCode").value(400));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/articles/{id}/attach — malformed UUID body → 400")
+  void attachToSession_malformedUuidBody_returns400() throws Exception {
+    UUID articleId = UUID.randomUUID();
+
+    mockMvc
+        .perform(
+            post("/api/v1/articles/" + articleId + "/attach")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"sessionId\":\"notauuid\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.statusCode").value(400));
+  }
+}

--- a/src/test/java/com/checkmate/web/exception/ExceptionTestController.java
+++ b/src/test/java/com/checkmate/web/exception/ExceptionTestController.java
@@ -1,6 +1,11 @@
 package com.checkmate.web.exception;
 
+import java.util.Map;
+import java.util.UUID;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,5 +27,25 @@ public class ExceptionTestController {
   @GetMapping("/server-error")
   public void serverError() {
     throw new RuntimeException("예상치 못한 오류");
+  }
+
+  @GetMapping("/illegal-argument")
+  public void throwIllegalArgument() {
+    throw new IllegalArgumentException("잘못된 인자");
+  }
+
+  @GetMapping("/illegal-state")
+  public void throwIllegalState() {
+    throw new IllegalStateException("잘못된 상태");
+  }
+
+  @GetMapping("/type-mismatch/{uuid}")
+  public String typeMismatch(@PathVariable UUID uuid) {
+    return uuid.toString();
+  }
+
+  @PostMapping("/malformed-body")
+  public Map<String, Object> malformedBody(@RequestBody Map<String, Object> body) {
+    return body;
   }
 }

--- a/src/test/java/com/checkmate/web/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/checkmate/web/exception/GlobalExceptionHandlerTest.java
@@ -1,6 +1,7 @@
 package com.checkmate.web.exception;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -52,5 +54,50 @@ class GlobalExceptionHandlerTest {
         .andExpect(jsonPath("$.status").value("error"))
         .andExpect(jsonPath("$.statusCode").value(500))
         .andExpect(jsonPath("$.message").value("서버 내부 오류"));
+  }
+
+  @Test
+  @DisplayName("IllegalArgumentException → 400, status=fail 반환")
+  void illegalArgumentReturns400() throws Exception {
+    mockMvc
+        .perform(get("/test/illegal-argument"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value("fail"))
+        .andExpect(jsonPath("$.statusCode").value(400))
+        .andExpect(jsonPath("$.message").value("잘못된 인자"));
+  }
+
+  @Test
+  @DisplayName("IllegalStateException → 409, status=fail 반환")
+  void illegalStateReturns409() throws Exception {
+    mockMvc
+        .perform(get("/test/illegal-state"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.status").value("fail"))
+        .andExpect(jsonPath("$.statusCode").value(409))
+        .andExpect(jsonPath("$.message").value("잘못된 상태"));
+  }
+
+  @Test
+  @DisplayName("MethodArgumentTypeMismatchException → 400, ApiErrorResponse shape")
+  void typeMismatchReturns400() throws Exception {
+    mockMvc
+        .perform(get("/test/type-mismatch/notauuid"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value("fail"))
+        .andExpect(jsonPath("$.statusCode").value(400));
+  }
+
+  @Test
+  @DisplayName("HttpMessageNotReadableException → 400, ApiErrorResponse shape")
+  void messageNotReadableReturns400() throws Exception {
+    mockMvc
+        .perform(
+            post("/test/malformed-body")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{not-json"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value("fail"))
+        .andExpect(jsonPath("$.statusCode").value(400));
   }
 }

--- a/src/test/java/com/checkmate/web/support/AbstractIntegrationTest.java
+++ b/src/test/java/com/checkmate/web/support/AbstractIntegrationTest.java
@@ -5,26 +5,33 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
  * Spring Boot 3.1+ {@code @ServiceConnection} 기반 Testcontainers 통합 테스트 base.
  *
- * <p>{@code @DynamicPropertySource} 보일러플레이트 제거. 컨테이너는 JVM 단위로 1회 기동되며 각 테스트 클래스가 공유한다. Docker가 부재한
- * 환경에서는 통합 테스트가 스킵되도록 lazy-init만 사용 — import-time 부작용 없음.
+ * <p>컨테이너는 <strong>JVM 단위 singleton</strong>으로 기동되며 모든 테스트 클래스가 공유한다. Spring TestContext 캐시 + 컨테이너
+ * 라이프사이클 정합성 보장: {@code @Container} JUnit extension annotation은 의도적으로 미사용 — extension은 클래스 단위로
+ * start/stop을 관리하므로 cached Spring context의 DataSource bean이 stale port를 가리키는 문제 발생. 대신 static
+ * initializer에서 직접 {@link PostgreSQLContainer#start()} 호출 → JVM 종료까지 동일 컨테이너/포트 보장.
+ *
+ * <p>참고: <a
+ * href="https://java.testcontainers.org/test_framework_integration/manual_lifecycle_control/#singleton-containers">Testcontainers
+ * Singleton Containers</a> + Spring Boot {@code @ServiceConnection} 가이드.
  *
  * <p>{@code WebEnvironment.RANDOM_PORT}로 Tomcat 기동 — 통합 테스트가 {@link
  * org.springframework.boot.test.web.client.TestRestTemplate}을 사용해 실제 HTTP 호출하기 위함. MOCK 기본값에서는
  * TestRestTemplate bean이 등록되지 않아 autowiring 실패.
- *
- * <p>참고: spring-template Phase E0 PR #22 패턴을 CheckMate에 시드.
  */
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @Testcontainers(disabledWithoutDocker = true)
 @TestPropertySource(properties = {"spring.jpa.hibernate.ddl-auto=create-drop"})
 public abstract class AbstractIntegrationTest {
 
-  @Container @ServiceConnection
-  static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
+  @ServiceConnection static final PostgreSQLContainer<?> POSTGRES;
+
+  static {
+    POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
+    POSTGRES.start();
+  }
 }

--- a/src/test/java/com/checkmate/web/support/AbstractIntegrationTest.java
+++ b/src/test/java/com/checkmate/web/support/AbstractIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.checkmate.web.support;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -13,9 +14,13 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * <p>{@code @DynamicPropertySource} 보일러플레이트 제거. 컨테이너는 JVM 단위로 1회 기동되며 각 테스트 클래스가 공유한다. Docker가 부재한
  * 환경에서는 통합 테스트가 스킵되도록 lazy-init만 사용 — import-time 부작용 없음.
  *
+ * <p>{@code WebEnvironment.RANDOM_PORT}로 Tomcat 기동 — 통합 테스트가 {@link
+ * org.springframework.boot.test.web.client.TestRestTemplate}을 사용해 실제 HTTP 호출하기 위함. MOCK 기본값에서는
+ * TestRestTemplate bean이 등록되지 않아 autowiring 실패.
+ *
  * <p>참고: spring-template Phase E0 PR #22 패턴을 CheckMate에 시드.
  */
-@SpringBootTest
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @Testcontainers(disabledWithoutDocker = true)
 @TestPropertySource(properties = {"spring.jpa.hibernate.ddl-auto=create-drop"})
 public abstract class AbstractIntegrationTest {


### PR DESCRIPTION
## Summary

FE Phase 21 P4 (real wiring) dependency 충족을 위해 BE에 `ArticleController` + `GET /api/v1/articles/{id}` + `POST /api/v1/articles/{id}/attach` endpoints 추가.

PR #27 (DDD/TDD seed) 머지(`73b5e43`) 위에 controller layer 확장. **13 atomic commits** 완료 (5 Wave).

## Changes (13 commits, 5 Wave)

### Wave 0 — 선행 base 변경 (2 commits)
- `ad4fe1e` 🔧chore(test): AbstractIntegrationTest webEnvironment=RANDOM_PORT 추가 (TestRestTemplate 주입 가능)
- `05db86b` ✅test(exception): ExceptionTestController에 endpoint 4건 추가

### Wave 1 — 예외/DTO/Converter (4 commits)
- `f62ba80` ✨feat(exception): ConflictException(409) + Handler 4종 추가
- `e1a29d9` ✨feat(dto): ArticleResponse DTO 추가
- `18c315e` ✨feat(dto): AttachToSessionRequest record 추가
- `ea1a368` ✨feat(converter): ArticleConverter 추가

### Wave 2 — Service + Controller (2 commits)
- `d645616` ✨feat(service): ArticleService 추가 (ArticleResponse 반환, dirty checking 의존)
- `ec5b011` ✨feat(controller): ArticleController + GET /{id} + POST /{id}/attach 추가

### Wave 3 — 테스트 3건 (3 commits)
- `2d85a45` ✅test(controller): ArticleControllerTest 7 cases
- `2f67da8` ✅test(integration): ArticleControllerIntegrationTest 5 cases (Testcontainers)
- `37748b7` ✅test(exception): GlobalExceptionHandlerTest 회귀 +4 case

### Wave 4 — Springdoc (2 commits)
- `346ab1c` 🔧chore(deps): springdoc-openapi-starter-webmvc-ui 2.8.6 추가
- `406c0ee` 📝docs(api): ArticleController @Tag/@Operation/@ApiResponse 어노테이션 추가

## API 명세

### `GET /api/v1/articles/{id}`
- 200: `ArticleResponse` (id/url/title/body/lang/domain/status/sessionId/extractedAt/createdAt)
- 404: Article 미존재

### `POST /api/v1/articles/{id}/attach`
- Request body: `AttachToSessionRequest { sessionId: UUID }`
- 200: `ArticleResponse` (status=ATTACHED, sessionId 포함)
- 400: sessionId 누락 또는 invalid UUID
- 404: Article 또는 Session 미존재
- 409: 이미 부착된 Article (재부착 거부, ConflictException via IllegalStateException)

> **endpoint 결정 (D1)**: backend-conventions의 "URI에 동사 금지" intentional deviation. FE PLAN rev.6 contract LOCK 정합 + state transition 시맨틱이 PATCH보다 명확 (GitHub/Stripe action URI 패턴).

## DDD/TDD 정합 (PR #27 패턴 상속)

- ArticleService → ArticleRepository → Article (역방향 금지, ArchUnit layerDependencies 자동 검증)
- Converter는 Service 트랜잭션 내부 호출 (open-in-view=false + LAZY @OneToOne session → LazyInit 회피)
- ArticleService.attachToSession: IllegalStateException → ConflictException(409) 명시적 변환 (Service 책임)
- Hibernate dirty checking 의존 (saveAndFlush 호출 X)

## 검증 결과

| 항목 | 결과 |
|---|---|
| spotlessApply / checkstyleMain / spotbugsMain | [✅] PASS |
| ArticleControllerTest | [✅] 7/7 PASS |
| GlobalExceptionHandlerTest | [✅] 7/7 PASS (3 기존 + 4 신규) |
| ArticleTest / ArchitectureTest / NewsControllerTest | [✅] 회귀 0 |
| ArticleControllerIntegrationTest (T8) | [⚠️] 로컬 Docker 미실행 — CI에서 검증 (disabledWithoutDocker=true) |

## 알려진 제약 (Sprint 1 가정)

- **Concurrent attach race condition**: Article에 @Version 없음. 두 PATCH 동시 호출 시 last-write-wins 또는 DataIntegrityViolationException → 500. Sprint 1 단일 사용자 데모 환경 전제. 운영 배포 전 (Phase 22+) Optimistic lock 또는 DataIntegrityViolationException → 409 핸들러 추가 의무.
- **Security**: csrf.disable() + permitAll() 가정. 향후 인증 도입 시 별도 PR.

## plan-review-deep 추적

- Round 1 (Contract Lens): 9 issues 반영 (Critical 0 / High 3 / Medium 4 / Low 2)
- Round 2 (Completeness Lens): 7 issues 반영 (Critical 0 / High 3 / Medium 4)
- 누적 **16 issues 반영**, 최종 Critical 0 / High 0 잔존, Verdict PROCEED-WITH-CONDITIONS
- 상세: `.plans/21-5-be-article-controller/PLAN.md` 검토 결과 반영 이력 섹션

## Test plan

- [✅] spotlessApply / checkstyleMain / spotbugsMain (main code) PASS
- [✅] ArticleControllerTest 7 cases PASS
- [✅] GlobalExceptionHandlerTest 7 cases PASS (회귀 0)
- [✅] ArticleTest / ArchitectureTest / NewsControllerTest 회귀 0
- [ ] ArticleControllerIntegrationTest 5 cases — CI에서 Testcontainers 자동 실행
- [ ] CodeRabbit 리뷰 통과
- [ ] (post-merge) Swagger UI에서 4 응답 코드 노출 확인 (선택)
- [ ] (post-merge) FE PLAN frontmatter `phase_21_5_dependency: ready` 갱신

Co-authored-by: gs07103 <gwonseok02@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 게시물 조회 및 세션 연결 API 엔드포인트 추가
  * OpenAPI/Swagger UI 문서화 지원 추가

* **Bug Fixes**
  * 요청 검증 오류에 대한 HTTP 400 응답 추가
  * 충돌 상황(이미 연결된 게시물)에 대한 HTTP 409 응답 추가

* **Tests**
  * 새로운 API 엔드포인트에 대한 통합 및 단위 테스트 추가
  * 예외 처리 시나리오별 테스트 케이스 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->