### PR TITLE
♻️refactor(build): extract spike sourceSet to workspace-level project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,10 +62,5 @@ logs/
 .plans/
 context/
 
-# ===========================
-# Spike sourceSet (개인 로컬 전용 — throwaway 연구 코드)
-# ===========================
-# app/build.gradle 의 sourceSet 정의는 git tracked, 그러나 app/src/spike/ 콘텐츠는
-# 개인 로컬에서만 작업. 결과 공유는 옵시디언/Notion 또는 별 .plans/ 산출물.
-# 상세: CLAUDE.md ## spike sourceSet
-app/src/spike/
+# spike code(throwaway 연구)는 2026-05-04 워크스페이스 레벨 `truthscope-web/spike/`로 분리됨.
+# BE repo에서는 더 이상 추적/제외 대상이 아니다. 상세: spike/README.md.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,74 +80,20 @@
 - Google Java Format (Spotless): `./gradlew spotlessApply`
 - 빌드 전 반드시 포맷 적용
 
-## spike sourceSet — throwaway 연구 코드 격리 (2026-05-04 도입)
+## spike (throwaway 연구 코드) — 2026-05-04 워크스페이스 레벨로 분리
 
-평소 build와 분리해서 운영하는 **연구·검증용 throwaway 코드** 전용 sourceSet. 외부 API/데이터소스 정합성 측정 같은 비-프로덕션 코드를 main test classpath에 섞지 않기 위해 도입.
+이전에는 `app/src/spike/` sourceSet이었으나 BE 빌드 파이프라인과 격리가 어려워 (CodeRabbit 정책 위반 nitpick · spotbugsTest false positive 등) 워크스페이스 레벨로 외부화함.
 
-### 위치
-
-| 종류 | 경로 |
+| 항목 | 값 |
 |---|---|
-| Java 소스 | `src/spike/java/` (패키지 자유) |
-| 리소스 (CSV, fixtures 등) | `src/spike/resources/` |
+| 위치 | `truthscope-web/spike/` (BE/FE repo 외부, 워크스페이스 루트) |
+| 빌드 | 자체 `settings.gradle` + `build.gradle` (plain Java 17 + JUnit 5 + AssertJ + jsoup + Jackson) |
+| Spring 의존 | **0** — 본 BE의 어떤 빌드 task에도 포함되지 않음 |
+| git 추적 | 없음 (워크스페이스 자체가 git이 아님) |
+| 사용법 / 정책 / 신규 spike 추가 절차 | `truthscope-web/spike/README.md` 참조 |
+| 결과물 박제 | 옵시디언/Notion 또는 `.plans/{N}-*/pm-spike/` (이전 위치 그대로) |
 
