### PR TITLE
🗃️db: verdict 컬럼 V3 도입 + label NOT NULL 해제

### DIFF
--- a/app/src/main/resources/db/migration/V3__add_verdict_column.sql
+++ b/app/src/main/resources/db/migration/V3__add_verdict_column.sql
@@ -1,0 +1,53 @@
+-- V3 verdict 컬럼 도입 — sprint-2 semantic-cache-correction-layer.
+--
+-- 결정 근거: .plans/sprint-2-.../DISCUSS.md 11-9(VARCHAR+CHECK), 11-11(label DROP NOT NULL = 1b),
+--           11-12(S10 승인), context/decisions/ADR-014-label-enum-migration.md (Accepted).
+-- 원칙(ADR-008 Database Migration Standard): V1 동결, 모든 스키마 변경은 신규 V3+ ALTER.
+--
+-- 박제 결정:
+--  - 무결성 기준 이전: V2가 박은 label NOT NULL은 label이 주 저장값일 때 의미가 있었으나,
+--    Phase 55 이후 모델(verdict 저장, score 수치, TruthLabel 도출, label deprecated)에서는
+--    도메인 무결성을 보호하지 않는다. 무결성은 verdict NOT NULL + 5종 CHECK로 이전한다.
+--  - Supabase 데이터 0건 시점이라 ADD COLUMN NOT NULL(DEFAULT 없이)이 무비용.
+--    데이터가 쌓이면 기존 row를 채울 DEFAULT 또는 백필이 필요해진다.
+--  - label 물리 DROP은 본 V3 미포함 — deprecated 고정 후 후속 V4. correction_registry,
+--    freshness 2컬럼, ADR-009 supersede 5컬럼은 V3 미포함(설계 문서에만, DISCUSS 11-15·11-16).
+
+SET lock_timeout = '5s';
+
+-- ============================================================
+-- 0. 0행 전제 검증 — verdict는 DEFAULT 없이 NOT NULL로 추가되므로 기존 row가
+--    1건이라도 있으면 ADD COLUMN이 NOT NULL 위반으로 실패한다. 전제를 명시적으로
+--    강제해 명확한 메시지로 fail-fast 한다(CodeRabbit PR 리뷰 반영). 데이터가
+--    있으면 임시 DEFAULT 지정 또는 백필 후 NOT NULL 전환으로 재작성해야 한다.
+-- ============================================================
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM verification_results LIMIT 1) THEN
+        RAISE EXCEPTION
+            'V3 requires empty verification_results before adding NOT NULL verdict without default/backfill';
+    END IF;
+END $$;
+
+-- ============================================================
+-- 1. verdict 컬럼 추가 — Verdict 5종 enum, @Enumerated(EnumType.STRING) 정합.
+--    데이터 0행이라 DEFAULT 없이 NOT NULL 직접 추가 가능.
+-- ============================================================
+ALTER TABLE verification_results
+    ADD COLUMN verdict VARCHAR(30) NOT NULL;
+
+-- ============================================================
+-- 2. verdict 허용 값 CHECK — core/.../entity/enums/Verdict.java 5종.
+--    Phase 53 D-053-5 LOCK 값. NULL은 1번 NOT NULL이 이미 차단.
+-- ============================================================
+ALTER TABLE verification_results
+    ADD CONSTRAINT ck_verification_results_verdict
+    CHECK (verdict IN ('SUPPORTED', 'CONTRADICTED', 'INSUFFICIENT', 'TIME_SENSITIVE', 'OUT_OF_SCOPE'));
+
+-- ============================================================
+-- 3. label NOT NULL 해제 — 무결성 기준이 verdict로 이전(DISCUSS 11-11 = 1b).
+--    label은 V3부터 nullable + deprecated(신규 의미 부여 금지), 물리 DROP은 V4.
+--    DROP NOT NULL은 PostgreSQL 카탈로그 변경이라 테이블 스캔 없음 — 데이터 0행이면 무비용.
+-- ============================================================
+ALTER TABLE verification_results
+    ALTER COLUMN label DROP NOT NULL;

