### PR TITLE
📝docs: AGENTS.md (A4-lite) + docs/guides 핵심 2건 (Sprint 2 멤버 onboarding)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,124 @@
+# AGENTS.md — TruthScope Backend
+
+> 모든 AI 도구 (Codex CLI / GitHub Copilot / Cursor / Claude Code 등) 공통 instruction.
+> 사람이 보는 상세 절차서는 `docs/guides/` 참조.
+> Claude Code 세부 규칙은 `CLAUDE.md` 보존 (본 파일과 정합 유지).
+
+---
+
+## 1. 절대 금지 (모든 PR에 강제)
+
+| 금지 | 이유 |
+|---|---|
+| `@Setter` on Entity / `@Data` / `@ToString` on Entity | ArchUnit 룰 — `entityShouldNotExposeSetters` 통과 의무 |
+| `EntityType.ORDINAL` (Enum 매핑) | `@Enumerated(EnumType.STRING)` 강제 — 컬럼 추가/순서 변경 시 데이터 손상 방지 |
+| `FetchType.EAGER` 관계 매핑 | 모든 관계는 `LAZY` 의무 — N+1 회피 |
+| `gemini-2.0-flash-lite` 모델 사용/언급 | 1순위 `gemini-3.1-flash-lite-preview` / 2순위 `gemini-2.5-flash-lite`만 허용 |
+| `--no-verify` git push (pre-commit/CI hook 우회) | hook 실패 시 원인 수정 의무 |
+| `springdoc-openapi 2.8.6 이하` | Spring Boot 3.5.x 비호환 (HateoasProperties NoSuchMethodError) — **2.8.9+ 필수** |
+
+---
+
+## 2. 핵심 패턴 (PR 작성 시 따라야 할 invariant)
+
+### Entity (JPA)
+- `@Getter` + `@NoArgsConstructor(access = PROTECTED)` + `@Builder(access = PRIVATE)` + `@AllArgsConstructor(access = PRIVATE)`
+- 변경은 비즈니스 메서드로 (`attachTo()` 같은 도메인 의도 명시)
+- `@GeneratedValue(strategy = GenerationType.UUID)` 기본 (Member는 Supabase Auth UUID 예외)
+- `extends BaseTimeEntity` (ApiUsageLog만 예외)
+- 상세: `docs/guides/backend-jpa-entity-template.md`
+
+### DDD/TDD aggregate (Phase 21 학습 reference)
+- 정적 팩토리 메서드 (`Article.extract(url, ...)`) 로만 인스턴스 생성
+- URL invariant 같은 비즈니스 invariant는 정적 팩토리에서 검증
+- 상태 전환은 `attachTo()` 같은 비즈니스 메서드로만 (직접 setter 호출 금지)
+- 재호출 시 `IllegalStateException` throw → `ConflictException(409)` 매핑
+- 상세: `docs/guides/backend-ddd-tdd-template.md`
+
+### DTO
+- 요청: `record` 타입 (Java 17+) + `@Valid` 검증
+- 응답: 클래스 + `@Getter` + `@Builder` + `@NoArgsConstructor` + `@AllArgsConstructor`
+- 패키지: `dto/request/`, `dto/response/`
+
+### Service
+- `@Transactional` (쓰기) / `@Transactional(readOnly = true)` (읽기)
+- 생성자 주입만 (`@RequiredArgsConstructor` + `private final`) — `@Autowired` 필드 주입 금지
+- Entity 직접 노출 금지 → 반드시 DTO 변환 (Converter는 `converter/` 패키지, static, `@NoArgsConstructor(PRIVATE)`)
+
+### Controller
+- URL: `/api/v1/{자원복수형}` — 동사 금지, 복수형 명사, 하이픈 구분, 소문자만
+- HTTP Method: GET 조회 / POST 생성 / PATCH 부분수정 / DELETE 삭제 (PUT은 전체 교체만)
+- 단순 200: 객체 직접 반환 (ResponseEntity 불필요), 201/204만 ResponseEntity 사용
+- Springdoc 어노테이션: `@Tag` + `@Operation` + `@ApiResponse` 의무
+
+### Exception
+- `GlobalExceptionHandler`에서 일괄 처리 → `ApiErrorResponse { status, statusCode, message }`
+- 도메인 예외: `ConflictException(409)` / `IllegalArgumentException → 400` / `IllegalStateException → 409`
+- 상세: `docs/guides/backend-error-handling.md` (Sprint 2 ErrorCode 채택 후 작성)
+
+### 통합 테스트 (Testcontainers)
+- `extends AbstractIntegrationTest` (Singleton container 패턴, `@ServiceConnection PostgreSQLContainer`)
+- 클래스 레벨 `@SpringBootTest(webEnvironment = RANDOM_PORT)` + `TestRestTemplate` autowire
+- 5+ test cases per controller (happy / 404 / invalid input / conflict / type mismatch)
+
+---
+
+## 3. 테스트 명령어 (PR 전 필수)
+
+```bash
+./gradlew spotlessApply      # 포맷 자동 수정 (Google Java Format)
+./gradlew checkstyleMain     # 린트
+./gradlew spotbugsMain       # 정적 분석
+./gradlew test               # 전체 테스트 (Testcontainers 포함)
+./gradlew build              # 최종 빌드
+```
+
+상세 절차 (격리 / Docker 의존성 / 일시 실패 처리): `docs/guides/testing-standard.md`
+
+---
+
+## 4. 멤버별 진입 경로 (Sprint 2 Week 1)
+
+| 멤버 | 시작 이슈 | 주 가이드 | 보조 가이드 |
+|---|---|---|---|
+| 한지민 | BE #22 (DataSourceAdapter 인터페이스) | `docs/guides/backend-datasource-adapter.md` | `docs/guides/testing-standard.md` |
+| 이정훈 | BE #24 (UrlInputAdapter) | `docs/guides/backend-url-input-adapter.md` | `docs/guides/backend-ddd-tdd-template.md` |
+| 권석 (PM) | BE #20 SSRF / BE #23 Gradle 분리 | 본 AGENTS.md + `docs/guides/*` 일관성 검수 | — |
+
+---
+
+## 5. PR 체크리스트 (모든 PR 본문에 복사)
+
+- [ ] `./gradlew spotlessApply / checkstyleMain / spotbugsMain` PASS
+- [ ] `./gradlew test` PASS (회귀 0)
+- [ ] `./gradlew build` PASS
+- [ ] ArchUnit 룰 PASS (entity setter 금지)
+- [ ] Springdoc 어노테이션 추가 (controller 신규 시)
+- [ ] PR 본문에 spec 이슈 번호 + 학습 가치 1줄 명시
+- [ ] CodeRabbit 리뷰 통과 (Critical 0)
+
+---
+
+## 6. 커밋 메시지 (Gitmoji)
+
+형식: `{이모지}{type}({scope}): {description}`
+
+```
+✨feat(controller): ArticleController + GET/POST endpoints (Phase 21 W3)
+🐛fix(test): AbstractIntegrationTest singleton container (CI hotfix)
+♻️refactor(service): ArticleService dirty checking 활용
+📝docs(guide): backend-ddd-tdd-template.md 신규
+🔧chore(deps): springdoc 2.8.6 → 2.8.9
+✅test(controller): ArticleControllerTest 7 cases
+🔒fix(article): URL invariant validateUrl 예외 메시지에서 원본 URL 제거
+```
+
+Co-authored-by 의무 (PM 본인): `Co-authored-by: gs07103 <gwonseok02@gmail.com>`
+
+---
+
+## 7. 5/4 Sprint 2 Week 1 진입 전 PM 의무
+
+- BE #20 SSRF Week 1 blocker 격상 + 최소 정책 PR (멤버 작업 진입 전)
+- BE #22 DataSourceAdapter scaffold reference 작성 → `docs/guides/backend-datasource-adapter.md` 박제
+- D7 90분 onboarding session 일정 공지 (Phase 21 DDD/TDD 패턴 walk-through)

