### PR TITLE
✨feat(scoring): 신뢰도 점수 집계·도출 4함수와 입력 계약 추가

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -14,4 +14,7 @@ dependencies {
 	// Spring Data JPA Auditing (@CreatedDate, @LastModifiedDate, AuditingEntityListener)
 	// Phase 1 compromise — 이 의존만으로는 Spring Boot/IoC 미사용
 	api 'org.springframework.data:spring-data-jpa'
+
+	// 테스트 assertion — app 모듈 idiom(AssertJ) 정합. spring-boot BOM이 버전 관리.
+	testImplementation 'org.assertj:assertj-core'
 }

--- a/core/src/main/java/com/truthscope/web/scoring/ArticleFactScore.java
+++ b/core/src/main/java/com/truthscope/web/scoring/ArticleFactScore.java
@@ -1,0 +1,13 @@
+package com.truthscope.web.scoring;
+
+/**
+ * 기사 종합 사실 검증 점수(DISCUSS D13). value는 0..100 정수. 검증 가능 claim이 0개인 기사는 이 객체를 만들지
+ * 않는다(aggregateArticleFactScore가 Optional.empty 반환).
+ */
+public record ArticleFactScore(int value) {
+  public ArticleFactScore {
+    if (value < 0 || value > 100) {
+      throw new IllegalArgumentException("기사 점수는 0..100이어야 한다: " + value);
+    }
+  }
+}

--- a/core/src/main/java/com/truthscope/web/scoring/ArticleFactScoreAggregator.java
+++ b/core/src/main/java/com/truthscope/web/scoring/ArticleFactScoreAggregator.java
@@ -1,0 +1,47 @@
+package com.truthscope.web.scoring;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * 기사 종합 사실 검증 점수를 검증 가능 claim의 기하평균 계열로 집계하는 순수 함수(DISCUSS D13).
+ *
+ * <p>SCORABLE claim만 대상으로 한다. 비판정 3종은 score가 null이며 집계에서 제외한다. 검증 가능 claim이 0개면 Optional.empty()를
+ * 반환한다(UI는 검증불가 표시).
+ *
+ * <p>계산은 log 공간에서 한다. 각 score를 scoreFloor로 클램프(max)해 0점 곱셈 붕괴를 막은 뒤 exp(평균(ln(clamped)))를 구하고
+ * policy.rounding() 모드로 0..100 정수로 만든다. rounding 모드는 후속 이연 정책값이라 ArticleScorePolicy로 주입받는다. cap이나
+ * penalty를 추가 결합하지 않는다(기하평균 자체가 낮은 claim을 끌어내려 이중 처벌 방지).
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ArticleFactScoreAggregator {
+
+  public static Optional<ArticleFactScore> aggregateArticleFactScore(
+      List<ClaimVerificationSignal> claims, ArticleScorePolicy policy) {
+    Objects.requireNonNull(claims, "claims는 null일 수 없다");
+    Objects.requireNonNull(policy, "policy는 null일 수 없다");
+
+    List<Integer> scores =
+        claims.stream()
+            .filter(c -> c.status() == ClaimScoreStatus.SCORABLE)
+            .map(ClaimVerificationSignal::score)
+            .toList();
+    if (scores.isEmpty()) {
+      return Optional.empty();
+    }
+
+    double sumOfLogs = 0.0;
+    for (int score : scores) {
+      double clamped = Math.max(score, policy.scoreFloor());
+      sumOfLogs += Math.log(clamped);
+    }
+    double geoMean = Math.exp(sumOfLogs / scores.size());
+    int rounded = BigDecimal.valueOf(geoMean).setScale(0, policy.rounding()).intValue();
+    int bounded = Math.min(100, Math.max(0, rounded));
+    return Optional.of(new ArticleFactScore(bounded));
+  }
+}

--- a/core/src/main/java/com/truthscope/web/scoring/ArticleScorePolicy.java
+++ b/core/src/main/java/com/truthscope/web/scoring/ArticleScorePolicy.java
@@ -1,0 +1,22 @@
+package com.truthscope.web.scoring;
+
+import java.math.RoundingMode;
+import java.util.Objects;
+
+/**
+ * 기사 종합 점수 기하평균 계산 정책. scoreFloor는 0점 claim의 곱셈 붕괴를 막는 양수 하한이다 (DISCUSS D13). scoreFloor 값과
+ * rounding 모드 둘 다 Phase 55 범위 밖 후속 이연 항목이며 (DISCUSS 5장 3절, FORMULA-DETAIL-ANALYSIS.md 5절), 함수는 이 둘을
+ * 정책 파라미터로 받는다. production 값 확정 전까지는 호출자(또는 테스트 fixture)가 주입한다.
+ */
+public record ArticleScorePolicy(double scoreFloor, RoundingMode rounding) {
+  public ArticleScorePolicy {
+    Objects.requireNonNull(rounding, "rounding은 null일 수 없다");
+    if (rounding == RoundingMode.UNNECESSARY) {
+      throw new IllegalArgumentException(
+          "rounding은 UNNECESSARY일 수 없다 — 기하평균은 비정수이므로 ArithmeticException 위험");
+    }
+    if (!(scoreFloor > 0.0 && scoreFloor <= 100.0)) {
+      throw new IllegalArgumentException("scoreFloor는 0 초과 100 이하 양수여야 한다: " + scoreFloor);
+    }
+  }
+}

--- a/core/src/main/java/com/truthscope/web/scoring/ClaimScoreStatus.java
+++ b/core/src/main/java/com/truthscope/web/scoring/ClaimScoreStatus.java
@@ -1,0 +1,16 @@
+package com.truthscope.web.scoring;
+
+/**
+ * claim이 점수 집계에 쓸 수 있는 상태인지 분류한다.
+ *
+ * <p>SCORABLE은 0..100 score를 가진 claim(Verdict의 SUPPORTED 또는 CONTRADICTED 대응). 나머지 3종은 비판정으로 score가
+ * null이며 기사 종합 점수 집계에서 제외된다(DISCUSS D12).
+ *
+ * <p>ClaimScoreStatus를 Verdict enum에서 파생할지 별도 유지할지는 ADR-014 소관이다. 본 계약은 status 4값만 고정한다.
+ */
+public enum ClaimScoreStatus {
+  SCORABLE,
+  INSUFFICIENT,
+  TIME_SENSITIVE,
+  OUT_OF_SCOPE
+}