--- a/app/src/test/java/com/truthscope/web/drift/VerificationIntegrityMigrationTest.java
+++ b/app/src/test/java/com/truthscope/web/drift/VerificationIntegrityMigrationTest.java
@@ -22,21 +22,26 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
- * V2 무결성 hardening 회귀 가드 — Flyway V1 + V2를 순차 적용한 스키마에서 도메인 불변식이 DB 레벨로 강제됨을 단언한다.
+ * V2/V3 무결성 hardening 회귀 가드 — Flyway V1 + V2 + V3를 순차 적용한 스키마에서 도메인 불변식이 DB 레벨로 강제됨을 단언한다.
  *
  * <p><b>핵심 불변식 (Phase 54 D8):</b> {@code verification_results}는 "모르면 모른다" 원칙을 DB CHECK로 박제한다 — Tier
  * 3은 score가 반드시 NULL(점수 부여 금지), Tier 1/2는 score가 반드시 0~100 사이 비-NULL. {@code
  * .claude/rules/domain-logic.md}의 3-Tier Cascade 규칙이 코드뿐 아니라 스키마에서도 깨지지 않게 한다.
+ *
+ * <p><b>V3 추가 불변식 (sprint-2 semantic-cache-correction-layer):</b> {@code verdict} 컬럼이 {@code NOT
+ * NULL}로 추가되고, 허용 값 CHECK({@code SUPPORTED|CONTRADICTED|INSUFFICIENT|TIME_SENSITIVE|OUT_OF_SCOPE})가
+ * 강제된다. 무결성 기준이 {@code label NOT NULL}에서 {@code verdict NOT NULL + 5종 CHECK}로 이전됐다(DISCUSS 11-11 =
+ * 1b, ADR-014 Accepted). {@code label}은 V3부터 nullable + deprecated.
  *
  * <p><b>pass-only 금지 (feedback_bdd_tdd_not_pass_only):</b> 통과 케이스만이 아니라 위반 케이스가 실제로
  * 거부됨(SQLException)을 함께 단언한다. tier=1 + score=NULL 케이스는 SQL 3치 논리(three-valued logic) 구멍 — 단순 {@code
  * BETWEEN}만으로는 통과해버리는 — 을 V2 CHECK가 {@code score IS NOT NULL} 항으로 닫음을 검증한다.
  *
  * <p>{@link ErdContractDriftReproductionTest}와 같은 raw-JDBC 패턴 — {@code AbstractIntegrationTest}는
- * create-drop이라 V2 ALTER 제약을 검증할 수 없다. 가변 값은 {@link PreparedStatement} 바인딩으로 전달한다.
+ * create-drop이라 V2/V3 ALTER 제약을 검증할 수 없다. 가변 값은 {@link PreparedStatement} 바인딩으로 전달한다.
  */
 @Testcontainers(disabledWithoutDocker = true)
