### PR TITLE
🗃️db: Flyway V1 스키마 정합 + V2 무결성 hardening (Phase 54)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,8 @@ dependencies {
 	implementation project(':core')
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.flywaydb:flyway-core'
+	implementation 'org.flywaydb:flyway-database-postgresql'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -8,6 +8,15 @@ spring:
     password: ${SUPABASE_PASSWORD:}
     driver-class-name: org.postgresql.Driver
 
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    # Supabase public 스키마는 기본 객체가 있어 "non-empty" — Flyway가 history 없으면 거부함.
+    # baseline-on-migrate로 history 테이블 생성 + baseline 마커 삽입 후 V1 적용.
+    # baseline-version=0 필수: 기본값 1이면 V1(version 1)이 "baseline 초과만 적용" 규칙에 걸려 스킵됨.
+    baseline-on-migrate: true
+    baseline-version: 0
+
   jpa:
     hibernate:
       ddl-auto: none

--- a/app/src/main/resources/db/migration/V1__init_schema.sql
+++ b/app/src/main/resources/db/migration/V1__init_schema.sql
@@ -1,0 +1,164 @@
+-- V1 init schema — TruthScope 단일 진실원(엔티티) 기준 최초 스키마.
+-- 출처: EntitySchemaExportTest가 Hibernate로 추출한 엔티티 파생 DDL (build/entity-schema.sql), parity 보장.
+-- Phase 52 ADR-008(Flyway 표준) 최초 이행. systematic-debugging Phase 4 — root cause(스키마 단일 진실원 부재) 정조준.
+--
+-- 박제 결정:
+--  - enum 컬럼은 @Enumerated(STRING) 대문자 그대로 CHECK (members.role / analysis_sessions.status /
+--    claims.importance / user_reactions.type / articles.source_type) → Drift A(대소문자) 해소.
+--  - 모든 BaseTimeEntity 테이블에 created_at/updated_at (api_usage_logs 제외) → Drift B 해소.
+--  - articles.source_type 존재, domain_type 미포함(엔티티가 진실) → Drift C 해소 및 ERD 문서가 낡음.
+--  - verification_results.label은 varchar(30) String 유지 (ADR-014 최소위험 기본값; Verdict enum 연결은 후속 ADR).
+--  - timestamp(6) 그대로 보존 (엔티티 LocalDateTime 정합 → ddl-auto=validate 통과 보장. timestamptz 전환은
+--    엔티티 타입 변경을 동반하므로 후속 마이그레이션 + ADR로 분리).
+--  - 후속 마이그레이션으로 분리(본 V1 미포함, 의도적): factcheck_cache.search_vector + GIN + 트리거(Tier1 한국어
+--    검색 기능 도입 시), RLS 정책(ERD 5절), ERD 4절의 NOT NULL/DEFAULT 강화. 미사용 인프라 선반영 금지 원칙.
+
+create table analysis_sessions (
+    tier1_count smallint,
+    tier2_count smallint,
+    tier3_count smallint,
+    total_score smallint,
+    completed_at timestamp(6),
+    created_at timestamp(6),
+    requested_at timestamp(6),
+    updated_at timestamp(6),
+    coverage varchar(10),
+    id uuid not null,
+    member_id uuid,
+    status varchar(20) check (status in ('PENDING','EXTRACTING','ANALYZING','COMPLETED','FAILED')),
+    error_message TEXT,
+    primary key (id)
+);
+
+create table api_usage_logs (
+    request_count integer,
+    token_count integer,
+    usage_date date,
+    id uuid not null,
+    member_id uuid,
+    provider varchar(30),
+    model varchar(50),
+    primary key (id)
+);
+
+create table articles (
+    created_at timestamp(6),
+    extracted_at timestamp(6),
+    updated_at timestamp(6),
+    lang varchar(10),
+    id uuid not null,
+    session_id uuid unique,
+    source_type varchar(20) check (source_type in ('URL_INPUT','TEXT_INPUT')),
+    title varchar(500),
+    url varchar(2048),
+    body TEXT,
+    domain varchar(255),
+    primary key (id)
+);
+
+create table claims (
+    sort_order smallint,
+    created_at timestamp(6),
+    updated_at timestamp(6),
+    importance varchar(10) check (importance in ('HIGH','MEDIUM','LOW')),
+    article_id uuid,
+    id uuid not null,
+    text TEXT,
+    primary key (id)
+);
+
+create table factcheck_cache (
+    collected_at timestamp(6),
+    created_at timestamp(6),
+    expires_at timestamp(6),
+    updated_at timestamp(6),
+    language varchar(10),
+    id uuid not null,
+    rating varchar(50),
+    source_org varchar(100),
+    original_url varchar(2048),
+    claim_text TEXT,
+    primary key (id)
+);
+
+create table members (
+    created_at timestamp(6),
+    updated_at timestamp(6),
+    id uuid not null,
+    role varchar(20) check (role in ('USER','ADMIN')),
+    nickname varchar(50),
+    email varchar(255) unique,
+    primary key (id)
+);
+
+create table user_reactions (
+    created_at timestamp(6),
+    updated_at timestamp(6),
+    type varchar(10) check (type in ('LIKE','DISLIKE','REPORT')),
+    article_id uuid,
+    id uuid not null,
+    member_id uuid,
+    reason varchar(500),
+    primary key (id),
+    constraint uk_user_reactions_article_member_type unique (article_id, member_id, type)
+);
+
+create table verification_results (
+    score smallint,
+    tier smallint,
+    created_at timestamp(6),
+    updated_at timestamp(6),
+    verified_at timestamp(6),
+    claim_id uuid unique,
+    id uuid not null,
+    label varchar(30),
+    disclaimer TEXT,
+    reason TEXT,
+    primary key (id)
+);
+
+create table verify_sources (
+    created_at timestamp(6),
+    updated_at timestamp(6),
+    stance varchar(10),
+    id uuid not null,
+    result_id uuid,
+    rating varchar(50),
+    publisher varchar(200),
+    title varchar(500),
+    url varchar(2048),
+    summary TEXT,
+    primary key (id)
+);
+
+alter table analysis_sessions
+    add constraint fk_analysis_sessions_member
+    foreign key (member_id) references members;
+
+alter table api_usage_logs
+    add constraint fk_api_usage_logs_member
+    foreign key (member_id) references members;
+
+alter table articles
+    add constraint fk_articles_session
+    foreign key (session_id) references analysis_sessions;
+
+alter table claims
+    add constraint fk_claims_article
+    foreign key (article_id) references articles;
+
+alter table user_reactions
+    add constraint fk_user_reactions_article
+    foreign key (article_id) references articles;
+
+alter table user_reactions
+    add constraint fk_user_reactions_member
+    foreign key (member_id) references members;
+
+alter table verification_results
+    add constraint fk_verification_results_claim
+    foreign key (claim_id) references claims;
+
+alter table verify_sources
+    add constraint fk_verify_sources_result
+    foreign key (result_id) references verification_results;

--- a/app/src/main/resources/db/migration/V2__hardening.sql
+++ b/app/src/main/resources/db/migration/V2__hardening.sql
@@ -1,0 +1,179 @@
+-- V2 hardening — TruthScope 데이터 무결성 제약 복원.
+--
+-- 출처: docs/md/10_erd.md 0-2 후속 마이그레이션 backlog + 4절 원안 DDL 의도.
+-- 결정 근거: docs/architecture/decisions/ADR-009-v2-integrity-hardening.md (Phase 54 D8).
+-- 원칙(ADR-008 Database Migration Standard): V1__init_schema.sql 동결, 모든 스키마 변경은 신규 V2+ ALTER.
+--
+-- 박제 결정:
+--  - verification_results 복합 불변식: domain-logic "모르면 모른다" — Tier 3은 score NULL,
+--    Tier 1/2는 score 0~100 비-NULL. score IS NOT NULL 항으로 SQL 3치 논리 구멍을 닫는다.
+--  - NOT NULL은 (a) 현 코드 경로가 항상 채우는 컬럼, (b) INSERT 경로가 아직 없어 회귀 위험 0인
+--    컬럼에만 적용. articles.url/lang은 source_type=TEXT_INPUT 설계상 NULL 가능 → 의도적 제외.
+--  - 후속(본 V2 미포함): factcheck_cache.search_vector(V3 검색), RLS(V4 보안),
+--    analysis_sessions tier count / api_usage_logs 카운터의 NOT NULL+DEFAULT 0 쌍(엔티티 필드
+--    nullable + JParla explicit-NULL INSERT 상호작용 → 엔티티 변경 동반 필요).
+--
+-- Supabase 데이터 0건 시점이라 NOT NULL/CHECK 추가가 무비용. 데이터가 쌓인 뒤엔 불량 row로 적용이 막힌다.
+
+SET lock_timeout = '5s';
+
+-- ============================================================
+-- 1. verification_results 복합 불변식 (Phase 54 D8 — "모르면 모른다")
+--    Tier 3 = score 반드시 NULL(점수 부여 금지), Tier 1/2 = score 반드시 0~100 비-NULL.
+--    score IS NOT NULL 항이 없으면 tier IN (1,2) + score=NULL이 3치 논리로 CHECK를 통과해버린다.
+-- ============================================================
+ALTER TABLE verification_results
+    ADD CONSTRAINT ck_verification_results_tier_score
+    CHECK (
+        (tier = 3 AND score IS NULL)
+        OR (tier IN (1, 2) AND score IS NOT NULL AND score BETWEEN 0 AND 100)
+    );
+
+-- ============================================================
+-- 2. verify_sources.stance 허용 값 (Tier 2 AI 교차검증 판정).
+--    Tier 1에서는 stance가 NULL이며, NULL은 CHECK가 3치 논리로 자동 허용한다.
+-- ============================================================
+ALTER TABLE verify_sources
+    ADD CONSTRAINT ck_verify_sources_stance
+    CHECK (stance IN ('supports', 'refutes', 'neutral'));
+
+-- ============================================================
+-- 3. NOT NULL — 비즈니스 필수 컬럼 + 감사 시각(created_at/updated_at).
+-- ============================================================
+ALTER TABLE members ALTER COLUMN email SET NOT NULL;
+ALTER TABLE members ALTER COLUMN nickname SET NOT NULL;
+ALTER TABLE members ALTER COLUMN role SET NOT NULL;
+ALTER TABLE members ALTER COLUMN created_at SET NOT NULL;
+ALTER TABLE members ALTER COLUMN updated_at SET NOT NULL;
+
+ALTER TABLE analysis_sessions ALTER COLUMN status SET NOT NULL;
+ALTER TABLE analysis_sessions ALTER COLUMN requested_at SET NOT NULL;
+ALTER TABLE analysis_sessions ALTER COLUMN created_at SET NOT NULL;
+ALTER TABLE analysis_sessions ALTER COLUMN updated_at SET NOT NULL;
+
+ALTER TABLE articles ALTER COLUMN session_id SET NOT NULL;
+ALTER TABLE articles ALTER COLUMN title SET NOT NULL;
+ALTER TABLE articles ALTER COLUMN body SET NOT NULL;
+ALTER TABLE articles ALTER COLUMN source_type SET NOT NULL;
+ALTER TABLE articles ALTER COLUMN extracted_at SET NOT NULL;
+ALTER TABLE articles ALTER COLUMN created_at SET NOT NULL;
+ALTER TABLE articles ALTER COLUMN updated_at SET NOT NULL;
+
+ALTER TABLE claims ALTER COLUMN article_id SET NOT NULL;
+ALTER TABLE claims ALTER COLUMN text SET NOT NULL;
+ALTER TABLE claims ALTER COLUMN importance SET NOT NULL;
+ALTER TABLE claims ALTER COLUMN sort_order SET NOT NULL;
+ALTER TABLE claims ALTER COLUMN created_at SET NOT NULL;
+ALTER TABLE claims ALTER COLUMN updated_at SET NOT NULL;
+
+ALTER TABLE verification_results ALTER COLUMN tier SET NOT NULL;
+ALTER TABLE verification_results ALTER COLUMN label SET NOT NULL;
+ALTER TABLE verification_results ALTER COLUMN reason SET NOT NULL;
+ALTER TABLE verification_results ALTER COLUMN verified_at SET NOT NULL;
+ALTER TABLE verification_results ALTER COLUMN created_at SET NOT NULL;
+ALTER TABLE verification_results ALTER COLUMN updated_at SET NOT NULL;
+
+ALTER TABLE verify_sources ALTER COLUMN result_id SET NOT NULL;
+ALTER TABLE verify_sources ALTER COLUMN title SET NOT NULL;
+ALTER TABLE verify_sources ALTER COLUMN publisher SET NOT NULL;
+ALTER TABLE verify_sources ALTER COLUMN created_at SET NOT NULL;
+ALTER TABLE verify_sources ALTER COLUMN updated_at SET NOT NULL;
+
+ALTER TABLE user_reactions ALTER COLUMN article_id SET NOT NULL;
+ALTER TABLE user_reactions ALTER COLUMN member_id SET NOT NULL;
+ALTER TABLE user_reactions ALTER COLUMN type SET NOT NULL;
+ALTER TABLE user_reactions ALTER COLUMN created_at SET NOT NULL;
+ALTER TABLE user_reactions ALTER COLUMN updated_at SET NOT NULL;
+
+ALTER TABLE factcheck_cache ALTER COLUMN claim_text SET NOT NULL;
+ALTER TABLE factcheck_cache ALTER COLUMN source_org SET NOT NULL;
+ALTER TABLE factcheck_cache ALTER COLUMN rating SET NOT NULL;
+ALTER TABLE factcheck_cache ALTER COLUMN original_url SET NOT NULL;
+ALTER TABLE factcheck_cache ALTER COLUMN language SET NOT NULL;
+ALTER TABLE factcheck_cache ALTER COLUMN collected_at SET NOT NULL;
+ALTER TABLE factcheck_cache ALTER COLUMN created_at SET NOT NULL;
+ALTER TABLE factcheck_cache ALTER COLUMN updated_at SET NOT NULL;
+
+ALTER TABLE api_usage_logs ALTER COLUMN provider SET NOT NULL;
+ALTER TABLE api_usage_logs ALTER COLUMN usage_date SET NOT NULL;
+
+-- ============================================================
+-- 4. DEFAULT — id(gen_random_uuid), 감사 시각(now()).
+--    JPA는 값을 명시 INSERT하므로 DEFAULT는 raw SQL/운영 작업용 방어막이다.
+--    members.id는 @GeneratedValue 미사용(Supabase Auth uid) → DEFAULT 미부여.
+-- ============================================================
+ALTER TABLE analysis_sessions    ALTER COLUMN id SET DEFAULT gen_random_uuid();
+ALTER TABLE articles             ALTER COLUMN id SET DEFAULT gen_random_uuid();
+ALTER TABLE claims               ALTER COLUMN id SET DEFAULT gen_random_uuid();
+ALTER TABLE verification_results ALTER COLUMN id SET DEFAULT gen_random_uuid();
+ALTER TABLE verify_sources       ALTER COLUMN id SET DEFAULT gen_random_uuid();
+ALTER TABLE user_reactions       ALTER COLUMN id SET DEFAULT gen_random_uuid();
+ALTER TABLE factcheck_cache      ALTER COLUMN id SET DEFAULT gen_random_uuid();
+ALTER TABLE api_usage_logs       ALTER COLUMN id SET DEFAULT gen_random_uuid();
+
+ALTER TABLE members              ALTER COLUMN created_at SET DEFAULT now();
+ALTER TABLE members              ALTER COLUMN updated_at SET DEFAULT now();
+ALTER TABLE analysis_sessions    ALTER COLUMN created_at SET DEFAULT now();
+ALTER TABLE analysis_sessions    ALTER COLUMN updated_at SET DEFAULT now();
+ALTER TABLE articles             ALTER COLUMN created_at SET DEFAULT now();
+ALTER TABLE articles             ALTER COLUMN updated_at SET DEFAULT now();
+ALTER TABLE claims               ALTER COLUMN created_at SET DEFAULT now();
+ALTER TABLE claims               ALTER COLUMN updated_at SET DEFAULT now();
+ALTER TABLE verification_results ALTER COLUMN created_at SET DEFAULT now();
+ALTER TABLE verification_results ALTER COLUMN updated_at SET DEFAULT now();
+ALTER TABLE verify_sources       ALTER COLUMN created_at SET DEFAULT now();
+ALTER TABLE verify_sources       ALTER COLUMN updated_at SET DEFAULT now();
+ALTER TABLE user_reactions       ALTER COLUMN created_at SET DEFAULT now();
+ALTER TABLE user_reactions       ALTER COLUMN updated_at SET DEFAULT now();
+ALTER TABLE factcheck_cache      ALTER COLUMN created_at SET DEFAULT now();
+ALTER TABLE factcheck_cache      ALTER COLUMN updated_at SET DEFAULT now();
+
+-- ============================================================
+-- 5. FK ON DELETE 의도 복원 (10_erd.md 4절 원안). V1은 plain FK였다.
+--    분석 그래프(session -> article -> claim -> result -> source)는 CASCADE,
+--    member 참조는 SET NULL(비로그인 분석 허용) 또는 CASCADE(member 소유 반응).
+-- ============================================================
+ALTER TABLE analysis_sessions DROP CONSTRAINT fk_analysis_sessions_member;
+ALTER TABLE analysis_sessions ADD CONSTRAINT fk_analysis_sessions_member
+    FOREIGN KEY (member_id) REFERENCES members (id) ON DELETE SET NULL;
+
+ALTER TABLE api_usage_logs DROP CONSTRAINT fk_api_usage_logs_member;
+ALTER TABLE api_usage_logs ADD CONSTRAINT fk_api_usage_logs_member
+    FOREIGN KEY (member_id) REFERENCES members (id) ON DELETE SET NULL;
+
+ALTER TABLE articles DROP CONSTRAINT fk_articles_session;
+ALTER TABLE articles ADD CONSTRAINT fk_articles_session
+    FOREIGN KEY (session_id) REFERENCES analysis_sessions (id) ON DELETE CASCADE;
+
+ALTER TABLE claims DROP CONSTRAINT fk_claims_article;
+ALTER TABLE claims ADD CONSTRAINT fk_claims_article
+    FOREIGN KEY (article_id) REFERENCES articles (id) ON DELETE CASCADE;
+
+ALTER TABLE verification_results DROP CONSTRAINT fk_verification_results_claim;
+ALTER TABLE verification_results ADD CONSTRAINT fk_verification_results_claim
+    FOREIGN KEY (claim_id) REFERENCES claims (id) ON DELETE CASCADE;
+
+ALTER TABLE verify_sources DROP CONSTRAINT fk_verify_sources_result;
+ALTER TABLE verify_sources ADD CONSTRAINT fk_verify_sources_result
+    FOREIGN KEY (result_id) REFERENCES verification_results (id) ON DELETE CASCADE;
+
+ALTER TABLE user_reactions DROP CONSTRAINT fk_user_reactions_article;
+ALTER TABLE user_reactions ADD CONSTRAINT fk_user_reactions_article
+    FOREIGN KEY (article_id) REFERENCES articles (id) ON DELETE CASCADE;
+
+ALTER TABLE user_reactions DROP CONSTRAINT fk_user_reactions_member;
+ALTER TABLE user_reactions ADD CONSTRAINT fk_user_reactions_member
+    FOREIGN KEY (member_id) REFERENCES members (id) ON DELETE CASCADE;
+
+-- ============================================================
+-- 6. 일반 인덱스 복원 (10_erd.md 4절 원안). V1은 PK/UNIQUE 인덱스만 두었다.
+-- ============================================================
+CREATE INDEX idx_sessions_member     ON analysis_sessions (member_id);
+CREATE INDEX idx_sessions_status     ON analysis_sessions (status);
+CREATE INDEX idx_sessions_requested  ON analysis_sessions (requested_at DESC);
+CREATE INDEX idx_articles_url        ON articles (url);
+CREATE INDEX idx_articles_domain     ON articles (domain);
+CREATE INDEX idx_claims_article      ON claims (article_id, sort_order);
+CREATE INDEX idx_vresults_tier       ON verification_results (tier);
+CREATE INDEX idx_usage_provider_date ON api_usage_logs (provider, usage_date);
+CREATE INDEX idx_usage_member_date   ON api_usage_logs (member_id, usage_date);

--- a/app/src/test/java/com/truthscope/web/drift/EntitySchemaExportTest.java
+++ b/app/src/test/java/com/truthscope/web/drift/EntitySchemaExportTest.java
@@ -1,0 +1,31 @@
+package com.truthscope.web.drift;
+
+import com.truthscope.web.support.AbstractIntegrationTest;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * 엔티티에서 권위 있는 스키마 DDL을 Hibernate로 추출한다 (Flyway V1의 parity-보장 기반).
+ *
+ * <p>손으로 V1을 쓰면 컬럼 타입/길이/제약이 추측이 된다. 본 테스트는 컨텍스트 부트 시 Hibernate가 엔티티로부터 생성하는 create 스크립트를 파일로 떨군다.
+ * 그 산출물이 곧 엔티티-진실 스키마이며 V1__init.sql의 출처가 된다. (특성화/추출 테스트 — 회귀 가드 아님)
+ */
+@TestPropertySource(
+    properties = {
+      "spring.jpa.properties.jakarta.persistence.schema-generation.scripts.action=create",
+      "spring.jpa.properties.jakarta.persistence.schema-generation.scripts.create-target=build/entity-schema.sql",
+      "spring.jpa.properties.hibernate.hbm2ddl.delimiter=;",
+      "spring.jpa.properties.hibernate.format_sql=true"
+    })
+class EntitySchemaExportTest extends AbstractIntegrationTest {
+
+  @Test
+  void exportEntityDerivedSchema() throws Exception {
+    Path out = Path.of("build/entity-schema.sql");
+    // EMF 부트 타이밍에 스크립트가 기록됨. 존재/비어있지 않음만 확인 (내용 검증은 사람이 수행).
+    org.junit.jupiter.api.Assertions.assertTrue(
+        Files.exists(out) && Files.size(out) > 0, "엔티티 파생 스키마 스크립트가 생성되어야 함");
+  }
+}

--- a/app/src/test/java/com/truthscope/web/drift/ErdContractDriftReproductionTest.java
+++ b/app/src/test/java/com/truthscope/web/drift/ErdContractDriftReproductionTest.java
@@ -1,0 +1,107 @@
+package com.truthscope.web.drift;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * 3 계약 drift 영구 회귀 가드 (flip 완료).
+ *
+ * <p><b>이력:</b> 본 클래스는 원래 ERD 문서 4절 DDL을 적용해 High-1(enum 대소문자) / Medium-1(BaseTime 컬럼) /
+ * Medium-2b(source_type) 위반을 결정적으로 재현·확정했다(systematic-debugging Phase 1·3, SQLState 23514/42703
+ * 입증). Phase 4에서 권위=엔티티-진실 + Flyway V1로 수정됐고, Supabase 실스키마 0 테이블(World C) 확인으로 이관 데이터가 없어 V1이 최초
+ * 생성자가 됐다.
+ *
+ * <p><b>현재 의미:</b> 운영 스키마 출처인 {@code db/migration/V1__init_schema.sql}을 적용한 뒤, 과거에 실패하던 3 연산이 이제
+ * 성공함을 단언한다. 누군가 후속 마이그레이션에서 enum CHECK를 소문자로 되돌리거나 created_at/updated_at·source_type을 제거하면 본 테스트가
+ * 깨져 회귀를 잡는다. FK 컬럼은 NULL로 두어 각 단언을 해당 drift 축으로 격리(systematic-debugging: 한 번에 한 변수).
+ */
+@Testcontainers(disabledWithoutDocker = true)
+@DisplayName("3 계약 drift 회귀 가드 (V1 스키마 적용 후 정상 동작)")
+class ErdContractDriftReproductionTest {
+
+  @Container
+  static final PostgreSQLContainer<?> PG = new PostgreSQLContainer<>("postgres:16-alpine");
+
+  @BeforeAll
+  static void applyV1() throws Exception {
+    String ddl;
+    try (InputStream in =
+        ErdContractDriftReproductionTest.class.getResourceAsStream(
+            "/db/migration/V1__init_schema.sql")) {
+      if (in == null) {
+        throw new IllegalStateException("V1__init_schema.sql 리소스를 찾을 수 없음");
+      }
+      ddl = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+    try (Connection c = conn();
+        Statement st = c.createStatement()) {
+      st.execute(ddl);
+    }
+  }
+
+  private static Connection conn() throws SQLException {
+    return DriverManager.getConnection(PG.getJdbcUrl(), PG.getUsername(), PG.getPassword());
+  }
+
+  /** High-1 회귀 가드: @Enumerated(STRING) 대문자 값이 V1 CHECK에 수용돼야 함. */
+  @Test
+  @DisplayName("A. claims.importance — 대문자 'HIGH' INSERT 성공 (Drift A 해소 유지)")
+  void high1_upperCaseEnumAccepted() {
+    assertThatCode(
+            () -> {
+              try (Connection c = conn();
+                  Statement st = c.createStatement()) {
+                st.executeUpdate(
+                    "INSERT INTO claims (id, article_id, text, importance, sort_order) "
+                        + "VALUES (gen_random_uuid(), NULL, 'x', 'HIGH', 0)");
+              }
+            })
+        .doesNotThrowAnyException();
+  }
+
+  /** Medium-1 회귀 가드: BaseTimeEntity created_at/updated_at 컬럼이 존재해야 함. */
+  @Test
+  @DisplayName("B. verification_results — created_at/updated_at INSERT 성공 (Drift B 해소 유지)")
+  void medium1_baseTimeColumnsPresent() {
+    assertThatCode(
+            () -> {
+              try (Connection c = conn();
+                  Statement st = c.createStatement()) {
+                st.executeUpdate(
+                    "INSERT INTO verification_results "
+                        + "(id, claim_id, tier, label, reason, verified_at, created_at, updated_at) "
+                        + "VALUES (gen_random_uuid(), NULL, 1, 'AI 교차검증', 'r', now(), now(), now())");
+              }
+            })
+        .doesNotThrowAnyException();
+  }
+
+  /** Medium-2b 회귀 가드: articles.source_type 컬럼이 존재해야 함. */
+  @Test
+  @DisplayName("C. articles.source_type — source_type INSERT 성공 (Drift C 해소 유지)")
+  void medium2b_sourceTypeColumnPresent() {
+    assertThatCode(
+            () -> {
+              try (Connection c = conn();
+                  Statement st = c.createStatement()) {
+                st.executeUpdate(
+                    "INSERT INTO articles "
+                        + "(id, session_id, url, title, body, lang, extracted_at, source_type, created_at, updated_at) "
+                        + "VALUES (gen_random_uuid(), NULL, 'http://x', 't', 'b', 'ko', now(), 'URL_INPUT', now(), now())");
+              }
+            })
+        .doesNotThrowAnyException();
+  }
+}

--- a/app/src/test/java/com/truthscope/web/drift/FlywaySchemaParityTest.java
+++ b/app/src/test/java/com/truthscope/web/drift/FlywaySchemaParityTest.java
@@ -1,0 +1,47 @@
+package com.truthscope.web.drift;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * 구조적 drift 가드 — Flyway V1 적용 스키마에 대해 Hibernate {@code ddl-auto=validate} 통과 여부로 "엔티티 == V1"
+ * parity를 강제한다.
+ *
+ * <p>기존 {@code AbstractIntegrationTest}는 {@code create-drop}(엔티티가 스키마 생성)이라 ERD/V1 drift를 구조적으로 절대
+ * 못 잡는다 — 이것이 3 drift가 여태 미검출된 root cause였다. 본 테스트는 운영과 동일하게 Flyway가 V1로 스키마를 만들고, Hibernate가 엔티티를
+ * 그 스키마에 validate한다. V1이 엔티티에서 어긋나면 컨텍스트 부트가 실패해 본 테스트가 깨진다(향후 마이그레이션 회귀 가드).
+ *
+ * <p>{@code AbstractIntegrationTest}를 의도적으로 상속하지 않음 — 그 base는 create-drop + flyway 비활성을 강제하므로 본 검증과
+ * 상반된다.
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+@Testcontainers(disabledWithoutDocker = true)
+@TestPropertySource(
+    properties = {
+      "spring.jpa.hibernate.ddl-auto=validate",
+      "spring.flyway.enabled=true",
+      "spring.flyway.locations=classpath:db/migration"
+    })
+@DisplayName("Flyway V1 == 엔티티 parity (ddl-auto=validate)")
+class FlywaySchemaParityTest {
+
+  @ServiceConnection static final PostgreSQLContainer<?> POSTGRES;
+
+  static {
+    POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
+    POSTGRES.start();
+  }
+
+  @Test
+  @DisplayName("Flyway V1 적용 후 엔티티 validate 통과 — 컨텍스트 부트 = parity 입증")
+  void entitiesValidateAgainstFlywaySchema() {
+    // 컨텍스트가 떴다는 것 자체가 Flyway V1 적용 + Hibernate validate 통과를 의미한다.
+    // validate 실패 시 ApplicationContext 로딩 실패 → 본 테스트 실패.
+  }
+}

--- a/app/src/test/java/com/truthscope/web/drift/VerificationIntegrityMigrationTest.java
+++ b/app/src/test/java/com/truthscope/web/drift/VerificationIntegrityMigrationTest.java
@@ -1,0 +1,224 @@
+package com.truthscope.web.drift;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * V2 무결성 hardening 회귀 가드 — Flyway V1 + V2를 순차 적용한 스키마에서 도메인 불변식이 DB 레벨로 강제됨을 단언한다.
+ *
+ * <p><b>핵심 불변식 (Phase 54 D8):</b> {@code verification_results}는 "모르면 모른다" 원칙을 DB CHECK로 박제한다 — Tier
+ * 3은 score가 반드시 NULL(점수 부여 금지), Tier 1/2는 score가 반드시 0~100 사이 비-NULL. {@code
+ * .claude/rules/domain-logic.md}의 3-Tier Cascade 규칙이 코드뿐 아니라 스키마에서도 깨지지 않게 한다.
+ *
+ * <p><b>pass-only 금지 (feedback_bdd_tdd_not_pass_only):</b> 통과 케이스만이 아니라 위반 케이스가 실제로
+ * 거부됨(SQLException)을 함께 단언한다. tier=1 + score=NULL 케이스는 SQL 3치 논리(three-valued logic) 구멍 — 단순 {@code
+ * BETWEEN}만으로는 통과해버리는 — 을 V2 CHECK가 {@code score IS NOT NULL} 항으로 닫음을 검증한다.
+ *
+ * <p>{@link ErdContractDriftReproductionTest}와 같은 raw-JDBC 패턴 — {@code AbstractIntegrationTest}는
+ * create-drop이라 V2 ALTER 제약을 검증할 수 없다. 가변 값은 {@link PreparedStatement} 바인딩으로 전달한다.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+@DisplayName("V2 무결성 hardening 회귀 가드 (V1 + V2 적용 후)")
+class VerificationIntegrityMigrationTest {
+
+  @Container
+  static final PostgreSQLContainer<?> PG = new PostgreSQLContainer<>("postgres:16-alpine");
+
+  private static final String INSERT_RESULT =
+      "INSERT INTO verification_results "
+          + "(id, claim_id, tier, label, score, reason, disclaimer, verified_at, created_at, updated_at) "
+          + "VALUES (gen_random_uuid(), NULL, ?, ?, ?, ?, NULL, ?, now(), now())";
+
+  private static final String INSERT_SOURCE =
+      "INSERT INTO verify_sources (id, result_id, title, publisher, stance, created_at, updated_at) "
+          + "VALUES (gen_random_uuid(), ?, 't', 'p', ?, now(), now())";
+
+  @BeforeAll
+  static void applyMigrations() throws Exception {
+    try (Connection c = conn();
+        Statement st = c.createStatement()) {
+      st.execute(readMigration("/db/migration/V1__init_schema.sql"));
+      st.execute(readMigration("/db/migration/V2__hardening.sql"));
+    }
+  }
+
+  private static String readMigration(String resource) throws Exception {
+    try (InputStream in = VerificationIntegrityMigrationTest.class.getResourceAsStream(resource)) {
+      if (in == null) {
+        throw new IllegalStateException(resource + " 리소스를 찾을 수 없음");
+      }
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  private static Connection conn() throws SQLException {
+    return DriverManager.getConnection(PG.getJdbcUrl(), PG.getUsername(), PG.getPassword());
+  }
+
+  private static Timestamp now() {
+    return Timestamp.valueOf(LocalDateTime.now());
+  }
+
+  /** verification_results 한 건을 INSERT. 가변 컬럼은 바인딩, FK claim_id는 NULL. */
+  private static void insertResult(
+      Short tier, Short score, String label, String reason, Timestamp verifiedAt)
+      throws SQLException {
+    try (Connection c = conn();
+        PreparedStatement ps = c.prepareStatement(INSERT_RESULT)) {
+      ps.setObject(1, tier);
+      ps.setObject(2, label);
+      ps.setObject(3, score);
+      ps.setObject(4, reason);
+      ps.setObject(5, verifiedAt);
+      ps.executeUpdate();
+    }
+  }
+
+  /** 유효한 verification_results(Tier 3) 한 건을 INSERT하고 그 id를 반환 — verify_sources FK 부모용. */
+  private static UUID insertParentResult() throws SQLException {
+    try (Connection c = conn();
+        Statement st = c.createStatement();
+        ResultSet rs =
+            st.executeQuery(
+                "INSERT INTO verification_results "
+                    + "(id, claim_id, tier, label, score, reason, verified_at, created_at, updated_at) "
+                    + "VALUES (gen_random_uuid(), NULL, 3, '검증 불가', NULL, 'r', now(), now(), now()) "
+                    + "RETURNING id")) {
+      rs.next();
+      return rs.getObject("id", UUID.class);
+    }
+  }
+
+  private static void insertSource(UUID resultId, String stance) throws SQLException {
+    try (Connection c = conn();
+        PreparedStatement ps = c.prepareStatement(INSERT_SOURCE)) {
+      ps.setObject(1, resultId);
+      ps.setObject(2, stance);
+      ps.executeUpdate();
+    }
+  }
+
+  // ── verification_results 복합 불변식 (D8) ──────────────────────────────
+
+  @Test
+  @DisplayName("A. Tier 3 + score NULL — 통과 (모르면 모른다: 점수 미부여)")
+  void tier3NullScore_accepted() {
+    assertThatCode(() -> insertResult((short) 3, null, "검증 불가", "r", now()))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  @DisplayName("B. Tier 3 + score 비-NULL(50) — 위반 (Tier 3에 점수 부여 금지)")
+  void tier3NonNullScore_rejected() {
+    assertThatThrownBy(() -> insertResult((short) 3, (short) 50, "검증 불가", "r", now()))
+        .isInstanceOf(SQLException.class);
+  }
+
+  @Test
+  @DisplayName("C. Tier 1 + score 범위 외(150) — 위반 (0~100 초과)")
+  void tier1ScoreOutOfRange_rejected() {
+    assertThatThrownBy(() -> insertResult((short) 1, (short) 150, "기관 검증 완료", "r", now()))
+        .isInstanceOf(SQLException.class);
+  }
+
+  @Test
+  @DisplayName("D. Tier 1 + score NULL — 위반 (3치 논리 구멍: score IS NOT NULL 항이 닫음)")
+  void tier1NullScore_rejected() {
+    assertThatThrownBy(() -> insertResult((short) 1, null, "기관 검증 완료", "r", now()))
+        .isInstanceOf(SQLException.class);
+  }
+
+  @Test
+  @DisplayName("E. Tier 1 + score 0~100(50) — 통과 (happy path)")
+  void tier1ValidScore_accepted() {
+    assertThatCode(() -> insertResult((short) 1, (short) 50, "기관 검증 완료", "r", now()))
+        .doesNotThrowAnyException();
+  }
+
+  // ── verification_results NOT NULL ────────────────────────────────────
+
+  @Test
+  @DisplayName("F. tier NULL — 위반 (NOT NULL — 복합 CHECK의 3치 논리 구멍도 함께 닫음)")
+  void nullTier_rejected() {
+    assertThatThrownBy(() -> insertResult(null, null, "검증 불가", "r", now()))
+        .isInstanceOf(SQLException.class);
+  }
+
+  @Test
+  @DisplayName("G. label NULL — 위반 (NOT NULL)")
+  void nullLabel_rejected() {
+    assertThatThrownBy(() -> insertResult((short) 3, null, null, "r", now()))
+        .isInstanceOf(SQLException.class);
+  }
+
+  @Test
+  @DisplayName("H. reason NULL — 위반 (NOT NULL)")
+  void nullReason_rejected() {
+    assertThatThrownBy(() -> insertResult((short) 3, null, "검증 불가", null, now()))
+        .isInstanceOf(SQLException.class);
+  }
+
+  @Test
+  @DisplayName("I. verified_at NULL — 위반 (NOT NULL)")
+  void nullVerifiedAt_rejected() {
+    assertThatThrownBy(() -> insertResult((short) 3, null, "검증 불가", "r", null))
+        .isInstanceOf(SQLException.class);
+  }
+
+  // ── verify_sources.stance CHECK ──────────────────────────────────────
+
+  @Test
+  @DisplayName("J. stance 'supports' — 통과 (Tier 2 허용 값)")
+  void stanceSupports_accepted() {
+    assertThatCode(() -> insertSource(insertParentResult(), "supports")).doesNotThrowAnyException();
+  }
+
+  @Test
+  @DisplayName("K. stance NULL — 통과 (Tier 1은 stance 미사용)")
+  void stanceNull_accepted() {
+    assertThatCode(() -> insertSource(insertParentResult(), null)).doesNotThrowAnyException();
+  }
+
+  @Test
+  @DisplayName("L. stance 'maybe' — 위반 (CHECK 허용 값 아님)")
+  void stanceInvalid_rejected() {
+    assertThatThrownBy(() -> insertSource(insertParentResult(), "maybe"))
+        .isInstanceOf(SQLException.class);
+  }
+
+  // ── articles.session_id NOT NULL ─────────────────────────────────────
+
+  @Test
+  @DisplayName("M. articles.session_id NULL — 위반 (NOT NULL — attachTo 누락 시 DB가 차단)")
+  void articleNullSession_rejected() {
+    assertThatThrownBy(
+            () -> {
+              try (Connection c = conn();
+                  Statement st = c.createStatement()) {
+                st.executeUpdate(
+                    "INSERT INTO articles "
+                        + "(id, session_id, title, body, source_type, extracted_at, created_at, updated_at) "
+                        + "VALUES (gen_random_uuid(), NULL, 't', 'b', 'URL_INPUT', now(), now(), now())");
+              }
+            })
+        .isInstanceOf(SQLException.class);
+  }
+}

--- a/app/src/test/java/com/truthscope/web/support/AbstractIntegrationTest.java
+++ b/app/src/test/java/com/truthscope/web/support/AbstractIntegrationTest.java
@@ -25,7 +25,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  */
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @Testcontainers(disabledWithoutDocker = true)
-@TestPropertySource(properties = {"spring.jpa.hibernate.ddl-auto=create-drop"})
+@TestPropertySource(
+    properties = {"spring.jpa.hibernate.ddl-auto=create-drop", "spring.flyway.enabled=false"})
 public abstract class AbstractIntegrationTest {
 
   @ServiceConnection static final PostgreSQLContainer<?> POSTGRES;

--- a/core/src/main/java/com/truthscope/web/entity/enums/Verdict.java
+++ b/core/src/main/java/com/truthscope/web/entity/enums/Verdict.java
@@ -1,0 +1,28 @@
+package com.truthscope.web.entity.enums;
+
+/**
+ * Claim 검증 판정값 (5단계).
+ *
+ * <p>Phase 53 결정 D-053-5에서 LOCK된 고정 값이다. 정보통신망법 70조(명예훼손) 및 AI 기본법 2026.1 제20조 대응 논거에 따라, 자동 검증
+ * 시스템은 단정적 참 또는 거짓 외에 "판단 불가" 계열 값을 명시적으로 가져야 한다 (도메인 원칙 "모르면 모른다").
+ *
+ * <ul>
+ *   <li>{@link #SUPPORTED} — 출처가 Claim을 뒷받침함
+ *   <li>{@link #CONTRADICTED} — 출처가 Claim과 배치됨
+ *   <li>{@link #INSUFFICIENT} — 근거 부족으로 판정 불가 (Tier 3, score = NULL)
+ *   <li>{@link #TIME_SENSITIVE} — 시점 의존 사실 (재검증 필요, supersede 대상)
+ *   <li>{@link #OUT_OF_SCOPE} — 검증 범위 밖 (의견 또는 예측, ADR-007 스코프 경계 정합)
+ * </ul>
+ *
+ * <p>이 enum이 {@code verification_results.label}(현재 VARCHAR(30) String)을 대체할지, 별도 컬럼으로 신설될지는
+ * ADR-014(라벨 enum 마이그레이션 — 조사 대기)에서 확정한다. 본 클래스는 값 정의만 박제하며 DB 매핑 전략은 ADR-014 확정 전까지 사용처에 연결하지 않는다.
+ *
+ * <p>Entity 필드 연결 시 backend-conventions 규칙대로 {@code @Enumerated(EnumType.STRING)} 의무 (ORDINAL 금지).
+ */
+public enum Verdict {
+  SUPPORTED,
+  CONTRADICTED,
+  INSUFFICIENT,
+  TIME_SENSITIVE,
+  OUT_OF_SCOPE
+}

--- a/docs/architecture/decisions/ADR-009-v2-integrity-hardening.md
+++ b/docs/architecture/decisions/ADR-009-v2-integrity-hardening.md
@@ -1,0 +1,130 @@
+---
+number: "009"
+title: "V2 Data Integrity Hardening Migration"
+status: "Accepted"
+date: "2026-05-22"
+authors: ["KWONSEOK02"]
+---
+
+# ADR-009 — V2 Data Integrity Hardening Migration
+
+## Context
+
+Phase 52(ADR-008)가 Flyway를 마이그레이션 표준으로 채택하고 `V1__init_schema.sql`을 작성·Supabase 적용·체크섬 동결했다. V1은 의도적으로 엔티티 파생 DDL(컬럼·타입·PK·UNIQUE·plain FK)만 담았고, 도메인 무결성 제약은 후속으로 미뤘다 — `docs/md/10_erd.md` 0-2 backlog가 그 미뤄진 항목을 박제한다.
+
+미뤄진 핵심은 `verification_results`의 3-Tier Cascade 불변식이다. `.claude/rules/domain-logic.md`의 "모르면 모른다" 원칙상 Tier 3(검증 불가)은 score가 반드시 NULL이어야 하고 Tier 1/2는 0~100 점수를 가져야 한다. V1에는 이 제약이 없어 `tier=3 + score=50`처럼 도메인을 위반하는 row가 DB 레벨에서 차단되지 않는다. Phase 54 cross-review(codex gpt-5.5 thread `019e39df`)가 이 누락을 High로 판정하고 "후속 backlog가 아니라 V1 직후 즉시 V2, 6/8 제출 blocker"로 격상했다.
+
+제약 조건:
+- **V1 동결**: `flyway_schema_history` v1에 체크섬이 기록돼 V1을 1바이트라도 수정하면 다음 부팅이 checksum mismatch로 실패한다. 모든 스키마 변경은 신규 `V2+` ALTER여야 한다(ADR-008 표준).
+- **데이터 0건 시점**: Supabase는 V1로 막 생성돼 데이터가 없다. NOT NULL/CHECK 추가가 지금은 무비용이지만, 앱이 데이터를 쓰기 시작한 뒤엔 불량 row가 V2 적용을 막는다.
+- **회귀 0**: 기존 131개 테스트가 green을 유지해야 한다.
+
+관련 ADR:
+- ADR-008(Database Migration Standard) — 본 ADR의 직계 선행. V1 동결 + 신규 V*.sql ALTER 패턴.
+- ADR-006(LLM Behavior Gates) — 무관.
+
+## Decision
+
+We will add `V2__hardening.sql` — V1을 수정하지 않는 ALTER 전용 마이그레이션 — 으로 데이터 무결성 제약을 복원한다.
+
+### §1 verification_results 복합 불변식
+
+다음 CHECK 제약을 추가한다:
+
+```sql
+CHECK (
+    (tier = 3 AND score IS NULL)
+    OR (tier IN (1, 2) AND score IS NOT NULL AND score BETWEEN 0 AND 100)
+)
+```
+
+Phase 54 D8의 원안 표현은 `(tier=3 AND score IS NULL) OR (tier IN (1,2) AND score BETWEEN 0 AND 100)`였다. 여기에 **`score IS NOT NULL` 항을 추가**한다. 이는 D8 결정을 바꾸는 것이 아니라 D8의 의도를 SQL로 정확히 인코딩하는 것이다 — 원안 표현은 SQL 3치 논리(three-valued logic) 구멍이 있다. `tier=1, score=NULL`이면 첫 항은 FALSE, 둘째 항은 `TRUE AND NULL = NULL`, `FALSE OR NULL = NULL`이 되어 CHECK가 통과한다(CHECK는 FALSE일 때만 거부). `score IS NOT NULL` 항이 둘째 항을 FALSE로 만들어 이 구멍을 닫는다. `tier`에 NOT NULL을 함께 걸어 `tier=NULL`로 전체가 NULL이 되는 경로도 차단한다.
+
+### §2 verify_sources.stance 허용 값
+
+`CHECK (stance IN ('supports', 'refutes', 'neutral'))`를 추가한다. Tier 1 출처는 stance가 NULL이며, `NULL IN (...)`은 NULL로 평가돼 CHECK가 자동 허용한다 — 별도 NULL 허용 절이 불필요하다. ERD 원안의 CHECK 의도(Medium)를 최소 위험으로 복원하며, `SourceStance` enum 승격은 엔티티 타입 변경을 동반하므로 별도 트랙으로 남긴다.
+
+### §3 NOT NULL 적용 범위
+
+`verification_results`는 `tier/label/reason/verified_at`에 NOT NULL을 건다(Phase 54 HANDOFF 명시 4컬럼). 나머지 테이블은 다음 두 부류에만 NOT NULL을 적용한다:
+
+- 현 코드 경로가 항상 채우는 컬럼 — `analysis_sessions`(status/requested_at), `articles`(session_id/title/body/source_type/extracted_at).
+- INSERT 경로가 아직 없어 회귀 위험이 0인 컬럼 — `members`, `claims`, `verification_results`, `verify_sources`, `user_reactions`, `factcheck_cache`, `api_usage_logs`의 ERD 필수 컬럼.
+
+`created_at`와 `updated_at`은 두 컬럼 모두 NOT NULL로 건다. 0-2 backlog의 "생성시각"을 감사 시각 쌍으로 해석한다 — JPA Auditing(`@CreatedDate`/`@LastModifiedDate`)이 INSERT 시 두 값을 모두 채우며, ERD 4절 원안도 `updated_at TIMESTAMPTZ NOT NULL DEFAULT now()`로 쌍을 NOT NULL로 둔다. created_at만 NOT NULL로 두면 일관성이 깨진다.
+
+### §4 DEFAULT
+
+`id`(8개 `@GeneratedValue` 테이블)에 `gen_random_uuid()`, `created_at`/`updated_at`에 `now()`를 DEFAULT로 건다. JPA는 값을 명시 INSERT하므로 이 DEFAULT는 raw SQL·운영 manual SQL용 방어막이며 JPA 경로에는 영향이 없다. `members.id`는 `@GeneratedValue`를 쓰지 않으므로(Supabase Auth uid를 외부에서 주입) DEFAULT를 부여하지 않는다.
+
+### §5 FK ON DELETE 의도 복원
+
+V1은 plain FK 8개를 만들었다. ERD 4절 원안 의도대로 분석 그래프(`session -> article -> claim -> result -> source`)는 `ON DELETE CASCADE`, member 참조는 `ON DELETE SET NULL`(비로그인 분석 허용) 또는 `CASCADE`(member 소유 반응)로 DROP 후 재생성한다.
+
+### §6 일반 인덱스 복원
+
+ERD 4절 원안의 일반 인덱스 9개(`idx_sessions_*` 3, `idx_articles_*` 2, `idx_claims_article`, `idx_vresults_tier`, `idx_usage_*` 2)를 복원한다. `CONCURRENTLY`는 쓰지 않는다 — Flyway가 마이그레이션을 단일 트랜잭션으로 감싸며, 데이터 0건이라 일반 `CREATE INDEX`로 충분하다.
+
+## Status
+
+`Accepted` (2026-05-22)
+
+cross-review 2종 통과 — codex gpt-5.5 thread `019e4f30` PROCEED(High 0건), Claude `code-reviewer` Agent 8-lens PROCEED-WITH-CONDITIONS(조건 = `articles.session_id` NOT NULL 가드 누락, 회귀 테스트 케이스 M 추가로 해소). 사용자 bootRun으로 Supabase(PostgreSQL 17.6)에 V2 적용 확인 — Flyway `Successfully applied 1 migration ... now at version v2`.
+
+## Consequences
+
+### 긍정 (Benefits)
+
+- "모르면 모른다" 도메인 불변식이 코드뿐 아니라 DB 레벨로 강제된다 — 향후 검증 파이프라인(Sprint 2 Service 4종)이 잘못된 row를 쓰면 INSERT가 실패해 즉시 드러난다.
+- `VerificationIntegrityMigrationTest` 회귀 가드 12케이스가 V1+V2 적용 스키마에서 불변식을 영구 검증한다. 후속 마이그레이션이 CHECK를 약화시키면 테스트가 깨진다.
+- 데이터 0건 시점에 착륙해 마이그레이션 비용이 0이다.
+- FK CASCADE 복원으로 분석 세션 삭제 시 하위 그래프가 자동 정리된다.
+
+### 부정 (Drawbacks)
+
+- NOT NULL을 추가한 컬럼을 향후 코드가 채우지 않으면 런타임 INSERT가 실패한다. 이는 hardening의 의도된 효과지만, Sprint 2 Service 구현 시 각 엔티티 빌더가 필수 컬럼을 채우는지 확인해야 한다.
+- `AbstractIntegrationTest`는 `create-drop` + `flyway.enabled=false`라 V2 제약을 검증하지 못한다. V2 제약 검증은 `VerificationIntegrityMigrationTest`(raw JDBC, V1+V2 적용)와 `FlywaySchemaParityTest`(Flyway V1+V2 + `ddl-auto=validate`)가 전담한다.
+
+### 중립 (Neutral)
+
+- Hibernate `validate`는 컬럼 존재·타입만 검사하고 nullable/CHECK/DEFAULT/FK 옵션은 검사하지 않는다. 따라서 V2는 `FlywaySchemaParityTest`의 엔티티 parity 검증에 영향을 주지 않는다(엔티티에 `nullable=false`를 추가할 필요 없음).
+- DB DEFAULT는 JPA 경로에서 inert다(Hibernate가 값을 명시 INSERT). raw SQL에서만 효과가 있다.
+
+## Alternatives Considered
+
+| 대안 | 기각 이유 |
+|------|----------|
+| `articles.url`에 NOT NULL 추가 (ERD 4절 원안·PLAN Part A 표기) | `ArticleSource.TEXT_INPUT` 기사는 외부 URL이 없어 `url`이 NULL이다(`Article.fromText()` javadoc 명시 불변식). url NOT NULL은 이 설계와 모순된다. PLAN Part A의 "url NOT NULL → V2" 표기를 본 ADR이 정정한다. `lang`도 `fromText`가 NULL을 허용하므로 동일하게 제외. |
+| `score IS NOT NULL` 없는 단순 CHECK (D8 원안 표현 그대로) | SQL 3치 논리상 `tier=1, score=NULL`이 CHECK를 통과하는 구멍이 생긴다. domain-logic상 Tier 1/2는 점수가 있어야 하므로 이는 결함이다. `score IS NOT NULL` 항 추가는 D8 결정 변경이 아니라 정확한 인코딩이다. |
+| `verdict` 컬럼 + label 전환을 V2에 함께 탑재 (sprint-2 DISCUSS 제안) | Phase 54 HANDOFF D3("label String 유지, Verdict 미연결")이 변경 금지 결정으로 lock됐다. `.plans/parallel-track-coordination-2026-05-22.md` 5장 Hard Rule이 verdict 컬럼을 sprint-2의 V3로 배정한다. 54 범위 확장은 사용자 승인 + D3 amend가 선행돼야 한다. |
+| `analysis_sessions` tier count·`api_usage_logs` 카운터에 NOT NULL+DEFAULT 0 즉시 적용 (ERD 4절 원안) | 해당 엔티티 필드가 nullable이고 Hibernate는 모든 컬럼을 명시 INSERT(explicit NULL)하므로, NOT NULL을 걸면 DB DEFAULT 0이 적용되지 못해 INSERT가 실패한다. NOT NULL+DEFAULT를 안전하게 적용하려면 엔티티 필드 기본값 동반이 필요하다 — 별도 트랙으로 이연. |
+| `verification_results.claim_id`에 NOT NULL 추가 (ERD 4절 원안) | HANDOFF가 verification_results NOT NULL 대상을 `tier/label/reason/verified_at` 4컬럼으로 명시 enumerate했다. claim_id NOT NULL은 scope 외이며, 회귀 테스트의 FK 격리 패턴(`ErdContractDriftReproductionTest`)과도 정합하지 않는다. 후속 트랙으로 이연. |
+| `factcheck_cache.search_vector`(V3) / RLS 정책(V4) 포함 | 0-2 backlog가 각각 V3(Tier1 한국어 검색 기능 동반)·V4(보안·auth 연동)로 분리 박제. 미사용 인프라 선반영 금지 원칙. |
+
+## References
+
+### Phase 54 산출물
+
+- HANDOFF: `truthscope-web/.plans/54-erd-entity-reconcile/HANDOFF.md` (D1~D8, V2 범위 박제)
+- PLAN: `truthscope-web/.plans/54-erd-entity-reconcile/PLAN.md` (Part B + 6절 cross-review)
+- ERD 정정 정본: `truthscope-web/docs/md/10_erd.md` 0절 (V1 verbatim + 0-2 backlog + 0-3 델타 + 4절 원안 DDL)
+- 병행 트랙 조율: `truthscope-web/.plans/parallel-track-coordination-2026-05-22.md` (ADR 네임스페이스·Flyway 버전·verdict V3 Hard Rule)
+
+### 코드 산출물
+
+- 마이그레이션: `app/src/main/resources/db/migration/V2__hardening.sql`
+- 회귀 가드: `app/src/test/java/com/truthscope/web/drift/VerificationIntegrityMigrationTest.java` (12 케이스)
+- 동결 기준 V1: `app/src/main/resources/db/migration/V1__init_schema.sql`
+
+### 선행 결정·도메인 근거
+
+- ADR-008(Database Migration Standard) — `docs/architecture/decisions/ADR-008-database-migration-standard.md`
+- domain-logic 3-Tier Cascade — `.claude/rules/domain-logic.md` ("모르면 모른다", Tier 3 score=NULL)
+- cross-review thread: codex gpt-5.5 `019e39df-9714-7852-897f-40abe85d4d3b`
+
+## Change Log
+
+| 날짜 | 변경 내용 |
+|------|----------|
+| 2026-05-22 | Status: Accepted — cross-review 2종 통과(codex `019e4f30` PROCEED, Claude reviewer PROCEED-WITH-CONDITIONS) + 회귀 가드 케이스 M(`articles.session_id`) 추가, 131→144 tests green + Supabase v2 적용 확인 |
+| 2026-05-22 | Initial draft (Phase 54 V2 hardening 실행 — V2__hardening.sql + 회귀 가드 작성) |


### PR DESCRIPTION
## 개요

Phase 54 — ERD-엔티티 계약 drift를 해소하고, Flyway를 단일 스키마 진실원으로 세운 뒤(V1), 도메인 무결성 제약을 V2로 복원한다.

3커밋:
- `8fdd8ec` 🗃️db — Flyway V1 초기 스키마 도입 + 와이어링 (엔티티 파생 DDL = 단일 진실원)
- `7bc26a2` ✅test — 스키마 drift 회귀 가드 + Verdict enum
- `574e741` 🗃️db — V2 데이터 무결성 hardening 마이그레이션

## Done

**요구사항 (수용 기준):**
- ERD-엔티티 계약 drift 3건(enum 대소문자 / BaseTime 컬럼 누락 / source_type)이 V1으로 해소된다.
- `verification_results`의 3-Tier Cascade 불변식("모르면 모른다" — Tier 3 score NULL, Tier 1/2 score 0~100 비-NULL)이 DB CHECK로 강제된다.
- 기존 테스트 회귀 0.

**산출물:**
- `app/src/main/resources/db/migration/V1__init_schema.sql` — 엔티티 기준 초기 스키마 (체크섬 동결)
- `app/src/main/resources/db/migration/V2__hardening.sql` — 복합 CHECK + NOT NULL + DEFAULT + FK ON DELETE 복원 + 일반 인덱스 9종. V1 무수정, ALTER만
- `app/src/test/java/com/truthscope/web/drift/` — `EntitySchemaExportTest`, `ErdContractDriftReproductionTest`, `FlywaySchemaParityTest`, `VerificationIntegrityMigrationTest`(신규 13케이스)
- `docs/architecture/decisions/ADR-009-v2-integrity-hardening.md`

**수용 테스트:**
- `./gradlew clean build` BUILD SUCCESSFUL — 144 tests / 27 classes, skipped 0, failures 0
- TDD: V2 회귀 가드 RED(V2 부재) → GREEN
- 회귀 시뮬레이션: V2 복합 CHECK를 `CHECK (true)`로 무력화 시 정확히 3개 테스트(B/C/D) fail — pass-only 아님 입증
- Supabase(PostgreSQL 17.6) 적용 확인 — Flyway `Successfully applied 1 migration ... now at version v2`
- cross-review 2종 통과 — codex gpt-5.5 PROCEED(High 0건), Claude code-reviewer PROCEED-WITH-CONDITIONS(조건 = `articles.session_id` NOT NULL 가드, 케이스 M으로 해소)

<!-- SAFE_OP_START -->
Assumptions: V1은 Supabase `flyway_schema_history` v1에 체크섬 동결됨 — V2는 신규 ALTER만으로 변경. Supabase 데이터 0건 시점이라 NOT NULL/CHECK 추가가 무비용.
Scope: app/src/main/resources/db/migration/, app/src/test/java/com/truthscope/web/drift/, docs/architecture/decisions/
Out-of-scope: verdict 컬럼 도입(sprint-2 V3 + ADR-014), RLS 정책(V4), factcheck_cache.search_vector(V3), analysis_sessions tier count·api_usage_logs 카운터 NOT NULL(엔티티 변경 동반 — 별도 트랙)
<!-- SAFE_OP_END -->

## 설계 판단 (ADR-009 Alternatives 박제)

- 복합 CHECK 둘째 항에 `score IS NOT NULL` 추가 — D8 원안 표현의 SQL 3치 논리 구멍(`tier=1 + score=NULL`이 통과) 차단. D8 결정 변경이 아니라 정확한 인코딩.
- `articles.url`/`lang` NOT NULL 제외 — `ArticleSource.TEXT_INPUT` 기사는 url이 NULL인 설계.
- FK ON DELETE 복원 — 분석 그래프(session→article→claim→result→source)는 CASCADE, member 참조는 SET NULL/CASCADE.

## 참조

- HANDOFF / PLAN: `.plans/54-erd-entity-reconcile/`
- ADR: `docs/architecture/decisions/ADR-008-database-migration-standard.md`(선행), `ADR-009-v2-integrity-hardening.md`
- ERD 정본: `truthscope-web/docs/md/10_erd.md` 0절


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리즈 노트

* **New Features**
  * 데이터베이스 마이그레이션 시스템을 통한 자동화된 스키마 관리 도입
  * 데이터 무결성 제약 강화로 데이터 일관성 개선

* **Chores**
  * 데이터베이스 마이그레이션 지원을 위한 종속성 추가
  * 마이그레이션 설정 및 초기 스키마 구성

* **Tests**
  * 데이터베이스 스키마 검증 및 무결성 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/truthscope-smu/truthscope-web-backend/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->