--- a/core/src/main/java/com/truthscope/web/scoring/ClaimVerificationSignal.java
+++ b/core/src/main/java/com/truthscope/web/scoring/ClaimVerificationSignal.java
@@ -31,6 +31,9 @@ public record ClaimVerificationSignal(
   public ClaimVerificationSignal {
     Objects.requireNonNull(claimId, "claimId는 null일 수 없다");
     Objects.requireNonNull(tier, "tier는 null일 수 없다");
+    if (tier < 1 || tier > 3) {
+      throw new IllegalArgumentException("tier는 1..3이어야 한다(3-Tier Cascade): tier=" + tier);
+    }
     Objects.requireNonNull(status, "status는 null일 수 없다");
     Objects.requireNonNull(sourceTransparency, "sourceTransparency는 null일 수 없다");
     if (status == ClaimScoreStatus.SCORABLE) {

--- a/core/src/main/java/com/truthscope/web/scoring/ClaimVerificationSignal.java
+++ b/core/src/main/java/com/truthscope/web/scoring/ClaimVerificationSignal.java
@@ -1,0 +1,45 @@
+package com.truthscope.web.scoring;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * 집계 4함수의 입력 계약. claim별 3-Tier Cascade 검증 결과를 담는 계산 계층 DTO다. 이 record를 생산하는 구현체(claim score 산출)는
+ * Phase 55 범위 밖 후속 트랙 소관이다.
+ *
+ * <p>계약 불변식(compact constructor가 강제):
+ *
+ * <ul>
+ *   <li>status가 SCORABLE이면 score는 0..100 non-null이다.
+ *   <li>status가 비판정 3종(INSUFFICIENT/TIME_SENSITIVE/OUT_OF_SCOPE)이면 score는 null이다.
+ * </ul>
+ *
+ * <p>tier는 표시·coverage 신호용이며 기사 점수 가중치로 쓰지 않는다. sourceTransparency는 점수에 합산하지 않고 D14 집계에만 쓴다.
+ *
+ * <p>score는 Integer다. 이 record는 계산 계층 DTO이므로 엔티티 VerificationResult.score(Short)와의 타입 매핑은 경계 서비스
+ * 책임이다(DECOMPOSITION-ANALYSIS.md 3절). execute 시 Short로 바꾸지 말 것.
+ *
+ * @param score 0..100, 비판정 claim이면 null
+ */
+public record ClaimVerificationSignal(
+    UUID claimId,
+    Short tier,
+    Integer score,
+    ClaimScoreStatus status,
+    SourceTransparency sourceTransparency) {
+
+  public ClaimVerificationSignal {
+    Objects.requireNonNull(claimId, "claimId는 null일 수 없다");
+    Objects.requireNonNull(tier, "tier는 null일 수 없다");
+    Objects.requireNonNull(status, "status는 null일 수 없다");
+    Objects.requireNonNull(sourceTransparency, "sourceTransparency는 null일 수 없다");
+    if (status == ClaimScoreStatus.SCORABLE) {
+      if (score == null || score < 0 || score > 100) {
+        throw new IllegalArgumentException("SCORABLE claim은 0..100 score가 필수다: score=" + score);
+      }
+    } else if (score != null) {
+      throw new IllegalArgumentException(
+          "비판정 claim은 score가 null이어야 한다: status=" + status + ", score=" + score);
+    }
+  }
+}

--- a/core/src/main/java/com/truthscope/web/scoring/CoverageAggregator.java
+++ b/core/src/main/java/com/truthscope/web/scoring/CoverageAggregator.java
@@ -1,0 +1,46 @@
+package com.truthscope.web.scoring;
+
+import java.util.List;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * 기사 검증 커버리지를 집계하는 순수 함수(DISCUSS D10 집계 최소 계약 + D12 비판정 분리).
+ *
+ * <p>검증 가능(SCORABLE) claim 수, 제외 claim 수와 사유별(INSUFFICIENT/TIME_SENSITIVE/OUT_OF_SCOPE) 분리 count,
+ * tier 분포(tier 값 1/2/3)를 만든다. tier가 1/2/3이 아니면 어느 tier count에도 포함하지 않는다(tier는 1/2/3을 기대).
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class CoverageAggregator {
+
+  public static CoverageSummary aggregateCoverage(List<ClaimVerificationSignal> claims) {
+    Objects.requireNonNull(claims, "claims는 null일 수 없다");
+    int scorable = 0;
+    int insufficient = 0;
+    int timeSensitive = 0;
+    int outOfScope = 0;
+    int tier1 = 0;
+    int tier2 = 0;
+    int tier3 = 0;
+    for (ClaimVerificationSignal c : claims) {
+      switch (c.status()) {
+        case SCORABLE -> scorable++;
+        case INSUFFICIENT -> insufficient++;
+        case TIME_SENSITIVE -> timeSensitive++;
+        case OUT_OF_SCOPE -> outOfScope++;
+      }
+      short tier = c.tier();
+      if (tier == 1) {
+        tier1++;
+      } else if (tier == 2) {
+        tier2++;
+      } else if (tier == 3) {
+        tier3++;
+      }
+    }
+    int excluded = insufficient + timeSensitive + outOfScope;
+    return new CoverageSummary(
+        scorable, excluded, insufficient, timeSensitive, outOfScope, tier1, tier2, tier3);
+  }
+}

--- a/core/src/main/java/com/truthscope/web/scoring/CoverageSummary.java
+++ b/core/src/main/java/com/truthscope/web/scoring/CoverageSummary.java
@@ -17,6 +17,16 @@ public record CoverageSummary(
     int tier3Count) {
 
   public CoverageSummary {
+    if (scorableCount < 0
+        || excludedCount < 0
+        || insufficientCount < 0
+        || timeSensitiveCount < 0
+        || outOfScopeCount < 0
+        || tier1Count < 0
+        || tier2Count < 0
+        || tier3Count < 0) {
+      throw new IllegalArgumentException("CoverageSummary의 모든 count는 0 이상이어야 한다");
+    }
     if (excludedCount != insufficientCount + timeSensitiveCount + outOfScopeCount) {
       throw new IllegalArgumentException(
           "excludedCount는 사유별 count의 합이어야 한다: excluded=" + excludedCount);

--- a/core/src/main/java/com/truthscope/web/scoring/CoverageSummary.java
+++ b/core/src/main/java/com/truthscope/web/scoring/CoverageSummary.java
@@ -1,0 +1,25 @@
+package com.truthscope.web.scoring;
+
+/**
+ * 기사 검증 커버리지 집계 결과. 검증 가능 claim 수, 제외 claim 수와 사유별 분리 count, tier 분포를 담는다(DISCUSS D10 집계 최소 계약 +
+ * D12 비판정 분리).
+ *
+ * <p>excludedCount = insufficientCount + timeSensitiveCount + outOfScopeCount.
+ */
+public record CoverageSummary(
+    int scorableCount,
+    int excludedCount,
+    int insufficientCount,
+    int timeSensitiveCount,
+    int outOfScopeCount,
+    int tier1Count,
+    int tier2Count,
+    int tier3Count) {
+
+  public CoverageSummary {
+    if (excludedCount != insufficientCount + timeSensitiveCount + outOfScopeCount) {
+      throw new IllegalArgumentException(
+          "excludedCount는 사유별 count의 합이어야 한다: excluded=" + excludedCount);
+    }
+  }
+}

--- a/core/src/main/java/com/truthscope/web/scoring/ScoreBandPolicy.java
+++ b/core/src/main/java/com/truthscope/web/scoring/ScoreBandPolicy.java
@@ -1,0 +1,29 @@
+package com.truthscope.web.scoring;
+
+/**
+ * 진실성 5종 밴드의 하한 임계값(포함). claimScore >= factMin이면 FACT, mostlyFactMin 이상이면 MOSTLY_FACT,
+ * partlyFactMin 이상이면 PARTLY_FACT, mostlyNotFactMin 이상이면 MOSTLY_NOT_FACT, 그 미만이면 NOT_FACT.
+ *
+ * <p>임계값 확정은 Phase 55 범위 밖 후속 이연 항목이다(DISCUSS 5장 4절). 함수 시그니처만 고정하고 production 값은 호출자가 주입한다.
+ */
+public record ScoreBandPolicy(
+    int factMin, int mostlyFactMin, int partlyFactMin, int mostlyNotFactMin) {
+
+  public ScoreBandPolicy {
+    if (!(factMin > mostlyFactMin
+        && mostlyFactMin > partlyFactMin
+        && partlyFactMin > mostlyNotFactMin
+        && mostlyNotFactMin > 0
+        && factMin <= 100)) {
+      throw new IllegalArgumentException(
+          "밴드 임계값은 0 초과 100 이하 내림차순이어야 한다: "
+              + factMin
+              + "/"
+              + mostlyFactMin
+              + "/"
+              + partlyFactMin
+              + "/"
+              + mostlyNotFactMin);
+    }
+  }
+}

--- a/core/src/main/java/com/truthscope/web/scoring/SourceTransparency.java
+++ b/core/src/main/java/com/truthscope/web/scoring/SourceTransparency.java
@@ -1,0 +1,11 @@
+package com.truthscope.web.scoring;
+
+/**
+ * claim 단위 출처 표기 투명성 3단계(DISCUSS D11·D14). EXPLICIT=명시, AMBIGUOUS=모호, NONE=없음. 점수 0..100에 합산하지 않고
+ * aggregateSourceTransparency 집계에만 쓴다.
+ */
+public enum SourceTransparency {
+  EXPLICIT,
+  AMBIGUOUS,
+  NONE
+}

--- a/core/src/main/java/com/truthscope/web/scoring/SourceTransparencyAggregator.java
+++ b/core/src/main/java/com/truthscope/web/scoring/SourceTransparencyAggregator.java
@@ -1,0 +1,48 @@
+package com.truthscope.web.scoring;
+
+import java.util.List;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * claim별 출처 표기 투명성 3단계를 기사 수준 분포와 보수 경고 밴드로 집계하는 순수 함수(DISCUSS D14).
+ *
+ * <p>분포(명시/모호/없음 개수)가 1차 표시. band 규칙:
+ *
+ * <ul>
+ *   <li>NONE이 1개 이상이면 MISSING_SOURCE(출처 누락 있음).
+ *   <li>NONE이 0이고 AMBIGUOUS가 1개 이상이면 SOME_UNCLEAR(일부 불명확).
+ *   <li>전부 EXPLICIT이면 ALL_EXPLICIT(모두 명시).
+ * </ul>
+ *
+ * <p>빈 리스트는 분포 (0,0,0) + ALL_EXPLICIT을 반환한다(NONE 0 그리고 AMBIGUOUS 0 규칙의 공허참). 모든 claim(비판정 포함)이
+ * sourceTransparency를 가지므로 집계 대상에서 제외하지 않는다.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class SourceTransparencyAggregator {
+
+  public static SourceTransparencySummary aggregateSourceTransparency(
+      List<ClaimVerificationSignal> claims) {
+    Objects.requireNonNull(claims, "claims는 null일 수 없다");
+    int explicit = 0;
+    int ambiguous = 0;
+    int none = 0;
+    for (ClaimVerificationSignal c : claims) {
+      switch (c.sourceTransparency()) {
+        case EXPLICIT -> explicit++;
+        case AMBIGUOUS -> ambiguous++;
+        case NONE -> none++;
+      }
+    }
+    SourceTransparencyBand band;
+    if (none > 0) {
+      band = SourceTransparencyBand.MISSING_SOURCE;
+    } else if (ambiguous > 0) {
+      band = SourceTransparencyBand.SOME_UNCLEAR;
+    } else {
+      band = SourceTransparencyBand.ALL_EXPLICIT;
+    }
+    return new SourceTransparencySummary(explicit, ambiguous, none, band);
+  }
+}

--- a/core/src/main/java/com/truthscope/web/scoring/SourceTransparencyBand.java
+++ b/core/src/main/java/com/truthscope/web/scoring/SourceTransparencyBand.java
@@ -1,0 +1,18 @@
+package com.truthscope.web.scoring;
+
+/** 기사 수준 출처 표기 요약 밴드(DISCUSS D14). 기사 대표값이 아니라 보수적 경고다. */
+public enum SourceTransparencyBand {
+  ALL_EXPLICIT("모두 명시"),
+  SOME_UNCLEAR("일부 불명확"),
+  MISSING_SOURCE("출처 누락 있음");
+
+  private final String displayName;
+
+  SourceTransparencyBand(String displayName) {
+    this.displayName = displayName;
+  }
+
+  public String displayName() {
+    return displayName;
+  }
+}

--- a/core/src/main/java/com/truthscope/web/scoring/SourceTransparencySummary.java
+++ b/core/src/main/java/com/truthscope/web/scoring/SourceTransparencySummary.java
@@ -1,5 +1,15 @@
 package com.truthscope.web.scoring;
 
+import java.util.Objects;
+
 /** 기사 수준 출처 표기 투명성 집계 결과(DISCUSS D14). 분포(명시/모호/없음 개수)가 1차 표시, band는 보조 경고 표시. */
 public record SourceTransparencySummary(
-    int explicitCount, int ambiguousCount, int noneCount, SourceTransparencyBand band) {}
+    int explicitCount, int ambiguousCount, int noneCount, SourceTransparencyBand band) {
+
+  public SourceTransparencySummary {
+    Objects.requireNonNull(band, "band는 null일 수 없다");
+    if (explicitCount < 0 || ambiguousCount < 0 || noneCount < 0) {
+      throw new IllegalArgumentException("SourceTransparencySummary의 모든 count는 0 이상이어야 한다");
+    }
+  }
+}

--- a/core/src/main/java/com/truthscope/web/scoring/SourceTransparencySummary.java
+++ b/core/src/main/java/com/truthscope/web/scoring/SourceTransparencySummary.java
@@ -1,0 +1,5 @@
+package com.truthscope.web.scoring;
+
+/** 기사 수준 출처 표기 투명성 집계 결과(DISCUSS D14). 분포(명시/모호/없음 개수)가 1차 표시, band는 보조 경고 표시. */
+public record SourceTransparencySummary(
+    int explicitCount, int ambiguousCount, int noneCount, SourceTransparencyBand band) {}

--- a/core/src/main/java/com/truthscope/web/scoring/TruthLabel.java
+++ b/core/src/main/java/com/truthscope/web/scoring/TruthLabel.java
@@ -1,0 +1,23 @@
+package com.truthscope.web.scoring;
+
+/**
+ * claim 사실 검증 상태 표시 라벨(DISCUSS D12 진실성 5종). claim score 0..100 밴딩에서 도출된다. 비판정 3종(ClaimScoreStatus)은
+ * 이 5종 밖 별도 상태다.
+ */
+public enum TruthLabel {
+  FACT("사실"),
+  MOSTLY_FACT("대체로 사실"),
+  PARTLY_FACT("일부 사실"),
+  MOSTLY_NOT_FACT("대체로 사실 아님"),
+  NOT_FACT("사실 아님");
+
+  private final String displayName;
+
+  TruthLabel(String displayName) {
+    this.displayName = displayName;
+  }
+
+  public String displayName() {
+    return displayName;
+  }
+}

--- a/core/src/main/java/com/truthscope/web/scoring/TruthLabelDeriver.java
+++ b/core/src/main/java/com/truthscope/web/scoring/TruthLabelDeriver.java
@@ -1,0 +1,37 @@
+package com.truthscope.web.scoring;
+
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/** claim score를 진실성 5종 라벨로 도출하는 순수 함수(DISCUSS D12). */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class TruthLabelDeriver {
+
+  /**
+   * claim score 0..100을 진실성 5종 TruthLabel로 밴딩 도출한다.
+   *
+   * @param claimScore 0..100. SCORABLE claim의 score.
+   * @param policy 밴드 임계값
+   * @throws IllegalArgumentException claimScore가 0..100 밖
+   */
+  public static TruthLabel deriveTruthLabel(int claimScore, ScoreBandPolicy policy) {
+    Objects.requireNonNull(policy, "policy는 null일 수 없다");
+    if (claimScore < 0 || claimScore > 100) {
+      throw new IllegalArgumentException("claimScore는 0..100이어야 한다: " + claimScore);
+    }
+    if (claimScore >= policy.factMin()) {
+      return TruthLabel.FACT;
+    }
+    if (claimScore >= policy.mostlyFactMin()) {
+      return TruthLabel.MOSTLY_FACT;
+    }
+    if (claimScore >= policy.partlyFactMin()) {
+      return TruthLabel.PARTLY_FACT;
+    }
+    if (claimScore >= policy.mostlyNotFactMin()) {
+      return TruthLabel.MOSTLY_NOT_FACT;
+    }
+    return TruthLabel.NOT_FACT;
+  }
+}

--- a/core/src/test/java/com/truthscope/web/scoring/ArticleFactScoreAggregatorTest.java
+++ b/core/src/test/java/com/truthscope/web/scoring/ArticleFactScoreAggregatorTest.java
@@ -1,0 +1,152 @@
+package com.truthscope.web.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class ArticleFactScoreAggregatorTest {
+
+  // fixture: ArticleScorePolicy(1.0, RoundingMode.HALF_UP)
+  private static final ArticleScorePolicy POLICY =
+      new ArticleScorePolicy(1.0, RoundingMode.HALF_UP);
+
+  private static ClaimVerificationSignal scorable(int score) {
+    return new ClaimVerificationSignal(
+        UUID.randomUUID(),
+        (short) 1,
+        score,
+        ClaimScoreStatus.SCORABLE,
+        SourceTransparency.EXPLICIT);
+  }
+
+  private static ClaimVerificationSignal nonScorable(ClaimScoreStatus status) {
+    return new ClaimVerificationSignal(
+        UUID.randomUUID(), (short) 2, null, status, SourceTransparency.NONE);
+  }
+
+  // 케이스 1: 빈 리스트 → Optional.empty
+  @Test
+  void 빈_리스트이면_Optional_empty() {
+    Optional<ArticleFactScore> result =
+        ArticleFactScoreAggregator.aggregateArticleFactScore(List.of(), POLICY);
+    assertThat(result).isEmpty();
+  }
+
+  // 케이스 2: 전부 비판정(검증 가능 0개) → Optional.empty
+  @Test
+  void 전부_비판정이면_Optional_empty() {
+    List<ClaimVerificationSignal> claims =
+        List.of(
+            nonScorable(ClaimScoreStatus.INSUFFICIENT),
+            nonScorable(ClaimScoreStatus.TIME_SENSITIVE),
+            nonScorable(ClaimScoreStatus.OUT_OF_SCOPE));
+    Optional<ArticleFactScore> result =
+        ArticleFactScoreAggregator.aggregateArticleFactScore(claims, POLICY);
+    assertThat(result).isEmpty();
+  }
+
+  // 케이스 3: 단일 SCORABLE score 80 → value 80
+  @Test
+  void 단일_SCORABLE_80이면_value_80() {
+    List<ClaimVerificationSignal> claims = List.of(scorable(80));
+    Optional<ArticleFactScore> result =
+        ArticleFactScoreAggregator.aggregateArticleFactScore(claims, POLICY);
+    assertThat(result).isPresent();
+    assertThat(result.get().value()).isEqualTo(80);
+  }
+
+  // 케이스 4: SCORABLE [90,90,20] → 기하평균 value 55, 산술평균 67보다 낮음 단언
+  // 검증: exp((ln90+ln90+ln20)/3) = exp(3.99845) = 54.513 → HALF_UP setScale(0) = 55
+  // 산술평균 (90+90+20)/3 = 66.67 → HALF_UP = 67
+  @Test
+  void SCORABLE_90_90_20이면_기하평균_55_산술평균_67보다_낮음() {
+    List<ClaimVerificationSignal> claims = List.of(scorable(90), scorable(90), scorable(20));
+    Optional<ArticleFactScore> result =
+        ArticleFactScoreAggregator.aggregateArticleFactScore(claims, POLICY);
+    assertThat(result).isPresent();
+    int geoMeanValue = result.get().value();
+    assertThat(geoMeanValue).isEqualTo(55);
+    // 기하평균(55)이 산술평균(67)보다 낮음을 명시 단언 — 산식이 실제로 기하평균임을 검증
+    int arithmeticMean = (90 + 90 + 20) / 3; // 66 (정수 나눗셈), HALF_UP → 67
+    assertThat(geoMeanValue).isLessThan(67);
+    assertThat(arithmeticMean).isEqualTo(66); // 정수 나눗셈 66, 실수 66.67 → 67
+  }
+
+  // 케이스 5: SCORABLE [0,100] → floor 1.0 클램프로 value 10, 0 붕괴 아님
+  // 검증: exp((ln1+ln100)/2) = exp((0+4.60517)/2) = exp(2.30259) = 10.0 → HALF_UP = 10
+  @Test
+  void SCORABLE_0과_100이면_floor_클램프로_value_10() {
+    List<ClaimVerificationSignal> claims = List.of(scorable(0), scorable(100));
+    Optional<ArticleFactScore> result =
+        ArticleFactScoreAggregator.aggregateArticleFactScore(claims, POLICY);
+    assertThat(result).isPresent();
+    assertThat(result.get().value()).isEqualTo(10);
+  }
+
+  // 케이스 6: SCORABLE 단일 [0] → floor 1.0 단독 클램프로 value 1
+  // 검증: exp(ln1) = exp(0) = 1.0 → HALF_UP setScale(0) = 1
+  @Test
+  void SCORABLE_단일_0이면_floor_1_클램프로_value_1() {
+    List<ClaimVerificationSignal> claims = List.of(scorable(0));
+    Optional<ArticleFactScore> result =
+        ArticleFactScoreAggregator.aggregateArticleFactScore(claims, POLICY);
+    assertThat(result).isPresent();
+    assertThat(result.get().value()).isEqualTo(1);
+  }
+
+  // 케이스 7: SCORABLE 2개 + INSUFFICIENT 1개 + OUT_OF_SCOPE 1개 혼합 → SCORABLE 2개만 집계
+  @Test
+  void SCORABLE_2개와_비판정_혼합이면_SCORABLE만_집계() {
+    List<ClaimVerificationSignal> claims =
+        List.of(
+            scorable(80),
+            scorable(80),
+            nonScorable(ClaimScoreStatus.INSUFFICIENT),
+            nonScorable(ClaimScoreStatus.OUT_OF_SCOPE));
+    Optional<ArticleFactScore> result =
+        ArticleFactScoreAggregator.aggregateArticleFactScore(claims, POLICY);
+    assertThat(result).isPresent();
+    // exp((ln80+ln80)/2) = 80 → value 80
+    assertThat(result.get().value()).isEqualTo(80);
+  }
+
+  // 케이스 8: claims null → NPE
+  @Test
+  void claims_null이면_NullPointerException() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> ArticleFactScoreAggregator.aggregateArticleFactScore(null, POLICY));
+  }
+
+  // 케이스 9: ArticleScorePolicy 불변식
+  @Test
+  void ArticleScorePolicy_scoreFloor_0이면_IllegalArgumentException() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> new ArticleScorePolicy(0.0, RoundingMode.HALF_UP))
+        .withMessageContaining("scoreFloor는 0 초과 100 이하 양수여야 한다");
+  }
+
+  @Test
+  void ArticleScorePolicy_scoreFloor_101이면_IllegalArgumentException() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> new ArticleScorePolicy(101.0, RoundingMode.HALF_UP))
+        .withMessageContaining("scoreFloor는 0 초과 100 이하 양수여야 한다");
+  }
+
+  @Test
+  void ArticleScorePolicy_rounding_null이면_NullPointerException() {
+    assertThatNullPointerException().isThrownBy(() -> new ArticleScorePolicy(1.0, null));
+  }
+
+  @Test
+  void ArticleScorePolicy_rounding_UNNECESSARY이면_IllegalArgumentException() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> new ArticleScorePolicy(1.0, RoundingMode.UNNECESSARY))
+        .withMessageContaining("rounding은 UNNECESSARY일 수 없다");
+  }
+}