-@DisplayName("V2 무결성 hardening 회귀 가드 (V1 + V2 적용 후)")
+@DisplayName("V2/V3 무결성 hardening 회귀 가드 (V1 + V2 + V3 적용 후)")
 class VerificationIntegrityMigrationTest {
 
   @Container
@@ -44,8 +49,8 @@ class VerificationIntegrityMigrationTest {
 
   private static final String INSERT_RESULT =
       "INSERT INTO verification_results "
-          + "(id, claim_id, tier, label, score, reason, disclaimer, verified_at, created_at, updated_at) "
-          + "VALUES (gen_random_uuid(), NULL, ?, ?, ?, ?, NULL, ?, now(), now())";
+          + "(id, claim_id, tier, label, verdict, score, reason, disclaimer, verified_at, created_at, updated_at) "
+          + "VALUES (gen_random_uuid(), NULL, ?, ?, ?, ?, ?, NULL, ?, now(), now())";
 
   private static final String INSERT_SOURCE =
       "INSERT INTO verify_sources (id, result_id, title, publisher, stance, created_at, updated_at) "
@@ -57,6 +62,7 @@ class VerificationIntegrityMigrationTest {
         Statement st = c.createStatement()) {
       st.execute(readMigration("/db/migration/V1__init_schema.sql"));
       st.execute(readMigration("/db/migration/V2__hardening.sql"));
+      st.execute(readMigration("/db/migration/V3__add_verdict_column.sql"));
     }
   }
 
@@ -79,15 +85,16 @@ class VerificationIntegrityMigrationTest {
 
   /** verification_results 한 건을 INSERT. 가변 컬럼은 바인딩, FK claim_id는 NULL. */
   private static void insertResult(
-      Short tier, Short score, String label, String reason, Timestamp verifiedAt)
+      Short tier, String label, String verdict, Short score, String reason, Timestamp verifiedAt)
       throws SQLException {
     try (Connection c = conn();
         PreparedStatement ps = c.prepareStatement(INSERT_RESULT)) {
       ps.setObject(1, tier);
       ps.setObject(2, label);
-      ps.setObject(3, score);
-      ps.setObject(4, reason);
-      ps.setObject(5, verifiedAt);
+      ps.setObject(3, verdict);
+      ps.setObject(4, score);
+      ps.setObject(5, reason);
+      ps.setObject(6, verifiedAt);
       ps.executeUpdate();
     }
   }
@@ -99,8 +106,8 @@ class VerificationIntegrityMigrationTest {
         ResultSet rs =
             st.executeQuery(
                 "INSERT INTO verification_results "
-                    + "(id, claim_id, tier, label, score, reason, verified_at, created_at, updated_at) "
-                    + "VALUES (gen_random_uuid(), NULL, 3, '검증 불가', NULL, 'r', now(), now(), now()) "
+                    + "(id, claim_id, tier, label, verdict, score, reason, verified_at, created_at, updated_at) "
+                    + "VALUES (gen_random_uuid(), NULL, 3, '검증 불가', 'INSUFFICIENT', NULL, 'r', now(), now(), now()) "
                     + "RETURNING id")) {
       rs.next();
       return rs.getObject("id", UUID.class);
@@ -121,35 +128,37 @@ class VerificationIntegrityMigrationTest {
   @Test
   @DisplayName("A. Tier 3 + score NULL — 통과 (모르면 모른다: 점수 미부여)")
   void tier3NullScore_accepted() {
-    assertThatCode(() -> insertResult((short) 3, null, "검증 불가", "r", now()))
+    assertThatCode(() -> insertResult((short) 3, "검증 불가", "INSUFFICIENT", null, "r", now()))
         .doesNotThrowAnyException();
   }
 
   @Test
   @DisplayName("B. Tier 3 + score 비-NULL(50) — 위반 (Tier 3에 점수 부여 금지)")
   void tier3NonNullScore_rejected() {
-    assertThatThrownBy(() -> insertResult((short) 3, (short) 50, "검증 불가", "r", now()))
+    assertThatThrownBy(
+            () -> insertResult((short) 3, "검증 불가", "INSUFFICIENT", (short) 50, "r", now()))
         .isInstanceOf(SQLException.class);
   }
 
   @Test
   @DisplayName("C. Tier 1 + score 범위 외(150) — 위반 (0~100 초과)")
   void tier1ScoreOutOfRange_rejected() {
-    assertThatThrownBy(() -> insertResult((short) 1, (short) 150, "기관 검증 완료", "r", now()))
+    assertThatThrownBy(
+            () -> insertResult((short) 1, "기관 검증 완료", "SUPPORTED", (short) 150, "r", now()))
         .isInstanceOf(SQLException.class);
   }
 
   @Test
   @DisplayName("D. Tier 1 + score NULL — 위반 (3치 논리 구멍: score IS NOT NULL 항이 닫음)")
   void tier1NullScore_rejected() {
-    assertThatThrownBy(() -> insertResult((short) 1, null, "기관 검증 완료", "r", now()))
+    assertThatThrownBy(() -> insertResult((short) 1, "기관 검증 완료", "SUPPORTED", null, "r", now()))
         .isInstanceOf(SQLException.class);
   }
 
   @Test
   @DisplayName("E. Tier 1 + score 0~100(50) — 통과 (happy path)")
   void tier1ValidScore_accepted() {
-    assertThatCode(() -> insertResult((short) 1, (short) 50, "기관 검증 완료", "r", now()))
+    assertThatCode(() -> insertResult((short) 1, "기관 검증 완료", "SUPPORTED", (short) 50, "r", now()))
         .doesNotThrowAnyException();
   }
 
@@ -158,28 +167,28 @@ class VerificationIntegrityMigrationTest {
   @Test
   @DisplayName("F. tier NULL — 위반 (NOT NULL — 복합 CHECK의 3치 논리 구멍도 함께 닫음)")
   void nullTier_rejected() {
-    assertThatThrownBy(() -> insertResult(null, null, "검증 불가", "r", now()))
+    assertThatThrownBy(() -> insertResult(null, "검증 불가", "INSUFFICIENT", null, "r", now()))
         .isInstanceOf(SQLException.class);
   }
 
   @Test
-  @DisplayName("G. label NULL — 위반 (NOT NULL)")
-  void nullLabel_rejected() {
-    assertThatThrownBy(() -> insertResult((short) 3, null, null, "r", now()))
-        .isInstanceOf(SQLException.class);
+  @DisplayName("G. label NULL — 통과 (V3 label DROP NOT NULL — 무결성 기준이 verdict로 이전)")
+  void nullLabel_accepted() {
+    assertThatCode(() -> insertResult((short) 3, null, "INSUFFICIENT", null, "r", now()))
+        .doesNotThrowAnyException();
   }
 
   @Test
   @DisplayName("H. reason NULL — 위반 (NOT NULL)")
   void nullReason_rejected() {
-    assertThatThrownBy(() -> insertResult((short) 3, null, "검증 불가", null, now()))
+    assertThatThrownBy(() -> insertResult((short) 3, "검증 불가", "INSUFFICIENT", null, null, now()))
         .isInstanceOf(SQLException.class);
   }
 
   @Test
   @DisplayName("I. verified_at NULL — 위반 (NOT NULL)")
   void nullVerifiedAt_rejected() {
-    assertThatThrownBy(() -> insertResult((short) 3, null, "검증 불가", "r", null))
+    assertThatThrownBy(() -> insertResult((short) 3, "검증 불가", "INSUFFICIENT", null, "r", null))
         .isInstanceOf(SQLException.class);
   }
 
@@ -219,6 +228,29 @@ class VerificationIntegrityMigrationTest {
                         + "VALUES (gen_random_uuid(), NULL, 't', 'b', 'URL_INPUT', now(), now(), now())");
               }
             })
+        .isInstanceOf(SQLException.class);
+  }
+
+  // ── verification_results.verdict (V3 — 무결성 기준 이전) ───────────────
+
+  @Test
+  @DisplayName("N1. verdict 'SUPPORTED' — 통과 (Verdict 5종 허용 값)")
+  void verdictValid_accepted() {
+    assertThatCode(() -> insertResult((short) 1, "기관 검증 완료", "SUPPORTED", (short) 50, "r", now()))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  @DisplayName("N2. verdict 'INVALID' — 위반 (ck_verification_results_verdict CHECK)")
+  void verdictInvalid_rejected() {
+    assertThatThrownBy(() -> insertResult((short) 1, "기관 검증 완료", "INVALID", (short) 50, "r", now()))
+        .isInstanceOf(SQLException.class);
+  }
+
+  @Test
+  @DisplayName("N3. verdict NULL — 위반 (NOT NULL — 무결성 기준이 verdict로 이전)")
+  void verdictNull_rejected() {
+    assertThatThrownBy(() -> insertResult((short) 3, "검증 불가", null, null, "r", now()))
         .isInstanceOf(SQLException.class);
   }
 }

--- a/core/src/main/java/com/truthscope/web/entity/VerificationResult.java
+++ b/core/src/main/java/com/truthscope/web/entity/VerificationResult.java
@@ -1,7 +1,10 @@
 package com.truthscope.web.entity;
 
+import com.truthscope.web.entity.enums.Verdict;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -36,6 +39,15 @@ public class VerificationResult extends BaseTimeEntity {
   @Column(name = "tier")
   private Short tier;
 
+  @Enumerated(EnumType.STRING)
+  @Column(name = "verdict", length = 30, nullable = false)
+  private Verdict verdict;
+
+  /**
+   * @deprecated Tier 파생 표시값(legacy). 무결성 기준은 V3부터 verdict로 이전됐다. V3에서 nullable 전환, 물리 DROP은 V4 예정.
+   *     신규 의미 부여 금지(ADR-014 Accepted).
+   */
+  @Deprecated
   @Column(name = "label", length = 30)
   private String label;
 


### PR DESCRIPTION
## Summary

- Phase: sprint-2-semantic-cache-correction-layer (verdict 도입 트랙)
- `verification_results`에 `verdict` 5종 enum 컬럼을 Flyway V3로 도입하고, 무결성 기준을 `label`에서 `verdict`로 이전한다.
- V3 마이그레이션: 0행 전제 검증(`DO` 블록) → `verdict VARCHAR(30) NOT NULL` 추가 → `ck_verification_results_verdict` CHECK 5종 → `label DROP NOT NULL`. label은 deprecated 고정(물리 DROP은 후속 V4).
- 동반: `VerificationResult` 엔티티 verdict 필드(`@Enumerated(EnumType.STRING)`) 추가와 label `@Deprecated` 표기, `VerificationIntegrityMigrationTest` 갱신(V3 적용, verdict 케이스 N1~N3, label NULL 허용 검증 전환).
- 결정 근거: ADR-014(Accepted), DISCUSS 11-9/11-11/11-12. enum 표현은 VARCHAR + CHECK(native PG enum 미채택), verdict는 데이터 0행 시점이라 NOT NULL 직접 도입.

<!-- SAFE_OP_START -->
Assumptions: verification_results 데이터 0행 전제. V3가 `DO` 블록으로 이 전제를 명시 강제하며, 1건이라도 있으면 명확한 메시지로 fail-fast 한다. 그 외 기본값에서 벗어난 가정 없음.
Scope: app/src/main/resources/db/migration/V3__add_verdict_column.sql, core/src/main/java/com/truthscope/web/entity/VerificationResult.java, app/src/test/java/com/truthscope/web/drift/VerificationIntegrityMigrationTest.java
Out-of-scope: correction_registry / freshness / ADR-009 supersede 컬럼(설계 문서에만, V3 미포함), label 물리 DROP(후속 V4), ADR-014 문서(워크스페이스 레포 별도)
<!-- SAFE_OP_END -->

## Done

요구사항 (검증 가능한 AC):
- `verification_results.verdict`는 `VARCHAR(30) NOT NULL`이고 5종(SUPPORTED, CONTRADICTED, INSUFFICIENT, TIME_SENSITIVE, OUT_OF_SCOPE)만 허용한다 — 허용 값 INSERT 통과, 미허용 값과 NULL INSERT는 거부.
- `label`의 NOT NULL 제약이 해제된다 — label NULL INSERT가 허용된다.
- 기존 row가 존재하는 상태에서 V3를 적용하면 명확한 예외 메시지로 즉시 실패한다.

산출물:
- `V3__add_verdict_column.sql` (신규 Flyway 마이그레이션)
- `VerificationResult.java` (verdict 필드 추가, label `@Deprecated`)
- `VerificationIntegrityMigrationTest.java` (V3 적용 + verdict 케이스 N1~N3 + G 케이스 전환)

수용 테스트 (integration, Testcontainers PostgreSQL):
- `VerificationIntegrityMigrationTest` 16건 — V1+V2+V3 적용 후 verdict CHECK/NOT NULL, label nullable, tier-score 불변식 검증
- `FlywaySchemaParityTest` 1건 — V3 포함 스키마에 대해 엔티티 `ddl-auto=validate` 통과

## Verification

- [✅] `./gradlew build` — BUILD SUCCESSFUL, Spotless/Checkstyle warning 0건
- [✅] `./gradlew test` — 147 tests, skipped 0, failures 0, errors 0
- [✅] 회귀 시뮬레이션 ABC — schema CHECK / entity-schema parity / migration contract 3계층 무력화로 비-tautological 입증
- [✅] CodeRabbit 리뷰 반영 — V3에 0행 전제 검증 `DO` 블록 추가(마이그레이션 fail-fast)
- E2E — N/A (스키마 전용 변경, UI 없음)

## Related

- Plan / Checklist: 워크스페이스 레포 `.plans/sprint-2-semantic-cache-correction-layer/` (PLAN.md, CHECKLIST.md, regression-sim/)
- ADR-014 (label-enum-migration, Accepted)