### PR TITLE
✅test(extract): truncate 메서드 prefix 정합 검증 추가 (F7, PR #40 nitpick)

### DIFF
--- a/app/src/test/java/com/truthscope/web/service/ContentExtractServiceTest.java
+++ b/app/src/test/java/com/truthscope/web/service/ContentExtractServiceTest.java
@@ -57,19 +57,20 @@ class ContentExtractServiceTest {
     }
 
     @Test
-    @DisplayName("8000자 초과 텍스트는 8000자로 잘림")
+    @DisplayName("8000자 초과 텍스트는 8000자로 잘림 + prefix 정합")
     void longTextTruncated() {
       String longText = "가".repeat(9000);
       String truncated = ArticleHtmlParser.truncate(longText);
       assertThat(truncated.length()).isEqualTo(8000);
+      assertThat(truncated).isEqualTo(longText.substring(0, 8000));
     }
 
     @Test
-    @DisplayName("정확히 8000자 텍스트는 그대로 반환")
+    @DisplayName("정확히 8000자 텍스트는 변경 없이 그대로 반환")
     void exactLimitTextNotTruncated() {
       String exactText = "b".repeat(8000);
       String result = ArticleHtmlParser.truncate(exactText);
-      assertThat(result.length()).isEqualTo(8000);
+      assertThat(result).isEqualTo(exactText);
     }
   }
 }


### PR DESCRIPTION
## Summary

HANDOFF F7 작업. PR #40 (Phase 20 SSRF blocker) CodeRabbit 1차 review에서 deferred됐던 nitpick 2건 중 quick-win 1건 처리.

## 처리 / Skip 분류

| Nitpick | 위치 | 처리 |
|---|---|---|
| 1 | `ContentExtractServiceTest.java:60-72` truncate 길이만 검증 → prefix 정합 추가 | **본 PR 처리** |
| 2 | `build.gradle:58-69` spike sourceSet 격리 정책 위반 | **Skip** — PR #43 (`dec96f6`) 워크스페이스 외부화로 근본 해결됨 |

## 변경

- `app/src/test/java/com/truthscope/web/service/ContentExtractServiceTest.java`
  - `longTextTruncated`: `assertThat(truncated).isEqualTo(longText.substring(0, 8000))` 추가
  - `exactLimitTextNotTruncated`: `assertThat(result).isEqualTo(exactText)` 추가 (길이만 검증 → 전체 비교)
  - `@DisplayName` 보강 ("+ prefix 정합" / "변경 없이")

## 학습 가치

길이만 검증하면 잘못된 절단 위치 / 내용 손상이 발생해도 통과. prefix 정합 검증으로 회귀 차단. 이후 BE #22 adapter 작성 시 fixture 정합 패턴 reference로 사용 가능.

## 검증

- `./gradlew :app:spotlessApply` PASS
- `./gradlew :app:test --tests "*ContentExtractServiceTest*"` PASS

## Reference

- PR #40 CodeRabbit review: <https://github.com/truthscope-smu/truthscope-web-backend/pull/40>
- HANDOFF F7: `truthscope-web/.plans/23-gradle-core-app-split/HANDOFF.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)