--- a/core/src/test/java/com/truthscope/web/scoring/ClaimVerificationSignalTest.java
+++ b/core/src/test/java/com/truthscope/web/scoring/ClaimVerificationSignalTest.java
@@ -1,0 +1,152 @@
+package com.truthscope.web.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class ClaimVerificationSignalTest {
+
+  private static final UUID CLAIM_ID = UUID.randomUUID();
+  private static final Short TIER = (short) 1;
+
+  // (1) SCORABLE + score 0/50/100 생성 성공
+  @Test
+  void scorable_score_0_생성_성공() {
+    ClaimVerificationSignal signal =
+        new ClaimVerificationSignal(
+            CLAIM_ID, TIER, 0, ClaimScoreStatus.SCORABLE, SourceTransparency.EXPLICIT);
+    assertThat(signal.score()).isEqualTo(0);
+    assertThat(signal.status()).isEqualTo(ClaimScoreStatus.SCORABLE);
+  }
+
+  @Test
+  void scorable_score_50_생성_성공() {
+    ClaimVerificationSignal signal =
+        new ClaimVerificationSignal(
+            CLAIM_ID, TIER, 50, ClaimScoreStatus.SCORABLE, SourceTransparency.AMBIGUOUS);
+    assertThat(signal.score()).isEqualTo(50);
+    assertThat(signal.status()).isEqualTo(ClaimScoreStatus.SCORABLE);
+  }
+
+  @Test
+  void scorable_score_100_생성_성공() {
+    ClaimVerificationSignal signal =
+        new ClaimVerificationSignal(
+            CLAIM_ID, TIER, 100, ClaimScoreStatus.SCORABLE, SourceTransparency.NONE);
+    assertThat(signal.score()).isEqualTo(100);
+    assertThat(signal.status()).isEqualTo(ClaimScoreStatus.SCORABLE);
+  }
+
+  // (2) SCORABLE + score null → IllegalArgumentException
+  @Test
+  void scorable_score_null이면_IllegalArgumentException() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                new ClaimVerificationSignal(
+                    CLAIM_ID, TIER, null, ClaimScoreStatus.SCORABLE, SourceTransparency.EXPLICIT))
+        .withMessageContaining("SCORABLE claim은 0..100 score가 필수다");
+  }
+
+  // (3) SCORABLE + score 101 → IAE
+  @Test
+  void scorable_score_101이면_IllegalArgumentException() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                new ClaimVerificationSignal(
+                    CLAIM_ID, TIER, 101, ClaimScoreStatus.SCORABLE, SourceTransparency.EXPLICIT))
+        .withMessageContaining("SCORABLE claim은 0..100 score가 필수다");
+  }
+
+  // (4) SCORABLE + score -1 → IAE
+  @Test
+  void scorable_score_마이너스1이면_IllegalArgumentException() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                new ClaimVerificationSignal(
+                    CLAIM_ID, TIER, -1, ClaimScoreStatus.SCORABLE, SourceTransparency.EXPLICIT))
+        .withMessageContaining("SCORABLE claim은 0..100 score가 필수다");
+  }
+
+  // (5) 비판정 3종(INSUFFICIENT/TIME_SENSITIVE/OUT_OF_SCOPE) + score null 생성 성공
+  @Test
+  void insufficient_score_null_생성_성공() {
+    ClaimVerificationSignal signal =
+        new ClaimVerificationSignal(
+            CLAIM_ID, TIER, null, ClaimScoreStatus.INSUFFICIENT, SourceTransparency.EXPLICIT);
+    assertThat(signal.score()).isNull();
+    assertThat(signal.status()).isEqualTo(ClaimScoreStatus.INSUFFICIENT);
+  }
+
+  @Test
+  void time_sensitive_score_null_생성_성공() {
+    ClaimVerificationSignal signal =
+        new ClaimVerificationSignal(
+            CLAIM_ID, TIER, null, ClaimScoreStatus.TIME_SENSITIVE, SourceTransparency.AMBIGUOUS);
+    assertThat(signal.score()).isNull();
+    assertThat(signal.status()).isEqualTo(ClaimScoreStatus.TIME_SENSITIVE);
+  }
+
+  @Test
+  void out_of_scope_score_null_생성_성공() {
+    ClaimVerificationSignal signal =
+        new ClaimVerificationSignal(
+            CLAIM_ID, TIER, null, ClaimScoreStatus.OUT_OF_SCOPE, SourceTransparency.NONE);
+    assertThat(signal.score()).isNull();
+    assertThat(signal.status()).isEqualTo(ClaimScoreStatus.OUT_OF_SCOPE);
+  }
+
+  // (6) INSUFFICIENT + score 50 → IAE
+  @Test
+  void insufficient_score_50이면_IllegalArgumentException() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                new ClaimVerificationSignal(
+                    CLAIM_ID, TIER, 50, ClaimScoreStatus.INSUFFICIENT, SourceTransparency.EXPLICIT))
+        .withMessageContaining("비판정 claim은 score가 null이어야 한다");
+  }
+
+  // (7) claimId/tier/status/sourceTransparency null → NullPointerException
+  @Test
+  void claimId_null이면_NullPointerException() {
+    assertThatNullPointerException()
+        .isThrownBy(
+            () ->
+                new ClaimVerificationSignal(
+                    null, TIER, 50, ClaimScoreStatus.SCORABLE, SourceTransparency.EXPLICIT))
+        .withMessageContaining("claimId는 null일 수 없다");
+  }
+
+  @Test
+  void tier_null이면_NullPointerException() {
+    assertThatNullPointerException()
+        .isThrownBy(
+            () ->
+                new ClaimVerificationSignal(
+                    CLAIM_ID, null, 50, ClaimScoreStatus.SCORABLE, SourceTransparency.EXPLICIT))
+        .withMessageContaining("tier는 null일 수 없다");
+  }
+
+  @Test
+  void status_null이면_NullPointerException() {
+    assertThatNullPointerException()
+        .isThrownBy(
+            () ->
+                new ClaimVerificationSignal(CLAIM_ID, TIER, 50, null, SourceTransparency.EXPLICIT))
+        .withMessageContaining("status는 null일 수 없다");
+  }
+
+  @Test
+  void sourceTransparency_null이면_NullPointerException() {
+    assertThatNullPointerException()
+        .isThrownBy(
+            () -> new ClaimVerificationSignal(CLAIM_ID, TIER, 50, ClaimScoreStatus.SCORABLE, null))
+        .withMessageContaining("sourceTransparency는 null일 수 없다");
+  }
+}