--- a/docs/guides/backend-ddd-tdd-template.md
+++ b/docs/guides/backend-ddd-tdd-template.md
@@ -1,0 +1,278 @@
+# Backend DDD/TDD Aggregate Template
+
+> Phase 21에서 검증된 DDD/TDD seed 패턴을 Sprint 2+ 신규 aggregate에 재사용하기 위한 reference template.
+> reference 코드: `src/main/java/com/checkmate/web/entity/Article.java` (PR #27 + #28 + #29 머지)
+
+## 1. Aggregate root 작성 패턴
+
+### 핵심 원칙
+
+| 원칙 | 강제 방법 |
+|---|---|
+| 인스턴스 생성은 정적 팩토리 메서드로만 | `private constructor` + `Article.extract(...)` 같은 정적 메서드 |
+| 비즈니스 invariant은 정적 팩토리에서 검증 | URL pattern / null 체크 → throw `InvariantViolationError` |
+| 상태 전환은 비즈니스 메서드로만 | `attachTo(sessionId)` 같은 의도 명시 메서드 (직접 setter 금지) |
+| 재호출 invariant은 명시적 throw | `IllegalStateException` → ExceptionHandler에서 409 매핑 |
+| ArchUnit 룰 강제 | `entityShouldNotExposeSetters` 통과 의무 |
+
+### Article reference 코드 (현 BE)
+
+```java
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class Article extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String url;
+
+    private String title;
+    private String body;
+    private String lang;
+
+    @Column(name = "domain", length = 255)
+    private String domain;
+
+    @Enumerated(EnumType.STRING)
+    private ArticleStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id")
+    private AnalysisSession session;
+
+    /**
+     * 정적 팩토리 — URL invariant + 필수 필드 검증.
+     */
+    public static Article extract(String url, String title, String body, String lang, String domain) {
+        validateUrl(url);
+        return Article.builder()
+            .url(url)
+            .title(title)
+            .body(body)
+            .lang(lang)
+            .domain(domain)
+            .status(ArticleStatus.EXTRACTED)
+            .build();
+    }
+
+    /**
+     * 비즈니스 메서드 — 1회 부착 invariant.
+     * 재부착 시 IllegalStateException → ConflictException(409) 매핑.
+     */
+    public Article attachTo(AnalysisSession session) {
+        if (this.status == ArticleStatus.ATTACHED) {
+            throw new IllegalStateException(
+                "Article은 이미 분석 세션에 부착되어 있습니다 (1회 부착 invariant)"
+            );
+        }
+        this.session = session;
+        this.status = ArticleStatus.ATTACHED;
+        return this;
+    }
+
+    private static void validateUrl(String url) {
+        if (url == null || !url.matches("^https?://.+")) {
+            throw new IllegalArgumentException("URL은 http(s)로 시작해야 합니다");
+        }
+    }
+}
+```
+
+## 2. Sprint 2+ 신규 aggregate 작성 단계
+
+### Step 1. Entity 클래스 신규 (5분)
+
+```bash
+# 위치
+src/main/java/com/checkmate/web/entity/{NewEntity}.java
+```
+
+체크리스트:
+- [ ] `@Getter` + `@NoArgsConstructor(access = PROTECTED)` + `@Builder(access = PRIVATE)` + `@AllArgsConstructor(access = PRIVATE)` 4개 어노테이션
+- [ ] `extends BaseTimeEntity`
+- [ ] 모든 관계 `fetch = FetchType.LAZY`
+- [ ] Enum 필드 `@Enumerated(EnumType.STRING)`
+- [ ] `@Setter` / `@Data` / `@ToString` 미사용
+
+### Step 2. 정적 팩토리 메서드 작성 (10분)
+
+```java
+public static {NewEntity} create({필수 인자}) {
+    validate{필수 invariant}();  // null / pattern / 범위 체크
+    return {NewEntity}.builder()
+        .{필드들}
+        .{초기 status}
+        .build();
+}
+```
+
+체크리스트:
+- [ ] 비즈니스 의미 명확한 메서드명 (`create` 대신 `extract` / `register` / `submit` 등)
+- [ ] invariant 검증을 정적 메서드 진입에서 수행
+- [ ] 검증 실패 시 `IllegalArgumentException` (400) 또는 도메인 전용 예외
+
+### Step 3. 비즈니스 메서드 작성 (10분)
+
+```java
+public {NewEntity} {action}({인자}) {
+    if ({invariant 위반 조건}) {
+        throw new IllegalStateException("{한국어 사용자 안내}");
+    }
+    this.{필드 변경};
+    return this;
+}
+```
+
+체크리스트:
+- [ ] 메서드명 = 도메인 의도 (`attachTo` / `complete` / `cancel` 등)
+- [ ] invariant 위반은 `IllegalStateException` throw → 409 매핑
+- [ ] return type = `this` (메서드 chaining 가능)
+
+### Step 4. ArchUnit 룰 통과 확인 (1분)
+
+```bash
+./gradlew test --tests "ArchitectureTest"
+```
+
+실패 시: `@Setter` / `@Data` 사용 여부 확인 → 제거.
+
+### Step 5. 단위 테스트 작성 (15분)
+
+```bash
+# 위치
+src/test/java/com/checkmate/web/entity/{NewEntity}Test.java
+```
+
+7+ test cases 의무:
+1. `create_validInput_returnsEntity` — happy path
+2. `create_nullInput_throws` — invariant 1
+3. `create_invalidPattern_throws` — invariant 2
+4. `{action}_validState_transitions` — happy state transition
+5. `{action}_invalidState_throws` — invariant 위반 (재호출 거부 등)
+6. `{action}_chained_returnsThis` — chaining 가능
+7. (Bonus) Edge case (empty string / max length 등)
+
+### Step 6. Repository 신규 (5분)
+
+```java
+public interface {NewEntity}Repository extends JpaRepository<{NewEntity}, UUID> {
+    Optional<{NewEntity}> findByXxx(String xxx);
+}
+```
+
+체크리스트:
+- [ ] `@Repository` 어노테이션 (Spring 자동 인식 시 생략 가능, 명시 권장)
+- [ ] 메서드명은 Spring Data JPA convention 따름 (`findBy{Field}`, `existsBy{Field}` 등)
+
+### Step 7. Service 작성 (15분)
+
+```java
+@Service
+@RequiredArgsConstructor
+public class {NewEntity}Service {
+    private final {NewEntity}Repository repository;
+
+    @Transactional(readOnly = true)
+    public {NewEntity}Response findById(UUID id) {
+        {NewEntity} entity = repository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException("{NewEntity} not found: " + id));
+        return {NewEntity}Converter.toResponse(entity);
+    }
+
+    @Transactional
+    public {NewEntity}Response {action}(UUID id, {action}Request request) {
+        {NewEntity} entity = repository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException("{NewEntity} not found: " + id));
+        entity.{action}(request.{필드}());  // 비즈니스 메서드 호출 (dirty checking 활용)
+        return {NewEntity}Converter.toResponse(entity);
+    }
+}
+```
+
+체크리스트:
+- [ ] `@Transactional` (쓰기) / `@Transactional(readOnly = true)` (읽기)
+- [ ] `@RequiredArgsConstructor` + `private final` 생성자 주입
+- [ ] Entity 직접 반환 X → Response DTO 변환
+- [ ] 비즈니스 메서드 호출은 dirty checking 의존 (명시적 save() 호출 불필요)
+
+### Step 8. Controller 작성 (15분)
+
+상세: `docs/guides/backend-controller-template.md` (별도 작성 예정).
+
+체크리스트:
+- [ ] URL: `/api/v1/{entities}` 복수형
+- [ ] `@Tag` + `@Operation` + `@ApiResponse` Springdoc 어노테이션
+- [ ] 통합 테스트 5+ cases (happy / 404 / 400 / 409 / type mismatch)
+
+## 3. ExceptionHandler 매핑 (이미 작성됨, 참고만)
+
+| 도메인 예외 | HTTP Status | 응답 |
+|---|---|---|
+| `IllegalArgumentException` | 400 | `ApiErrorResponse { status: "fail", statusCode: 400, message }` |
+| `EntityNotFoundException` | 404 | 동일 |
+| `IllegalStateException` | 409 | `ConflictException(409)` 매핑 |
+| `MethodArgumentTypeMismatchException` | 400 | type mismatch (invalid UUID PathVariable 등) |
+| `HttpMessageNotReadableException` | 400 | malformed JSON body |
+
+## 4. 학습 가치 박제 (Phase 21 → Sprint 2+)
+
+본 패턴이 해결하는 것:
+
+1. **lifecycle invariant 시각화** — aggregate가 자기 상태 보호 (재부착 거부 등)
+2. **silent corruption 방지** — Enum ORDINAL 금지 + setter 금지로 무지성 변경 차단
+3. **일관된 예외 → HTTP status 매핑** — 모든 도메인 예외가 같은 ApiErrorResponse shape으로 응답
+4. **테스트 가능한 도메인** — 정적 팩토리 + 비즈니스 메서드 → JPA 컨텍스트 없이 단위 테스트 가능
+
+## 5. 안티패턴 (절대 금지)
+
+```java
+// ❌ 금지 1: setter
+article.setStatus(ArticleStatus.ATTACHED);
+article.setSession(session);
+
+// ✅ 올바름
+article.attachTo(session);
+
+// ❌ 금지 2: public constructor
+public Article(String url, ...) { ... }
+new Article("https://...", ...);
+
+// ✅ 올바름 (private constructor + 정적 팩토리)
+Article.extract(url, ...);
+
+// ❌ 금지 3: invariant 검증 부재
+public static Article extract(String url) {
+    return Article.builder().url(url).build();  // URL invariant 검증 X
+}
+
+// ✅ 올바름
+public static Article extract(String url) {
+    validateUrl(url);  // throw if invalid
+    return Article.builder().url(url).build();
+}
+
+// ❌ 금지 4: ORDINAL Enum
+@Enumerated(EnumType.ORDINAL)  // 컬럼 추가/순서 변경 시 데이터 손상
+private ArticleStatus status;
+
+// ✅ 올바름
+@Enumerated(EnumType.STRING)
+private ArticleStatus status;
+```
+
+## 6. 참고 PR (실제 패턴 적용 사례)
+
+- PR #27 (`73b5e43c`): Article DDD/TDD seed — `extract()` + URL invariant + `attachTo()` + ArchUnit 룰
+- PR #28 (`d9b6168`): ArticleController + DTOs + Service + 통합 테스트 5 cases + ExceptionHandler 매핑
+- PR #29 (`6ad70ec`): AnalysisResponse에 articleId 노출 (FE attach wiring unblock)
+
+## 7. 다음 단계
+
+- BE #22 DataSourceAdapter — `docs/guides/backend-datasource-adapter.md` (PM scaffold reference, 작성 예정)
+- BE #24 UrlInputAdapter — `docs/guides/backend-url-input-adapter.md` (Article.extract 사용 reference, 작성 예정)
+- ErrorCode Sprint 2 채택 — 5/5 회의 결정 후 `docs/guides/backend-error-handling.md` 신규

--- a/docs/guides/testing-standard.md
+++ b/docs/guides/testing-standard.md
@@ -1,0 +1,118 @@
+# Testing Standard — TruthScope Backend
+
+> Sprint 2+ 모든 BE PR이 통과해야 할 표준 테스트 절차.
+> 멤버는 본 가이드를 그대로 따라하면 PR 통과 가능 (AI 도구 무관).
+
+## 1. 사전 환경 점검 (한 번만)
+
+```bash
+# Java 17+
+java -version
+
+# Docker (Testcontainers 의존)
+docker version
+
+# Gradle wrapper (저장소 내 ./gradlew 사용 — 별도 설치 X)
+./gradlew --version
+```
+
+Docker 미설치 또는 미실행 시 통합 테스트(Testcontainers) 5건 모두 실패 → **반드시 Docker Desktop 실행 후 진행**.
+
+## 2. PR 전 필수 명령어 (순서 중요)
+
+```bash
+./gradlew spotlessApply      # 1. 포맷 자동 수정 (Google Java Format)
+./gradlew checkstyleMain     # 2. 린트
+./gradlew spotbugsMain       # 3. 정적 분석
+./gradlew test               # 4. 전체 테스트 (단위 + 통합)
+./gradlew build              # 5. 최종 빌드
+```
+
+한 단계라도 실패하면 수정 후 재실행. 전부 통과한 뒤에만 commit/push.
+
+## 3. 테스트 종류 구분
+
+| 종류 | 위치 | 실행 명령 | 환경 |
+|---|---|---|---|
+| 단위 테스트 | `src/test/java/.../service/*Test.java` | `./gradlew test --tests "*ServiceTest"` | Spring 컨텍스트 X, 빠름 |
+| 통합 테스트 | `src/test/java/.../controller/*IntegrationTest.java` | `./gradlew test --tests "*IntegrationTest"` | Testcontainers PostgreSQL, 느림 |
+| 아키텍처 테스트 | `src/test/java/.../architecture/ArchitectureTest.java` | `./gradlew test --tests "ArchitectureTest"` | ArchUnit 룰 검증 (setter 금지 등) |
+
+## 4. 통합 테스트 작성 규칙 (Phase 21 학습 정합)
+
+### 베이스 클래스 상속 의무
+
+```java
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ArticleControllerIntegrationTest extends AbstractIntegrationTest {
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    // ... test cases
+}
+```
+
+`AbstractIntegrationTest`는 Singleton container 패턴으로 PostgreSQL 컨테이너를 JVM-singleton으로 관리 (클래스 단위 lifecycle 회피, stale port "Connection refused" 방지).
+
+### 5+ test cases per controller (의무)
+
+| 시나리오 | 필수 |
+|---|---|
+| Happy path (200/201) | 의무 |
+| 404 Not Found | 의무 |
+| 400 Bad Request (invalid input) | 의무 |
+| 409 Conflict (도메인 invariant 위반) | 의무 (해당하는 경우) |
+| 415/422 등 type mismatch / message not readable | 의무 (해당하는 경우) |
+
+### Mock vs Testcontainers 선택
+
+- **Mock**: Service layer 단위 테스트 (`@Mock` Repository, `@InjectMocks` Service)
+- **Testcontainers**: Controller 통합 테스트 (실제 DB + JPA 매핑 검증)
+
+→ Service에 비즈니스 로직 / Repository에 쿼리 / Controller에 매핑이 있다면 모두 통합 테스트로 검증.
+
+## 5. 테스트 실패 디버깅 절차
+
+### "Connection refused" (Testcontainers)
+
+1. Docker Desktop 실행 확인
+2. `./gradlew test --tests "ArticleControllerIntegrationTest" --info` 로 컨테이너 시작 로그 확인
+3. PostgreSQL 컨테이너 image pull 진행도 확인 (첫 실행 시 30~60초 소요)
+
+### "NoSuchBeanDefinitionException: TestRestTemplate"
+
+1. `@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)` 명시 확인 (기본값 MOCK은 TestRestTemplate 미주입)
+
+### "ArchUnit rule violated"
+
+1. Entity 클래스에 `@Setter` / `@Data` 사용 여부 확인 — 모두 제거
+2. `@Getter` + 비즈니스 메서드(`attachTo()` 등)로 변경
+
+### Spotless format 실패
+
+```bash
+./gradlew spotlessApply  # 자동 수정 후 재커밋
+```
+
+## 6. CI 파이프라인 (GitHub Actions)
+
+PR 생성 시 자동 실행:
+
+1. `format:check` (Spotless)
+2. `checkstyleMain`
+3. `spotbugsMain`
+4. `test` (Testcontainers 포함)
+5. `build`
+
+**1건이라도 실패 시 PR merge 불가**. 로컬에서 동일 명령어로 미리 통과 의무.
+
+## 7. PR 체크리스트 (PR 본문에 복사)
+
+```markdown
+- [ ] `./gradlew spotlessApply / checkstyleMain / spotbugsMain` PASS
+- [ ] `./gradlew test` PASS (회귀 0, 신규 테스트 N건 추가)
+- [ ] `./gradlew build` PASS
+- [ ] ArchUnit 룰 PASS
+- [ ] Springdoc 어노테이션 추가 (controller 신규 시)
+- [ ] PR 본문에 spec 이슈 번호 명시
+```


### PR DESCRIPTION
## Summary

Sprint 2 멤버 onboarding 의무 자료 박제. Codex (gpt-5.5) thread `019de8e3-1b95-7a73-81d7-f1736a4fd6df` 권장 **A4-lite 구조** 채택.

- `AGENTS.md`: 모든 AI 도구 (Codex CLI / GitHub Copilot / Cursor / Claude Code 등) 공통 instruction
- `docs/guides/testing-standard.md`: 사람이 따라할 PR 전 5단계 테스트 절차
- `docs/guides/backend-ddd-tdd-template.md`: Phase 21 학습 정합 reference (Article aggregate 패턴)
- 기존 `CLAUDE.md` 보존 (Claude 전용 보충)
- `.claude/agents/` Phase 22+ deferred

## Background

5/1 회의 D-0501-1~7 결정 + 5/2 본 세션 Phase 21 머지 (PR #28 + #29 + FE #24) 후 Sprint 2 Week 1 진입 준비. 멤버별 도구 환경 차이:

- 안세환 = Claude Pro
- 한지민 = AI 구독 X (가이드 문서 의존)
- 이정훈 / 정세린 = 도구 불명 (무도구 baseline 가정)

→ "AI 도구가 읽을 것은 AGENTS.md, 사람이 따라할 것은 docs/guides, Claude 사용자는 기존 CLAUDE.md로 진입" 분리 패턴 채택.

## Changes (3 files +520 lines)

### `AGENTS.md` (신규, 152 lines)

- 절대 금지 6건 (`@Setter` Entity / `EntityType.ORDINAL` / `FetchType.EAGER` / `gemini-2.0-flash-lite` / `--no-verify` / `springdoc 2.8.6 이하`)
- 핵심 패턴 7개: Entity / DDD aggregate / DTO / Service / Controller / Exception / 통합 테스트
- 테스트 명령어 (PR 전 5단계)
- 멤버별 진입 경로 (한지민 / 이정훈 / 권석)
- PR 체크리스트 + Gitmoji 커밋
- 5/4 Sprint 2 진입 전 PM 의무 (BE #20 SSRF blocker / BE #22 scaffold reference / D7 onboarding 일정 공지)

### `docs/guides/testing-standard.md` (신규, 145 lines)

- 사전 환경 점검 (Java 17 + Docker + Gradle wrapper)
- PR 전 필수 명령어 (spotlessApply → checkstyleMain → spotbugsMain → test → build)
- 테스트 종류 구분 (단위 / 통합 / 아키텍처)
- 통합 테스트 작성 규칙 (AbstractIntegrationTest 상속 + 5+ test cases per controller)
- 디버깅 절차 ("Connection refused" / "NoSuchBeanDefinitionException" / "ArchUnit rule violated" / Spotless format 실패)
- CI 파이프라인 + PR 체크리스트

### `docs/guides/backend-ddd-tdd-template.md` (신규, 223 lines)

- Phase 21 학습 정합 reference: Article aggregate 패턴 (정적 팩토리 + URL invariant + attachTo + ArchUnit)
- Sprint 2+ 신규 aggregate 작성 8단계 (Entity → 정적 팩토리 → 비즈니스 메서드 → ArchUnit → 단위 테스트 → Repository → Service → Controller)
- ExceptionHandler 매핑 표
- 학습 가치 박제 4건 (lifecycle invariant / silent corruption 방지 / 일관된 예외→HTTP 매핑 / 테스트 가능한 도메인)
- 안티패턴 4종 (setter / public constructor / invariant 부재 / ORDINAL Enum)
- 참고 PR (PR #27 / #28 / #29)

## Test plan

본 PR은 **문서 only** — 코드 변경 없음.

- [✅] AGENTS.md 작성 + 모든 링크 (`docs/guides/*`) 정합 확인
- [✅] docs/guides/testing-standard.md 작성 + 명령어 5단계 검증 (`./gradlew spotlessApply` ~ `build`)
- [✅] docs/guides/backend-ddd-tdd-template.md 작성 + Article reference 코드 (`src/main/java/com/checkmate/web/entity/Article.java`) 정합 확인
- [ ] CI green (build-and-test)
- [ ] CodeRabbit 리뷰 (코드 변경 0이라 skipped 예상)

## 후속 작업 (별도 PR)

본 PR 머지 후 PM이 5/3~5/4 작성 예정 (Codex thread `019de8e3-...` 우선순위 표 정합):

1. `docs/guides/backend-datasource-adapter.md` (BE #22 한지민 reference)
2. `docs/guides/backend-url-input-adapter.md` (BE #24 이정훈 reference)
3. BE #20 SSRF Week 1 blocker PR (Codex 1순위)
4. BE #23 Gradle 분리 (S2-02)
5. D6 Tier 2 토큰 v2 초안 (5/5 회의 안건)
6. ErrorCode 템플릿 초안 (5/5 회의 안건)

## 관련

- Codex thread: `019de8e3-1b95-7a73-81d7-f1736a4fd6df` (gpt-5.5, 2 turn 검토)
- 5/1 회의 결정: D-0501-1~7 박제 (`Team-project/CheckMate/meetings/2026-05-01-additional-round.md`)
- Sprint 2 Week 1 분배: 옵션 A 재배정 (FE #21 close + BE #25 → Week 2 + BE #22 한지민 코드 분할)
- 옵션 A 적용 GitHub 이슈 갱신: BE #22 / #24 / #25 본문 갱신 + BE #20 week1 라벨 추가 + BE #30 GDELT quota 신규 + FE #21 close + FE #25 신규 + FE #19 D6 분리 코멘트

Co-authored-by: gs07103 <gwonseok02@gmail.com>
