### PR TITLE
🔒fix(security): address CodeRabbit findings from PR #37 (6 fixes)

### DIFF
--- a/src/main/java/com/truthscope/web/security/SsrfGuard.java
+++ b/src/main/java/com/truthscope/web/security/SsrfGuard.java
@@ -82,7 +82,7 @@ public class SsrfGuard {
       throw new BadRequestException("유효하지 않은 URL 형식입니다");
     }
     String scheme = uri.getScheme();
-    if (scheme == null || (!scheme.equals("http") && !scheme.equals("https"))) {
+    if (scheme == null || (!scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https"))) {
       throw new BadRequestException("유효하지 않은 URL 형식입니다");
     }
     String host = uri.getHost();

--- a/src/main/java/com/truthscope/web/security/SsrfGuard.java
+++ b/src/main/java/com/truthscope/web/security/SsrfGuard.java
@@ -108,12 +108,8 @@ public class SsrfGuard {
       String ipString = effectiveAddr.getHostAddress();
       for (IpAddressMatcher matcher : denyMatchers) {
         if (matcher.matches(ipString)) {
-          log.warn(
-              "SSRF block: url={} host={} resolved={} matched_cidr={}",
-              url,
-              host,
-              ipString,
-              matcher);
+          // CodeRabbit #2: raw URL 로그 회피 (userinfo/query 토큰 유출 방지) - host/IP/CIDR만 기록
+          log.warn("SSRF block: host={} resolved={} matched_cidr={}", host, ipString, matcher);
           throw new SsrfBlockedException("내부 네트워크 주소는 차단되었습니다");
         }
       }
@@ -125,6 +121,35 @@ public class SsrfGuard {
   /** Test seam - Mockito @Spy로 override 가능 (DNS rebinding 시나리오 등). */
   protected InetAddress[] resolveHost(String host) throws UnknownHostException {
     return InetAddress.getAllByName(host);
+  }
+
+  /**
+   * 로그 안전을 위해 URI를 {@code scheme://host[:port][/path]}로 redact.
+   *
+   * <p>userinfo와 query string은 제거 — query에 담긴 토큰/식별자나 userinfo의 자격 증명이 로그에 유출되는 것을 방지. SSRF block /
+   * redirect chain 등 로그에서 사용.
+   *
+   * @param uri 원본 URI (null 허용)
+   * @return redacted 형식 문자열, null 입력 시 {@code "<null>"}
+   */
+  public static String redactUri(URI uri) {
+    if (uri == null) {
+      return "<null>";
+    }
+    StringBuilder sb = new StringBuilder();
+    if (uri.getScheme() != null) {
+      sb.append(uri.getScheme()).append("://");
+    }
+    if (uri.getHost() != null) {
+      sb.append(uri.getHost());
+    }
+    if (uri.getPort() != -1) {
+      sb.append(':').append(uri.getPort());
+    }
+    if (uri.getPath() != null) {
+      sb.append(uri.getPath());
+    }
+    return sb.toString();
   }
 
   /** RFC 4291 §2.5.5.2 IPv4-mapped IPv6 (::ffff:0:0/96)를 IPv4로 unmap. */

--- a/src/main/java/com/truthscope/web/service/ContentExtractService.java
+++ b/src/main/java/com/truthscope/web/service/ContentExtractService.java
@@ -34,6 +34,7 @@ import org.jsoup.nodes.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 뉴스 URL에서 기사 본문을 추출하는 서비스. SSRF 방어를 위해 SsrfGuard로 사전 검증 + Apache HttpClient 5의 custom DnsResolver로
@@ -60,6 +61,7 @@ public class ContentExtractService {
    * @param url 뉴스 기사 URL (http/https만 허용, 사설망/loopback/문서화 대역 차단)
    * @return 제목, 본문, 언어, 도메인이 담긴 ExtractedArticle
    */
+  @Transactional(readOnly = true)
   public ExtractedArticle extract(String url) {
     SsrfGuard.ValidatedTarget initialTarget = ssrfGuard.validateAndResolve(url);
     FetchOutcome outcome = fetchWithRedirectGuard(initialTarget);

--- a/src/main/java/com/truthscope/web/service/ContentExtractService.java
+++ b/src/main/java/com/truthscope/web/service/ContentExtractService.java
@@ -97,16 +97,20 @@ public class ContentExtractService {
             throw new ExtractionFailedException("기사를 가져올 수 없습니다: " + initialUri);
           }
           URI nextUri = parseLocation(result.locationHeader(), currentTarget.uri(), initialUri);
+          // CodeRabbit #4: redirect chain 로그도 redact (userinfo/query 유출 방지)
           log.debug(
               "Redirect from {} to {} ({}/{})",
-              currentTarget.uri(),
-              nextUri,
+              SsrfGuard.redactUri(currentTarget.uri()),
+              SsrfGuard.redactUri(nextUri),
               redirects,
               MAX_REDIRECTS);
           try {
             currentTarget = ssrfGuard.validateAndResolve(nextUri.toString());
           } catch (SsrfBlockedException e) {
-            log.warn("SSRF block on redirect chain: initial={}, blocked={}", initialUri, nextUri);
+            log.warn(
+                "SSRF block on redirect chain: initial={} blocked={}",
+                SsrfGuard.redactUri(initialUri),
+                SsrfGuard.redactUri(nextUri));
             throw e;
           }
           continue;

--- a/src/main/java/com/truthscope/web/service/ContentExtractService.java
+++ b/src/main/java/com/truthscope/web/service/ContentExtractService.java
@@ -155,19 +155,15 @@ public class ContentExtractService {
         throw new ExtractionFailedException("기사를 가져올 수 없습니다: " + initialUri);
       }
 
-      // R1-2: null entity check
       HttpEntity entity = response.getEntity();
       if (entity == null) {
         throw new ExtractionFailedException("기사를 가져올 수 없습니다: " + initialUri);
       }
-      // CX-22: charset 추출 (Content-Type header)
       Charset charset = extractCharset(entity);
       try {
-        // CX-12 + CX-14: bounded read on decompressed stream
         byte[] body = readBoundedBytes(entity.getContent(), MAX_FETCH_BYTES, initialUri);
         return FetchResult.body(body, charset);
       } catch (ExtractionFailedException e) {
-        // R2-4: ensure entity is consumed even when bounded read aborts
         try {
           EntityUtils.consume(entity);
         } catch (IOException ignored) {

--- a/src/test/java/com/truthscope/web/service/ContentExtractServiceRealSocketTest.java
+++ b/src/test/java/com/truthscope/web/service/ContentExtractServiceRealSocketTest.java
@@ -15,11 +15,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * ContentExtractService 통합 테스트 — Real socket 127.0.0.1 직접 차단 시나리오. PLAN @SpringBootTest 대신 직접
- * construction 사용 (포커스 테스트 + DB 미필요로 빠른 실행).
+ * ContentExtractService Real-socket 테스트 — 127.0.0.1 직접 차단 시나리오.
+ *
+ * <p>네이밍 정책: {@code *IntegrationTest}는 {@code AbstractIntegrationTest} 상속 + Spring 컨텍스트 의무
+ * (CodeRabbit #5). 본 테스트는 Spring 컨텍스트 + DB 미필요로 직접 construction 사용 → {@code *RealSocketTest} 접미사로
+ * 분리.
  */
-@DisplayName("ContentExtractService 통합 테스트 (Real socket - 127.0.0.1 차단)")
-class ContentExtractServiceIntegrationTest {
+@DisplayName("ContentExtractService Real-socket 테스트 (127.0.0.1 차단)")
+class ContentExtractServiceRealSocketTest {
 
   private static HttpServer localServer;
 

--- a/src/test/java/com/truthscope/web/service/ContentExtractServiceTest.java
+++ b/src/test/java/com/truthscope/web/service/ContentExtractServiceTest.java
@@ -51,7 +51,9 @@ class ContentExtractServiceTest {
     @DisplayName("8000자 이하 텍스트는 그대로 반환")
     void shortTextNotTruncated() {
       String shortText = "a".repeat(7999);
+      String result = ArticleHtmlParser.truncate(shortText);
       assertThat(shortText.length()).isLessThan(8000);
+      assertThat(result).isEqualTo(shortText);
     }
 
     @Test


### PR DESCRIPTION
## Summary

PR #37 (SSRF blocker) 머지 후 누락 처리한 **CodeRabbit actionable comments 6건** 반영. 모두 Quick win (보안 + 컨벤션 + 테스트 강화).

## Findings 처리

| # | 카테고리 | 심각도 | Commit | 변경 |
|---|---|---|---|---|
| 1 | Scheme 비교 | 🟡 Minor | `01bb05e` | `equals` → `equalsIgnoreCase` (HTTP/HTTPS 대문자 valid URL 거부 버그 수정) |
| 2 | 보안 (로그) | 🟠 Major | `39bb675` | SSRF block 로그에서 raw user URL 제거 (host/IP/CIDR만 기록) |
| 3 | 컨벤션 | 🟠 Major | `1dd2d20` | `extract()`에 `@Transactional(readOnly = true)` 추가 |
| 4 | 보안 (로그) | 🟠 Major | `39bb675` | redirect chain 로그도 `SsrfGuard.redactUri(URI)` helper로 redact |
| 5 | 네이밍 룰 | 🟠 Major | `f8fcd85` | `*IntegrationTest` → `*RealSocketTest` (Spring 컨텍스트 미사용 분리) |
| 6 | 테스트 강화 | 🟡 Minor | `8325f3a` | `shortTextNotTruncated`에 `ArticleHtmlParser.truncate()` 호출 + assertion |
| (보조) | FileLength | — | `778a658` | `@Transactional` 추가로 ContentExtractService.java 304줄 → 300줄 (PLAN review-history 주석 4개 압축) |

## 신규 helper

`SsrfGuard.redactUri(URI)` static method:
- `scheme://host[:port][/path]` 형식만 남김
- `userinfo` + `query string` 제거 (토큰/식별자 유출 방지)
- SSRF block + redirect chain 로그 두 곳에서 사용

## 검증

| 검증 | 결과 |
|---|---|
| `./gradlew clean spotlessApply checkstyleMain spotbugsMain spotbugsTest test build` | ✅ BUILD SUCCESSFUL (4m 34s, 19 tasks) |
| Project test count | **95/0/0** (PR #37 머지 결과 그대로 유지) |
| ContentExtractService.java FileLength | 300줄 (한도 정합) |
| Phase 20 56 tests + 기존 39 = 95 | ✅ |

## 머지 정책

**Squash merge 권장** — 6 commits 단일 commit으로 정리.

## Test plan

- [ ] CI green (Spotless / Checkstyle / SpotBugs main+test / Test / Build)
- [ ] CodeRabbit 재리뷰 시 6 findings 모두 resolved 확인
- [ ] `HTTP://news.naver.com/...` 같은 대문자 scheme URL 정상 처리 (Fix 1)
- [ ] SSRF block 시 로그에 토큰/userinfo 노출 없음 (Fix 2/4)

## 참조

- 원본 PR: #37 (SSRF blocker, MERGED)
- CodeRabbit 리뷰: PR #37 6 line comments
- Reviewer thread fingerprints: e65ccb48 / 551a227f / d98c2f50

🤖 Generated with [Claude Code](https://claude.com/claude-code)