--- a/core/src/test/java/com/truthscope/web/scoring/ClaimVerificationSignalTest.java
+++ b/core/src/test/java/com/truthscope/web/scoring/ClaimVerificationSignalTest.java
@@ -133,6 +133,35 @@ class ClaimVerificationSignalTest {
         .withMessageContaining("tier는 null일 수 없다");
   }
 
+  // (8) tier 범위 밖(1..3) → IllegalArgumentException — CodeRabbit F2 반영
+  @Test
+  void tier_0이면_IllegalArgumentException() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                new ClaimVerificationSignal(
+                    CLAIM_ID,
+                    (short) 0,
+                    50,
+                    ClaimScoreStatus.SCORABLE,
+                    SourceTransparency.EXPLICIT))
+        .withMessageContaining("tier는 1..3이어야 한다");
+  }
+
+  @Test
+  void tier_4이면_IllegalArgumentException() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                new ClaimVerificationSignal(
+                    CLAIM_ID,
+                    (short) 4,
+                    50,
+                    ClaimScoreStatus.SCORABLE,
+                    SourceTransparency.EXPLICIT))
+        .withMessageContaining("tier는 1..3이어야 한다");
+  }
+
   @Test
   void status_null이면_NullPointerException() {
     assertThatNullPointerException()

--- a/core/src/test/java/com/truthscope/web/scoring/CoverageAggregatorTest.java
+++ b/core/src/test/java/com/truthscope/web/scoring/CoverageAggregatorTest.java
@@ -1,0 +1,86 @@
+package com.truthscope.web.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class CoverageAggregatorTest {
+
+  private static ClaimVerificationSignal scorable(short tier) {
+    return new ClaimVerificationSignal(
+        UUID.randomUUID(), tier, 80, ClaimScoreStatus.SCORABLE, SourceTransparency.EXPLICIT);
+  }
+
+  private static ClaimVerificationSignal excluded(ClaimScoreStatus status, short tier) {
+    return new ClaimVerificationSignal(
+        UUID.randomUUID(), tier, null, status, SourceTransparency.NONE);
+  }
+
+  // 케이스 1: 빈 리스트 → 전부 0
+  @Test
+  void 빈_리스트이면_전부_0() {
+    CoverageSummary result = CoverageAggregator.aggregateCoverage(List.of());
+    assertThat(result.scorableCount()).isEqualTo(0);
+    assertThat(result.excludedCount()).isEqualTo(0);
+    assertThat(result.insufficientCount()).isEqualTo(0);
+    assertThat(result.timeSensitiveCount()).isEqualTo(0);
+    assertThat(result.outOfScopeCount()).isEqualTo(0);
+    assertThat(result.tier1Count()).isEqualTo(0);
+    assertThat(result.tier2Count()).isEqualTo(0);
+    assertThat(result.tier3Count()).isEqualTo(0);
+  }
+
+  // 케이스 2: SCORABLE 2(tier 1,2) + INSUFFICIENT 1(tier 3) + TIME_SENSITIVE 1(tier 3) + OUT_OF_SCOPE
+  // 1(tier 3)
+  // → scorable 2, excluded 3, insufficient 1, timeSensitive 1, outOfScope 1, tier1 1, tier2 1,
+  // tier3 3
+  // excludedCount(3) = insufficientCount(1) + timeSensitiveCount(1) + outOfScopeCount(1) 명시 단언
+  @Test
+  void 혼합_5개_케이스2() {
+    List<ClaimVerificationSignal> claims =
+        List.of(
+            scorable((short) 1),
+            scorable((short) 2),
+            excluded(ClaimScoreStatus.INSUFFICIENT, (short) 3),
+            excluded(ClaimScoreStatus.TIME_SENSITIVE, (short) 3),
+            excluded(ClaimScoreStatus.OUT_OF_SCOPE, (short) 3));
+    CoverageSummary result = CoverageAggregator.aggregateCoverage(claims);
+
+    assertThat(result.scorableCount()).isEqualTo(2);
+    assertThat(result.excludedCount()).isEqualTo(3);
+    assertThat(result.insufficientCount()).isEqualTo(1);
+    assertThat(result.timeSensitiveCount()).isEqualTo(1);
+    assertThat(result.outOfScopeCount()).isEqualTo(1);
+    assertThat(result.tier1Count()).isEqualTo(1);
+    assertThat(result.tier2Count()).isEqualTo(1);
+    assertThat(result.tier3Count()).isEqualTo(3);
+
+    // excludedCount가 사유별 count의 합(1+1+1=3)임을 명시 단언 (pass-only 금지 원칙)
+    assertThat(result.excludedCount())
+        .isEqualTo(
+            result.insufficientCount() + result.timeSensitiveCount() + result.outOfScopeCount());
+    assertThat(result.insufficientCount() + result.timeSensitiveCount() + result.outOfScopeCount())
+        .isEqualTo(3);
+  }
+
+  // 케이스 3: 단일 SCORABLE claim(tier 1) → scorable 1, excluded 0, tier1 1
+  @Test
+  void 단일_SCORABLE_tier1() {
+    List<ClaimVerificationSignal> claims = List.of(scorable((short) 1));
+    CoverageSummary result = CoverageAggregator.aggregateCoverage(claims);
+    assertThat(result.scorableCount()).isEqualTo(1);
+    assertThat(result.excludedCount()).isEqualTo(0);
+    assertThat(result.tier1Count()).isEqualTo(1);
+    assertThat(result.tier2Count()).isEqualTo(0);
+    assertThat(result.tier3Count()).isEqualTo(0);
+  }
+
+  // 케이스 4: claims null → NPE
+  @Test
+  void claims_null이면_NullPointerException() {
+    assertThatNullPointerException().isThrownBy(() -> CoverageAggregator.aggregateCoverage(null));
+  }
+}

--- a/core/src/test/java/com/truthscope/web/scoring/SourceTransparencyAggregatorTest.java
+++ b/core/src/test/java/com/truthscope/web/scoring/SourceTransparencyAggregatorTest.java
@@ -1,0 +1,94 @@
+package com.truthscope.web.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class SourceTransparencyAggregatorTest {
+
+  private static ClaimVerificationSignal signal(
+      ClaimScoreStatus status, Integer score, SourceTransparency transparency) {
+    return new ClaimVerificationSignal(UUID.randomUUID(), (short) 1, score, status, transparency);
+  }
+
+  private static ClaimVerificationSignal explicit() {
+    return signal(ClaimScoreStatus.SCORABLE, 80, SourceTransparency.EXPLICIT);
+  }
+
+  private static ClaimVerificationSignal ambiguous() {
+    return signal(ClaimScoreStatus.SCORABLE, 70, SourceTransparency.AMBIGUOUS);
+  }
+
+  private static ClaimVerificationSignal none() {
+    return signal(ClaimScoreStatus.INSUFFICIENT, null, SourceTransparency.NONE);
+  }
+
+  // 케이스 1: 빈 리스트 → (0,0,0, ALL_EXPLICIT)
+  @Test
+  void 빈_리스트이면_ALL_EXPLICIT() {
+    SourceTransparencySummary result =
+        SourceTransparencyAggregator.aggregateSourceTransparency(List.of());
+    assertThat(result.explicitCount()).isEqualTo(0);
+    assertThat(result.ambiguousCount()).isEqualTo(0);
+    assertThat(result.noneCount()).isEqualTo(0);
+    assertThat(result.band()).isEqualTo(SourceTransparencyBand.ALL_EXPLICIT);
+  }
+
+  // 케이스 2: 전부 EXPLICIT 3개 → (3,0,0, ALL_EXPLICIT)
+  @Test
+  void 전부_EXPLICIT_3개이면_ALL_EXPLICIT() {
+    List<ClaimVerificationSignal> claims = List.of(explicit(), explicit(), explicit());
+    SourceTransparencySummary result =
+        SourceTransparencyAggregator.aggregateSourceTransparency(claims);
+    assertThat(result.explicitCount()).isEqualTo(3);
+    assertThat(result.ambiguousCount()).isEqualTo(0);
+    assertThat(result.noneCount()).isEqualTo(0);
+    assertThat(result.band()).isEqualTo(SourceTransparencyBand.ALL_EXPLICIT);
+  }
+
+  // 케이스 3: EXPLICIT 2 + NONE 1 → (2,0,1, MISSING_SOURCE)
+  @Test
+  void EXPLICIT_2와_NONE_1이면_MISSING_SOURCE() {
+    List<ClaimVerificationSignal> claims = List.of(explicit(), explicit(), none());
+    SourceTransparencySummary result =
+        SourceTransparencyAggregator.aggregateSourceTransparency(claims);
+    assertThat(result.explicitCount()).isEqualTo(2);
+    assertThat(result.ambiguousCount()).isEqualTo(0);
+    assertThat(result.noneCount()).isEqualTo(1);
+    assertThat(result.band()).isEqualTo(SourceTransparencyBand.MISSING_SOURCE);
+  }
+
+  // 케이스 4: EXPLICIT 1 + AMBIGUOUS 1, NONE 0 → (1,1,0, SOME_UNCLEAR)
+  @Test
+  void EXPLICIT_1과_AMBIGUOUS_1이면_SOME_UNCLEAR() {
+    List<ClaimVerificationSignal> claims = List.of(explicit(), ambiguous());
+    SourceTransparencySummary result =
+        SourceTransparencyAggregator.aggregateSourceTransparency(claims);
+    assertThat(result.explicitCount()).isEqualTo(1);
+    assertThat(result.ambiguousCount()).isEqualTo(1);
+    assertThat(result.noneCount()).isEqualTo(0);
+    assertThat(result.band()).isEqualTo(SourceTransparencyBand.SOME_UNCLEAR);
+  }
+
+  // 케이스 5: AMBIGUOUS 1 + NONE 1 → (0,1,1, MISSING_SOURCE) — NONE 우선
+  @Test
+  void AMBIGUOUS_1과_NONE_1이면_MISSING_SOURCE_NONE_우선() {
+    List<ClaimVerificationSignal> claims = List.of(ambiguous(), none());
+    SourceTransparencySummary result =
+        SourceTransparencyAggregator.aggregateSourceTransparency(claims);
+    assertThat(result.explicitCount()).isEqualTo(0);
+    assertThat(result.ambiguousCount()).isEqualTo(1);
+    assertThat(result.noneCount()).isEqualTo(1);
+    assertThat(result.band()).isEqualTo(SourceTransparencyBand.MISSING_SOURCE);
+  }
+
+  // 케이스 6: claims null → NPE
+  @Test
+  void claims_null이면_NullPointerException() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> SourceTransparencyAggregator.aggregateSourceTransparency(null));
+  }
+}