-### 정책
-
-| 항목 | 정책 |
-|---|---|
-| Spring 의존 | **금지** — Plain Java + JUnit 5만. 필요하면 별 module로 분리 |
-| **Git 추적** | **비추적** (`.gitignore`에 `src/spike/` 등재) — 개인 로컬 전용. 결과 공유는 옵시디언/Notion 또는 별 `.plans/` 산출물 |
-| Spotless (포맷) | 적용 — 협업 가능한 코드 스타일 유지 |
-| Checkstyle | **비활성화** (`checkstyleSpike.enabled = false`) |
-| SpotBugs | **비활성화** (`spotbugsSpike.enabled = false`) — 연구 코드 false positive 무시 |
-| 평소 `./gradlew test` | **자동 제외** — 별 sourceSet이라 test classpath 미공유 |
-| 명시 실행 | `./gradlew spikeTest` |
-| Throwaway 권장 어노테이션 | `@Tag("spike")` + `@Disabled("spike — verified YYYY-MM-DD. Enable manually to re-run.")` |
-
-> **왜 git 비추적?** spike 코드는 throwaway 검증용이라 정식 PR/리뷰 없이 빠르게 작성·폐기. API 키 의존성도 잦음. 결과(CSV, 분석)만 옵시디언/Notion에 박제하면 충분. 본 정책 변경 시 `.gitignore`에서 `src/spike/` 줄 제거 + 사용자 결정 필요.
-
-### build.gradle 설정 (이미 적용됨)
-
-```groovy
-sourceSets {
-    spike {
-        java { srcDirs = ['src/spike/java'] }
-        resources { srcDirs = ['src/spike/resources'] }
-        compileClasspath += sourceSets.test.runtimeClasspath
-        runtimeClasspath += sourceSets.test.runtimeClasspath
-    }
-}
-
-configurations {
-    spikeImplementation.extendsFrom testImplementation
-    spikeRuntimeOnly.extendsFrom testRuntimeOnly
-}
-
-tasks.register('spikeTest', Test) { ... }
-
-tasks.matching { it.name in ['checkstyleSpike', 'spotbugsSpike'] }.configureEach {
-    enabled = false
-}
-```
-
-### 사용 시점 (스파이크 추가)
-
-1. 새 spike 디렉토리: `src/spike/java/{도메인}/...` (working tree만, git 무시)
-2. 패키지 자유 (`com.truthscope.web.spike.{도메인}` 권장 but 강제 아님)
-3. 리소스: `src/spike/resources/{도메인}/...`
-4. 클래스 상단에 `@Tag("spike")` + `@Disabled` (검증 완료 후 보존이라면)
-5. 처음 실행: `./gradlew spikeTest --tests "...{TestName}"` (또는 `@Disabled` 제거 후 `./gradlew spikeTest`)
-6. 결과(CSV, 분석)는 옵시디언/Notion/`.plans/` 에 별도 박제 — 코드 자체는 로컬에서만 보존
-
-### 사용 시점 (검증 졸업 시)
-
-spike 코드가 본 프로덕션 패턴으로 졸업하면 → `src/spike/`에서 `src/main/` + `src/test/`로 정식 마이그레이션. spike sourceSet은 **연구 단계 임시 보관소**.
-
-### 현재 spike 입주 작업 (PM 로컬 working tree, git untracked)
-
-- `src/spike/java/com/truthscope/web/spike/datasourceaccuracy/` — 데이터 소스 6개 정합성 측정 (2026-04-24 PM-spike rev.5/6) — 4 클래스
-- `src/spike/resources/spike/datasource-accuracy/` — gold-set + 결과 CSV 4개
-- 코드 백업/공유: `.plans/19-plan-v1.2/pm-spike/2026-04-24-datasource-accuracy/` (analysis 산출물) + 옵시디언
+> BE repo 안에서는 spike 관련 build.gradle 항목 / `.gitignore` 룰 / `app/src/spike/` 디렉토리가 모두 제거됨. 본 섹션은 위치 안내만 남긴다.
 
 ---
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,36 +26,5 @@ dependencies {
 	testImplementation 'org.testcontainers:junit-jupiter'
 }
 
-// ── Spike sourceSet (throwaway research code — 평소 build에서 제외) ──
-//
-// 위치: app/src/spike/java/, app/src/spike/resources/
-// 정책: Plain Java + JUnit 5 (Spring 의존 0). Spotless 적용 / Checkstyle·SpotBugs 비활성화.
-// 실행: ./gradlew :app:spikeTest (명시 호출 시만, ./gradlew test 에는 미포함)
-// 상세: backend CLAUDE.md ## spike sourceSet 섹션
-sourceSets {
-	spike {
-		java { srcDirs = ['src/spike/java'] }
-		resources { srcDirs = ['src/spike/resources'] }
-		compileClasspath += sourceSets.test.runtimeClasspath
-		runtimeClasspath += sourceSets.test.runtimeClasspath
-	}
-}
-
-configurations {
-	spikeImplementation.extendsFrom testImplementation
-	spikeRuntimeOnly.extendsFrom testRuntimeOnly
-}
-
-tasks.register('spikeTest', Test) {
-	description = 'Run spike research tests (data source accuracy 검증). 평소 build에서 제외.'
-	group = 'verification'
-	testClassesDirs = sourceSets.spike.output.classesDirs
-	classpath = sourceSets.spike.runtimeClasspath
-	useJUnitPlatform()
-	shouldRunAfter test
-}
-
-// spike sourceSet은 throwaway 연구 코드 — Checkstyle/SpotBugs 비활성화
-tasks.matching { it.name in ['checkstyleSpike', 'spotbugsSpike'] }.configureEach {
-	enabled = false
-}
+// throwaway 연구 코드(spike)는 워크스페이스 레벨 `truthscope-web/spike/` 독립 Java 프로젝트로 분리됨 (2026-05-04).
+// 이전 `app/src/spike/` sourceSet 제거 — BE 빌드 파이프라인과 단절. 상세는 spike/README.md 및 BE CLAUDE.md.


