### PR TITLE
📝docs(governance): add ADR-006 LLM Behavior Gates infrastructure

### DIFF
--- a/docs/architecture/decisions/ADR-006-llm-behavior-gates.md
+++ b/docs/architecture/decisions/ADR-006-llm-behavior-gates.md
@@ -1,0 +1,114 @@
+---
+number: "006"
+title: "LLM Behavior Gates 4-gate PR-level Input Contract"
+status: "Accepted"
+date: "2026-05-10"
+authors: ["gs07103"]
+---
+
+# ADR-006 — LLM Behavior Gates 4-gate PR-level Input Contract
+
+## Context
+
+### 배경
+
+TruthScope backend 레포에서 LLM 에이전트가 PR을 생성할 때 downstream 자동화(ralph 루프, discord bot, CodeRabbit 워크플로우)가 안전하게 동작하려면 PR-level **입력 계약(input contract)**이 명확해야 한다는 필요성이 제기됐다.
+
+초기 검토에서 Codex gpt-5.5 Round 1~3 자문을 통해 6개 gate 초안이 검토됐다:
+1. PR scope (SAFE_OP 마커)
+2. Plan-Review-Deep §1 위임 (F1.a-d)
+3. Done 섹션 embed
+4. pr-meta-check.yml workflow 자동 강제
+5. 리뷰어 routing
+6. 릴리즈 노트 자동 생성
+
+Round 3 자문 결과, **6 gate → 4 gate 축소** 컨센서스에 도달했다.
+Gate 5(리뷰어 routing)는 plan-review-deep으로, Gate 6(릴리즈 노트 자동 생성)은 changelog-timeline-guide로 위임함으로써 각 artifact의 단일 책임 원칙을 보존했다.
+
+### 선행 근거
+
+- Karpathy LLM 코딩 가이드라인(MIT) 4 원칙 중 행동 영역: Gate 1(Goal Defined) / Gate 2(Assumption Surfaced) / Gate 3(Surgical Diff) / Gate 4(Minimum Code)는 각각 Karpathy §4/§1/§3/§2 원칙을 PR-level 행동 계약으로 변환한 것이다.
+- `.claude/rules/plan-review-deep.md` §1의 F1.a-d 4 subfacet(Reproducible Failure / Staged Gate / Immutable Verification / Full-Solution Verification)은 **downstream 실행/검증 계약**으로, 본 ADR이 다루는 upstream 입력 계약과 역할이 분리된다.
+- 중복 정의 방지: 테스트 커버리지 정량 기준, verification 형식, E2E 필수 요건은 F1.a-d의 단일 소스 오브 트루스이므로 본 rule에 추가하지 않는다.
+
+## Decision
+
+**4 gate를 PR-level LLM 행동 계약으로 채택한다.**
+
+### 4 Gate 정의
+
+| # | Gate | 통과 기준 |
+|---|------|----------|
+| F1 | **Goal Defined** | PR 본문 `## Done` 섹션에 Done 체크리스트(요구사항 목록 + 산출물 목록 + 수용 테스트) 존재 |
+| F2 | **Assumption Surfaced** | PR 본문 SAFE_OP 마커 블록에 Assumptions / Scope / Out-of-scope 3줄 명시 |
+| F3 | **Surgical Diff** | 변경 라인이 모두 사용자 요청에 직접 추적 가능. 명문 예외(보안 패치 hotfix · CI 차단 dead code) 외 인접 코드 개선 금지 |
+| F4 | **Minimum Code** | 단일 사용처 추상화 금지. 요청 외 유연성 금지. "200줄을 50줄로?" 통과 기준 |
+
+### Plan-Review-Deep §1 위임 (F1.a-d)
+
+본 rule이 다루지 않는 영역(테스트 커버리지 정량 기준, 재현 가능성 verification 형식, E2E 필수 요건)은 `.claude/rules/plan-review-deep.md` Section 1의 F1.a-d 4 subfacet으로 위임한다. 본 ADR은 그 **entry condition**을 정의할 뿐이다.
+
+### Trivial 예외
+
+≤10 LOC + 새 의존성 0 + 새 파일 0 + 동작 변경 0인 trivial 변경은 F1 Gate를 Micro-Done(1줄 형식)으로 완화한다.
+
+### 자동 강제 (pr-meta-check.yml)
+
+`.github/workflows/pr-meta-check.yml` workflow가 다음을 자동 검사한다:
+- SAFE_OP 마커 블록 존재 → **차단**
+- `## Done` 섹션 존재 (또는 Micro-Done) → **차단**
+- trivial 라벨 vs diff LOC 자동 계산 일치 → **차단**
+- Scope 업데이트 코멘트 시 scope-ack 라벨 또는 ACK SCOPE 코멘트 → **차단**
+
+Bot(dependabot 등) PR은 `jobs.check.if: pull_request.user.type != 'Bot'` 조건으로 skip 처리한다.
+
+## Status
+
+`Accepted`
+
+BE#50 MERGED (2026-05-XX). llm-setup-templates 3 repos (spring PR#28 / python PR#33 / typescript PR#23) batch validation 완료 후 TruthScope backend 레포에 동일 계약 박제.
+
+## Consequences
+
+### 긍정 (Benefits)
+
+- PR scope가 SAFE_OP 마커로 명확화되어 코드 리뷰어와 자동화 도구가 의도 파악이 빠르다.
+- pr-meta-check.yml workflow로 계약 위반이 CI 단계에서 자동 차단된다.
+- downstream 자동화(ralph 루프, discord bot 공지, CodeRabbit 리뷰)가 SAFE_OP 마커 + Done 섹션을 파싱해 안전하게 동작한다.
+- 6 gate에서 4 gate로 축소함으로써 단일 책임이 강화됐다(리뷰어 routing = plan-review-deep, 릴리즈 노트 = changelog-timeline-guide).
+- Karpathy 원칙과 1:1 매핑되어 외부 근거가 명확하다.
+
+### 부정 (Drawbacks)
+
+- PR 생성 시 SAFE_OP 마커 블록 + Done 섹션이 필수가 되어 소규모 fix에도 보일러플레이트가 늘어난다(trivial Micro-Done으로 완화).
+- 팀원이 새 형식에 적응하는 초기 비용이 존재한다.
+
+### 중립 (Neutral)
+
+- F4 pr-meta-check.yml workflow가 GitHub Actions에 종속된다. 다른 CI 시스템(GitLab CI, Bitbucket Pipelines)으로 이전 시 workflow 재구현이 필요하다.
+- Gate 3/4 위반은 workflow가 자동 차단하지 않고 CodeRabbit 리뷰 + 로컬 리뷰 에이전트가 지적한다.
+
+## Alternatives Considered
+
+| 대안 | 기각 이유 |
+|------|----------|
+| **6 gate 유지** | Gate 5(리뷰어 routing)와 Gate 6(릴리즈 노트)가 각각 plan-review-deep + changelog-timeline-guide와 책임이 겹쳐 cross-drift 발생. F1 권위 약화. |
+| **0 gate (free-form PR)** | downstream 자동화(ralph 루프, discord bot)가 파싱할 구조적 계약 없이 무력화. |
+| **외부 governance 도구 (Probot, Danger JS 등)** | npm/Node 의존성 추가 + 별도 설정 파일 관리 부담. GitHub Actions 네이티브 workflow로 동등한 효과 달성 가능. |
+| **PR description 자유 형식 + 코드 리뷰 only** | 반복 리뷰 코멘트 + LLM 행동 불확실성. 자동 강제 없으면 gate 누락률 높음. |
+
+## References
+
+- `.claude/rules/llm-behavior-gates.md` — 본 ADR이 박제하는 rule 전문 (4 gate 상세 정의, 예외 조항, 실패 모드 테이블)
+- `.claude/rules/plan-review-deep.md` §1 — F1.a-d 4 subfacet (downstream 실행/검증 계약, F2 위임 대상)
+- `.github/PULL_REQUEST_TEMPLATE.md` — SAFE_OP 마커 블록 + Done 섹션 임베드
+- `.github/workflows/pr-meta-check.yml` — F4 자동 강제 workflow (trigger: pull_request + issue_comment)
+- Codex gpt-5.5 thread (R1~R3 자문, 6→4 gate 축소 컨센서스)
+- [Karpathy LLM Coding Guidelines](https://github.com/forrestchang/andrej-karpathy-skills) (MIT) — Gate 1/2/3/4 원칙 출처
+- 메모리 `project_llm_behavior_gates_pilot.md` — BE#50 + spring/python/typescript 3 templates 머지 박제 (2026-05-07)
+
+## Change Log
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| 2026-05-10 | Accepted — BE#50 머지 + llm-setup-templates 3 repos batch validation 완료로 Accepted. backend 레포 ADR 인프라 신설과 함께 박제. |

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -1,0 +1,64 @@
+---
+tags: [adr, architecture, governance]
+status: active
+created: 2026-05-10
+---
+
+# Architecture Decision Records
+
+## §1 Nygard ADR 패턴 소개
+
+Architecture Decision Record(ADR)는 소프트웨어 아키텍처 결정과 그 맥락·결과를 짧은 텍스트 문서로 박제하는 패턴이다.
+Michael Nygard가 [Documenting Architecture Decisions](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)(Cognitect blog, 2011)에서 제안했으며,
+MIT Sloan Management Review의 기술 문서화 연구에서도 architecture decision 기록의 중요성이 강조된다.
+
+핵심 원칙:
+- 결정 당시의 **Context**(왜 이 선택지가 고려됐는가)를 보존한다.
+- 결정이 **Superseded**되더라도 원본 ADR은 삭제하지 않고 상태만 변경한다.
+- 짧고(1~2 페이지), 자가 완결형으로 작성한다.
+
+## §2 본 디렉토리 역할
+
+`truthscope-web-backend/docs/architecture/decisions/`는 **backend 레포 코드베이스 레벨의 architecture decision**을 박제한다.
+
+대상:
+- backend 서비스 자체 설계 결정 (레이어 구조, 도메인 모델, CI/governance 계약 등)
+- Nygard 표준 TEMPLATE.md를 사용하는 ADR 시퀀스
+
+대상이 아닌 것:
+- 전역 기술 스택 선정, 팀 협업 방식 등 monorepo 레벨 결정 → `truthscope-web/context/decisions/` 참조
+
+## §3 시퀀스 시작 이유 — ADR-006부터
+
+본 디렉토리는 **ADR-006**으로 시작한다. ADR-001~005는 `truthscope-web/context/decisions/`의 전역 시퀀스에 이미 존재한다.
+
+ADR-006에서 시작하는 이유: `.claude/rules/llm-behavior-gates.md` line 162에 기존 dangling link
+(`docs/architecture/decisions/ADR-006-llm-behavior-gates.md`)가 있었으며,
+link 경로를 변경하지 않고 해당 파일을 신설함으로써 자동 정합을 달성한다.
+
+향후 신규 backend 레포 자체 결정은 **ADR-007부터** 순차 번호를 사용한다.
+
+## §4 두 위치 병존
+
+| 위치 | 역할 | 시퀀스 |
+|------|------|--------|
+| `truthscope-web/context/decisions/` | 전역 결정 archive (monorepo 레벨 — 기술 스택, 팀 협업, 조직 결정 등) | ADR-001~010+ |
+| `truthscope-web-backend/docs/architecture/decisions/` | backend 레포 자체 architecture decision (Nygard 패턴, GitHub repo 컨텍스트) | ADR-006+ |
+
+두 위치는 **별개 시퀀스**이며 중복이 아니다:
+- 전역 ADR은 여러 레포에 걸친 결정을 다룬다.
+- backend ADR은 이 레포의 코드베이스 내부 결정(governance, 레이어 계약, CI 자동화 등)을 다룬다.
+
+## §5 작성 규칙
+
+- 신규 ADR은 `TEMPLATE.md`를 복사해서 시작한다.
+- 파일명: `ADR-{NNN}-{kebab-case-title}.md` (NNN = 3자리 zero-padding)
+- status 값: `Proposed` → `Accepted` → `Superseded by ADR-XXX` 또는 `Deprecated`
+- Accepted 후 내용 변경 필요 시 → 새 ADR을 작성하고 기존 ADR status를 `Superseded by ADR-NNN`으로 변경
+- 변경 이력은 각 ADR의 `## Change Log` 섹션에 추가 (역순 — 최신 항목을 위에)
+
+## §6 참조
+
+- Nygard 원문: [Documenting Architecture Decisions](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) (Cognitect, 2011)
+- ADR GitHub: [joelparkerhenderson/architecture-decision-record](https://github.com/joelparkerhenderson/architecture-decision-record)
+- 전역 결정 archive: `truthscope-web/context/decisions/`

--- a/docs/architecture/decisions/TEMPLATE.md
+++ b/docs/architecture/decisions/TEMPLATE.md
@@ -1,0 +1,78 @@
+---
+number: "NNN"
+title: "Short Title of Decision"
+status: "Proposed"
+date: "YYYY-MM-DD"
+authors: ["handle1", "handle2"]
+---
+
+# ADR-NNN — {Short Title of Decision}
+
+## Context
+
+<!--
+이 결정이 필요해진 배경과 제약 조건을 서술한다.
+- 어떤 문제 또는 요구가 있었는가?
+- 어떤 제약(기술, 팀, 일정)이 있었는가?
+- 관련된 기존 결정이나 ADR이 있으면 링크한다.
+-->
+
+## Decision
+
+<!--
+채택한 결정을 명확하게 서술한다.
+- "We will ..." 형식 권장 (능동태, 현재형)
+- 왜 이 선택지를 골랐는지 핵심 이유 포함
+-->
+
+## Status
+
+`Proposed` | `Accepted` | `Superseded by ADR-XXX` | `Deprecated`
+
+## Consequences
+
+<!--
+이 결정으로 인한 결과를 긍정/부정/중립으로 분류해서 서술한다.
+-->
+
+### 긍정 (Benefits)
+
+- ...
+
+### 부정 (Drawbacks)
+
+- ...
+
+### 중립 (Neutral)
+
+- ...
+
+## Alternatives Considered
+
+<!--
+검토했지만 채택하지 않은 대안을 나열한다.
+각 대안에 대해 기각 이유를 짧게 서술한다.
+-->
+
+| 대안 | 기각 이유 |
+|------|----------|
+| 대안 1 | ... |
+| 대안 2 | ... |
+
+## References
+
+<!--
+관련 문서, 링크, 표준, 팀 내 artifact를 열거한다.
+-->
+
+- ...
+
+## Change Log
+
+<!--
+역순 (최신 항목이 위) — 최초 작성 이후 변경 사항만 기록.
+-->
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| YYYY-MM-DD | Initial draft |


### PR DESCRIPTION
## Summary
- Nygard 표준 ADR 디렉토리 신설 (`docs/architecture/decisions/`)
- README.md (디렉토리 역할 + 두 위치 병존 설명) + TEMPLATE.md (Nygard 템플릿) + ADR-006-llm-behavior-gates.md (BE#50 박제)
- `.claude/rules/llm-behavior-gates.md` line 162 dangling link 자동 정합 (link 변경 없음)

## 작업 영역
- backend 레포 자체 architecture decision 박제 시작 (시퀀스 ADR-006부터, 기존 dangling link path 정합 위해)
- 전역 결정 archive는 `truthscope-web/context/decisions/` (ADR-001~010, monorepo 레벨, 별개 시퀀스)
- 두 위치 병존 — README §4에 역할 분리 명시

<!-- SAFE_OP_START -->
Assumptions: 기존 context/decisions/ 시퀀스(ADR-001~005)와 numbering 충돌 없음. backend 레포 자체 ADR 시퀀스는 ADR-006부터 독립 운영.
Scope: docs/architecture/decisions/README.md, docs/architecture/decisions/TEMPLATE.md, docs/architecture/decisions/ADR-006-llm-behavior-gates.md
Out-of-scope: .claude/rules/llm-behavior-gates.md 변경 없음. context/decisions/ 변경 없음. ADR-001~005 backfill 없음.
<!-- SAFE_OP_END -->

## Done
- [✅] `docs/architecture/decisions/` 디렉토리 신설
- [✅] README.md 작성 (Nygard ADR 소개 + 두 위치 병존 §4 포함)
- [✅] TEMPLATE.md 작성 (Context/Decision/Status/Consequences/Alternatives/References/ChangeLog 섹션)
- [✅] ADR-006-llm-behavior-gates.md 작성 (4 gate 채택 근거 + 6→4 축소 결정 + F1 위임 + Accepted 상태)
- [✅] `.claude/rules/llm-behavior-gates.md` line 162 dangling link 정합 확인 (파일 신설로 자동 해소)

## Test plan
- [ ] `docs/architecture/decisions/` 디렉토리 + 3 파일 존재 확인
- [ ] `.claude/rules/llm-behavior-gates.md` line 162 link 정합 (파일 클릭 시 ADR-006로 이동)
- [ ] CI green (pr-meta-check.yml workflow 통과)
- [ ] CodeRabbit 리뷰 응답 (필요 시)

## Out of Scope (PRD §6)
- 본 PR 머지 금지 (open만, 머지는 별도 세션)
- TEMPLATE.md를 다른 레포에 복제하는 작업 (frontend 레포는 이미 `docs/architecture/decisions/` 자체 시퀀스 사용)
- ADR-001~005 backfill (기존 결정은 context/decisions/에 박제됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 설명서

* **설명서**
  * 아키텍처 결정 기록(ADR) 시스템 도입
  * ADR 템플릿, 가이드라인 및 README 문서 추가
  * 아키텍처 결정의 체계적 관리 및 추적 기반 구축

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/truthscope-smu/truthscope-web-backend/pull/51)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->