--- a/core/src/test/java/com/truthscope/web/scoring/TruthLabelDeriverTest.java
+++ b/core/src/test/java/com/truthscope/web/scoring/TruthLabelDeriverTest.java
@@ -1,0 +1,116 @@
+package com.truthscope.web.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import org.junit.jupiter.api.Test;
+
+class TruthLabelDeriverTest {
+
+  // fixture: ScoreBandPolicy(85, 70, 45, 20)
+  private static final ScoreBandPolicy POLICY = new ScoreBandPolicy(85, 70, 45, 20);
+
+  // 경계값 10건 — fixture ScoreBandPolicy(85, 70, 45, 20)
+  @Test
+  void score_100이면_FACT() {
+    assertThat(TruthLabelDeriver.deriveTruthLabel(100, POLICY)).isEqualTo(TruthLabel.FACT);
+  }
+
+  @Test
+  void score_85이면_FACT() {
+    assertThat(TruthLabelDeriver.deriveTruthLabel(85, POLICY)).isEqualTo(TruthLabel.FACT);
+  }
+
+  @Test
+  void score_84이면_MOSTLY_FACT() {
+    assertThat(TruthLabelDeriver.deriveTruthLabel(84, POLICY)).isEqualTo(TruthLabel.MOSTLY_FACT);
+  }
+
+  @Test
+  void score_70이면_MOSTLY_FACT() {
+    assertThat(TruthLabelDeriver.deriveTruthLabel(70, POLICY)).isEqualTo(TruthLabel.MOSTLY_FACT);
+  }
+
+  @Test
+  void score_69이면_PARTLY_FACT() {
+    assertThat(TruthLabelDeriver.deriveTruthLabel(69, POLICY)).isEqualTo(TruthLabel.PARTLY_FACT);
+  }
+
+  @Test
+  void score_45이면_PARTLY_FACT() {
+    assertThat(TruthLabelDeriver.deriveTruthLabel(45, POLICY)).isEqualTo(TruthLabel.PARTLY_FACT);
+  }
+
+  @Test
+  void score_44이면_MOSTLY_NOT_FACT() {
+    assertThat(TruthLabelDeriver.deriveTruthLabel(44, POLICY))
+        .isEqualTo(TruthLabel.MOSTLY_NOT_FACT);
+  }
+
+  @Test
+  void score_20이면_MOSTLY_NOT_FACT() {
+    assertThat(TruthLabelDeriver.deriveTruthLabel(20, POLICY))
+        .isEqualTo(TruthLabel.MOSTLY_NOT_FACT);
+  }
+
+  @Test
+  void score_19이면_NOT_FACT() {
+    assertThat(TruthLabelDeriver.deriveTruthLabel(19, POLICY)).isEqualTo(TruthLabel.NOT_FACT);
+  }
+
+  @Test
+  void score_0이면_NOT_FACT() {
+    assertThat(TruthLabelDeriver.deriveTruthLabel(0, POLICY)).isEqualTo(TruthLabel.NOT_FACT);
+  }
+
+  // 상한 경계 2건 — ScoreBandPolicy(100, 70, 45, 20)
+  @Test
+  void factMin_100일때_score_100이면_FACT() {
+    ScoreBandPolicy policy100 = new ScoreBandPolicy(100, 70, 45, 20);
+    assertThat(TruthLabelDeriver.deriveTruthLabel(100, policy100)).isEqualTo(TruthLabel.FACT);
+  }
+
+  @Test
+  void factMin_100일때_score_99이면_MOSTLY_FACT() {
+    ScoreBandPolicy policy100 = new ScoreBandPolicy(100, 70, 45, 20);
+    assertThat(TruthLabelDeriver.deriveTruthLabel(99, policy100)).isEqualTo(TruthLabel.MOSTLY_FACT);
+  }
+
+  // 예외 — claimScore 범위 밖
+  @Test
+  void score_마이너스1이면_IllegalArgumentException() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> TruthLabelDeriver.deriveTruthLabel(-1, POLICY))
+        .withMessageContaining("claimScore는 0..100이어야 한다");
+  }
+
+  @Test
+  void score_101이면_IllegalArgumentException() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> TruthLabelDeriver.deriveTruthLabel(101, POLICY))
+        .withMessageContaining("claimScore는 0..100이어야 한다");
+  }
+
+  // 예외 — policy null
+  @Test
+  void policy_null이면_NullPointerException() {
+    assertThatNullPointerException().isThrownBy(() -> TruthLabelDeriver.deriveTruthLabel(50, null));
+  }
+
+  // ScoreBandPolicy 불변식 — 비내림차순 인자 (mostlyFactMin > factMin)
+  @Test
+  void ScoreBandPolicy_비내림차순이면_IllegalArgumentException() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> new ScoreBandPolicy(70, 85, 45, 20))
+        .withMessageContaining("밴드 임계값은 0 초과 100 이하 내림차순이어야 한다");
+  }
+
+  // ScoreBandPolicy 불변식 — mostlyNotFactMin = 0 (0 초과 조건 위반)
+  @Test
+  void ScoreBandPolicy_mostlyNotFactMin_0이면_IllegalArgumentException() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> new ScoreBandPolicy(85, 70, 45, 0))
+        .withMessageContaining("밴드 임계값은 0 초과 100 이하 내림차순이어야 한다");
+  }
+}