### PR DESCRIPTION
## Summary

PR #42 CodeRabbit nitpick (spike sourceSet 의 spring stack 자동 상속 정책 위반) 근본 해결. spike sourceSet 자체를 BE app 모듈에서 제거하고 워크스페이스 루트 `truthscope-web/spike/` 독립 Java 프로젝트로 분리.

## 분리 사유

- **PR #42 CodeRabbit nitpick**: spike sourceSet 의 `extendsFrom testImplementation` 가 spring-boot-starter-test, Testcontainers 등을 spike 에 자동 상속시켜 BE CLAUDE.md 정책("Plain Java + JUnit 5 / Spring 의존 0") 위반
- **BE 빌드 잡음**: spotbugsTest 등이 spike code false positive 를 PR 리뷰에 잡아 rename PR 진행 중에도 잔여 작업 발생 (오늘 두 번째 spike-related issue)
- **conventions 분리 자연스러움**: throwaway 연구 코드와 BE 정식 코드는 다른 lifecycle / 다른 정책. 같은 Gradle project 안에 두면 빌드 파이프라인이 두 책임 가짐

## BE 변경

| 파일 | 변경 |
|---|---|
| `app/build.gradle` | spike sourceSet, spikeTest task, spike checkstyle/spotbugs disable 블록, spikeImplementation deps 모두 제거. 안내 주석 1줄 추가 (35 lines → 약 30 lines) |
| `.gitignore` | `app/src/spike/` 등재 제거 + 짧은 안내 주석으로 교체 |
| `CLAUDE.md` | spike 섹션 76 lines → 11 lines 안내 (외부 위치 안내만) |
| `app/src/spike/` | 디렉토리 통째 제거 (PM 로컬에서 spike code 는 워크스페이스 spike/로 이동) |

## 워크스페이스 변경 (PR scope 외 — git untracked)

`truthscope-web/spike/` 신설:
- 자체 `settings.gradle` + `build.gradle` (plain Java 17 + JUnit 5 + AssertJ + jsoup + Jackson)
- 자체 Gradle wrapper 8.14.4 (BE 에서 복사)
- `src/test/java/com/truthscope/web/spike/` (helper + Test 모두 test sourceSet 에)
- `src/test/resources/datasource-accuracy/` (gold-set + 결과 CSV)
- `README.md` (정책 + 사용법 + 신규 spike 추가 절차)

본 워크스페이스 spike/ 는 git untracked 라 본 PR 에 포함되지 않음. PM 로컬 only.

## 검증

- `./gradlew :app:spotlessApply` PASS
- `./gradlew :app:check` PASS (spike 없는 BE 정상 작동)
- `./gradlew :core:build` PASS
- 워크스페이스 spike: `./gradlew compileTestJava` PASS (4 클래스 + AssertJ + jsoup + Jackson + JUnit 5)

## Reference

- PR #42 (dev → main propagation, BE #23 머지) — 본 PR 머지 시 자동 갱신됨
- BE CLAUDE.md `## spike` 섹션 (이번에 단순화)
- 워크스페이스: `truthscope-web/spike/README.md` (PM 로컬 only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)