### PR TITLE
✨feat(api): AnalysisResponse에 articleId 추가 (Phase 21-5-1)

### DIFF
--- a/src/main/java/com/checkmate/web/converter/AnalysisConverter.java
+++ b/src/main/java/com/checkmate/web/converter/AnalysisConverter.java
@@ -2,6 +2,7 @@ package com.checkmate.web.converter;
 
 import com.checkmate.web.dto.response.AnalysisResponse;
 import com.checkmate.web.entity.AnalysisSession;
+import com.checkmate.web.entity.Article;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -9,10 +10,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AnalysisConverter {
 
-  /** AnalysisSession → AnalysisResponse 변환 */
-  public static AnalysisResponse toResponse(AnalysisSession session) {
+  /**
+   * AnalysisSession + Article → AnalysisResponse 변환.
+   *
+   * <p>FE Phase 21 P4 attach wiring을 위해 articleId 노출 의무. article은 항상 attached 상태로 전달됨
+   * (AnalysisTransactionService에서 `Article.extract().attachTo(session).save()` 후 호출).
+   */
+  public static AnalysisResponse toResponse(AnalysisSession session, Article article) {
     return AnalysisResponse.builder()
         .sessionId(session.getId())
+        .articleId(article.getId())
         .status(session.getStatus().name())
         .build();
   }

--- a/src/main/java/com/checkmate/web/dto/response/AnalysisResponse.java
+++ b/src/main/java/com/checkmate/web/dto/response/AnalysisResponse.java
@@ -16,6 +16,9 @@ public class AnalysisResponse {
   /** 분석 세션 ID */
   private UUID sessionId;
 
+  /** 추출된 Article의 ID (FE Phase 21 attach wiring 위해 노출) */
+  private UUID articleId;
+
   /** 현재 세션 상태 */
   private String status;
 }

--- a/src/main/java/com/checkmate/web/service/AnalysisTransactionService.java
+++ b/src/main/java/com/checkmate/web/service/AnalysisTransactionService.java
@@ -51,11 +51,11 @@ public class AnalysisTransactionService {
                 extracted.getLang(),
                 extracted.getDomain())
             .attachTo(session);
-    articleRepository.save(article);
+    Article savedArticle = articleRepository.save(article);
 
     session.updateStatus(SessionStatus.EXTRACTING);
 
-    return AnalysisConverter.toResponse(session);
+    return AnalysisConverter.toResponse(session, savedArticle);
   }
 
   /** 세션 상태를 FAILED로 전이 */

--- a/src/test/java/com/checkmate/web/controller/NewsControllerTest.java
+++ b/src/test/java/com/checkmate/web/controller/NewsControllerTest.java
@@ -33,11 +33,16 @@ class NewsControllerTest {
   @MockitoBean private AnalysisService analysisService;
 
   @Test
-  @DisplayName("POST /api/v1/analysis-sessions — 유효한 URL → 201 반환")
+  @DisplayName("POST /api/v1/analysis-sessions — 유효한 URL → 201 반환 (sessionId + articleId + status)")
   void analyze_validUrl_returns201() throws Exception {
     UUID sessionId = UUID.randomUUID();
+    UUID articleId = UUID.randomUUID();
     AnalysisResponse response =
-        AnalysisResponse.builder().sessionId(sessionId).status("EXTRACTING").build();
+        AnalysisResponse.builder()
+            .sessionId(sessionId)
+            .articleId(articleId)
+            .status("EXTRACTING")
+            .build();
 
     given(analysisService.analyze(any(AnalysisRequest.class))).willReturn(response);
 
@@ -48,6 +53,7 @@ class NewsControllerTest {
                 .content("{\"url\":\"https://news.naver.com/article/001\"}"))
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.sessionId").value(sessionId.toString()))
+        .andExpect(jsonPath("$.articleId").value(articleId.toString()))
         .andExpect(jsonPath("$.status").value("EXTRACTING"));
   }
 


### PR DESCRIPTION
## Summary

FE Phase 21 P4 attach wiring 보완 — `AnalysisResponse`에 `articleId: UUID` 필드 1개 추가.

- **현 BE flow**: `POST /analysis-sessions` → `Article.extract().attachTo(session).save()` → `AnalysisResponse {sessionId, status}` 반환 (articleId 미노출)
- **FE Phase 21 W3-3 attach feature**: `requestAttachToSession(articleId, sessionId)` 호출 시연 의도 — **하지만 articleId를 얻을 방법이 없음**
- **이 미니 PR이 unblock**: FE PR #24 (`feat/21-frontend-ddd-tdd`) W-1b 게이트 통과 + W3-3 real wiring 진행 가능

## Changes (1 commit, 4 files)

### `src/main/java/com/checkmate/web/dto/response/AnalysisResponse.java`
- `articleId: UUID` 필드 추가 (Javadoc: "FE Phase 21 attach wiring 위해 노출")

### `src/main/java/com/checkmate/web/converter/AnalysisConverter.java`
- `toResponse(AnalysisSession session)` → `toResponse(AnalysisSession session, Article article)` signature 변경
- 호출자 1군데만 (AnalysisTransactionService) — overload 대신 단일 signature로 단순화 (YAGNI)
- `Article` import 추가

### `src/main/java/com/checkmate/web/service/AnalysisTransactionService.java`
- `articleRepository.save(article)` 반환값을 `Article savedArticle` 변수로 받아 `AnalysisConverter.toResponse(session, savedArticle)`에 전달
- `@GeneratedValue(strategy = UUID)`로 `save` 후 ID 보장됨

### `src/test/java/com/checkmate/web/controller/NewsControllerTest.java`
- `analyze_validUrl_returns201`: mock builder에 `.articleId(UUID.randomUUID())` 추가
- `andExpect(jsonPath("$.articleId").value(articleId.toString()))` 단언 추가

## DDD/TDD 정합

- Article aggregate root 패턴 유지 (PR #27 `73b5e43c` + PR #28 `d9b6168` 정합)
- AnalysisTransactionService의 트랜잭션 경계 무수정 — 응답 DTO 필드 1개만 추가
- ArchUnit layerDependencies + naming 자동 통과 (회귀 0)

## 검증 결과

| 항목 | 결과 |
|---|---|
| spotlessApply / checkstyleMain / spotbugsMain | [✅] PASS |
| NewsControllerTest | [✅] 3/3 PASS (articleId jsonPath 단언 포함) |
| ArchitectureTest | [✅] 8/8 PASS (회귀 0) |
| compileJava / compileTestJava | [✅] PASS |

## Test plan

- [✅] `./gradlew spotlessApply / checkstyleMain / spotbugsMain` PASS
- [✅] `./gradlew test --tests "NewsControllerTest" --tests "ArchitectureTest"` PASS
- [ ] `./gradlew test` 전체 PASS (CI 자동 — Testcontainers 포함)
- [ ] `./gradlew build` PASS (CI 자동)
- [ ] CI green
- [ ] CodeRabbit 리뷰 통과
- [ ] dev 머지

## 의존 phase

- BE Phase 21-5 PR #28 머지 완료 (`d9b6168`) — Article aggregate + ArticleController 인프라 정합
- BE Phase 21 PR #27 머지 완료 (`73b5e43c`) — Article DDD/TDD seed (`extract`/`attachTo` invariants)
- 이 PR 머지 후 → FE Phase 21 PR #24 W-1b 게이트 통과 + W3-3 attach feature real wiring 진행 가능

Co-authored-by: gs07103 <gwonseok02@gmail.com>