### PR DESCRIPTION
## Summary

- Phase: 55-credibility-score-redesign — 신뢰도 점수 재설계의 계산 함수 분해(DISCUSS D15)
- core 모듈에 `scoring` 패키지 신설: claim 검증 신호 입력 계약 + 4개 순수 함수(진실성 5종 라벨 도출 / 기사 종합 점수 기하평균 집계 / 출처 표기 투명성 집계 / 검증 커버리지 집계)
- 엔티티·스키마 미변경. 검증 파이프라인 연동, 4함수 출력의 DB 영속화, 정책값 확정은 Phase 55 범위 밖(후속 트랙)

## Done

- 요구사항: DISCUSS D15의 4개 순수 함수(`deriveTruthLabel` / `aggregateArticleFactScore` / `aggregateSourceTransparency` / `aggregateCoverage`)와 입력 계약(`ClaimVerificationSignal` record, `ClaimScoreStatus`·`SourceTransparency` enum). 입력에서 출력 변환 + 경계 케이스(빈 리스트, score null, 0점 floor 클램프, 비판정 claim 제외, 단일 claim) 동작. 계약 불변식은 compact constructor가 fail-fast 강제.
- 산출물: `core/src/main/java/com/truthscope/web/scoring/` 14개 신규 + `core/src/test/java/com/truthscope/web/scoring/` 5개 테스트 + `core/build.gradle`(AssertJ testImplementation 1줄)
- 수용 테스트: JUnit 5 unit 53건 + 회귀 시뮬레이션 ABC 3건

