### PR TITLE
✅test(arch): ArchUnit core 격리 + DTO record 룰 추가 (F9)

### DIFF
--- a/app/src/test/java/com/truthscope/web/architecture/ArchitectureTest.java
+++ b/app/src/test/java/com/truthscope/web/architecture/ArchitectureTest.java
@@ -121,4 +121,38 @@ class ArchitectureTest {
           .haveNameStartingWith("set")
           .because(
               "Entity 변경은 비즈니스 메서드로만 허용 (DDD always-valid 모델). enum 패키지는 별도(..entity.enums..)이므로 영향 없음.");
+
+  // ── core 모듈 격리 (ADR-006 D1: OSS 단독 배포 가능성 강제) ──
+
+  @ArchTest
+  static final ArchRule corePackagesShouldNotDependOnAppLayer =
+      noClasses()
+          .that()
+          .resideInAnyPackage(
+              "..entity..", "..dto..", "..converter..", "..exception..", "..adapter..")
+          .should()
+          .dependOnClassesThat()
+          .resideInAnyPackage(
+              "..controller..",
+              "..service..",
+              "..repository..",
+              "..config..",
+              "..security..",
+              "..html..")
+          .allowEmptyShould(true)
+          .because(
+              "ADR-006: core 모듈(entity/dto/converter/exception/adapter)은 app 모듈(controller/service/repository/config/security/html)에 의존 금지. core가 OSS jar로 단독 배포 가능해야 함.");
+
+  // ── DTO record 강제 (CONVENTIONS: 요청 DTO는 record 타입) ──
+
+  @ArchTest
+  static final ArchRule requestDtoShouldBeRecord =
+      classes()
+          .that()
+          .resideInAPackage("..dto.request..")
+          .should()
+          .beRecords()
+          .allowEmptyShould(true)
+          .because(
+              "CONVENTIONS: 요청 DTO는 record 타입 (Java 17+) — immutable + 자동 equals/hashCode/toString.");
 }


### PR DESCRIPTION
## Summary

HANDOFF F9 작업. 기존 ArchitectureTest에 layer enforcement 룰 2개 추가:

1. **`corePackagesShouldNotDependOnAppLayer`** — ADR-006 D1 강제. core 모듈 패키지(entity/dto/converter/exception/adapter)가 app 모듈 패키지(controller/service/repository/config/security/html)에 의존 금지. Gradle subproject dependency가 자동 보장하지만 ArchUnit 레벨에서 코드 import 검증 추가
2. **`requestDtoShouldBeRecord`** — CONVENTIONS 정합. `dto.request` 패키지 클래스는 record 의무

## 변경

- `app/src/test/java/com/truthscope/web/architecture/ArchitectureTest.java` (+34 lines)

## 검증

- `./gradlew :app:spotlessApply` PASS
- `./gradlew :app:test --tests "*ArchitectureTest*"` PASS (룰 11개 모두 통과)
- `./gradlew :app:check` 전체 PASS (test 0 regression)

## 학습 가치

ADR-006 핵심 비전(core OSS 단독 배포)을 Gradle multi-project + ArchUnit 이중 강제. core 패키지에 미존재인 adapter도 미리 보호 → BE #22 한지민 Week 2 작업이 본 룰 자동 검증 대상.

## Reference

- HANDOFF F9: `truthscope-web/.plans/23-gradle-core-app-split/HANDOFF.md`
- ADR-006: `truthscope-web/context/decisions/ADR-006-core-app-separation.md`
- BE CONVENTIONS.md (요청 DTO record 규칙)

🤖 Generated with [Claude Code](https://claude.com/claude-code)