## Verification

- [✅] Build passed — `./gradlew spotlessApply checkstyleMain spotbugsMain :core:test :core:build` BUILD SUCCESSFUL
- [✅] checkstyle 0 warnings (maxWarnings=0), spotbugs 0
- [✅] Tests passed — 53/53, 0 failures 0 errors (JUnit XML 실측)
- [✅] 회귀 시뮬레이션 ABC — 무력화 A 2건 / B 3건 / C 4건 FAIL 확인 후 복구하여 53 GREEN. 6 로그 `.plans/55-credibility-score-redesign/regression-sim/` 박제

<!-- SAFE_OP_START -->
Assumptions: 없음
Scope: core/src/main/java/com/truthscope/web/scoring/, core/src/test/java/com/truthscope/web/scoring/, core/build.gradle
Out-of-scope: 검증 파이프라인(3-Tier Cascade 오케스트레이션, claim score 산출), 4함수 출력의 DB 영속화(VerificationResult·AnalysisSession 컬럼 write), 정책값(밴드 임계값·0점 floor·rounding 모드) 확정 — 전부 후속 트랙
<!-- SAFE_OP_END -->

## Related

- Plan: `.plans/55-credibility-score-redesign/PLAN.md`
- Checklist: `.plans/55-credibility-score-redesign/CHECKLIST.md`
- ADR: ADR-019(score-display-policy), ADR-020(sift-trace-mapping-correction) — 워크스페이스 레포 `context/decisions/`, 본 PR과 분리 커밋 대상


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 기사 사실 검증 종합 점수 집계 시스템 추가
  * 검증 범위 및 소스 투명성 분석 기능 추가
  * 진실성 라벨 자동 분류 기능 추가

* **테스트**
  * 점수 집계 로직 검증 테스트 추가
  * 범위 분석 및 투명성 평가 테스트 추가
  * 라벨 파생 동작 검증 테스트 추가

* **기타**
  * 테스트 Assertion 라이브러리 의존성 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/truthscope-smu/truthscope-web-backend/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->