### PR TITLE
✨feat(claim): ClaimExtractor interface + stub (Phase 19 S2-04)

### DIFF
--- a/app/src/main/java/com/truthscope/web/service/claim/ClaimExtractorService.java
+++ b/app/src/main/java/com/truthscope/web/service/claim/ClaimExtractorService.java
@@ -39,9 +39,14 @@ public interface ClaimExtractorService {
    * <p>정규화 이후 의미가 동일한 두 claim은 {@link ExtractedClaim#equals(Object)}로 같다고 판정된다 — 후속 dedupe 단계는
    * {@code Stream.distinct()} 또는 {@code Set} 자료구조로 가능하다.
    *
+   * <p>contract: {@code raw.text}와 {@code raw.sortOrder}는 non-null 의무. {@code raw.importance}만 null
+   * 허용(MEDIUM으로 보강). {@code sortOrder}는 정렬 키 의도로 도입됐고 무의미한 기본값이 없으므로 호출자가 명시해야 한다 — Phase 55 점수 산식이
+   * 향후 sortOrder를 정렬 키로 사용해도 NPE/잘못된 순서가 발생하지 않도록 strict 정책을 유지한다.
+   *
    * @param raw 정규화 전 claim
    * @return 정규화된 claim (입력 객체와 같은 인스턴스가 아닐 수 있다)
-   * @throws IllegalArgumentException {@code raw} 또는 {@code raw.text}가 null인 경우
+   * @throws IllegalArgumentException {@code raw}, {@code raw.text}, 또는 {@code raw.sortOrder}가 null인
+   *     경우
    */
   ExtractedClaim normalize(ExtractedClaim raw);
 }

--- a/app/src/main/java/com/truthscope/web/service/claim/ClaimExtractorService.java
+++ b/app/src/main/java/com/truthscope/web/service/claim/ClaimExtractorService.java
@@ -1,0 +1,47 @@
+package com.truthscope.web.service.claim;
+
+import com.truthscope.web.dto.response.ExtractedClaim;
+import java.util.List;
+
+/**
+ * Article 본문에서 사실 주장(claim)을 추출하고 정규화하는 input port.
+ *
+ * <p>Sprint 3 실구현체는 {@code gemini-3.1-flash-lite-preview} (1순위) / {@code gemini-2.5-flash-lite}
+ * (폴백) 모델을 호출한다. {@code gemini-2.0-flash-lite}는 본 프로젝트에서 사용하지 않는다.
+ *
+ * <p>Sprint 2 현 시점은 contract 확정용 stub({@link ClaimExtractorStubService})만 제공. Sprint 3에서 stub을 실 호출
+ * 구현체로 교체할 때 본 인터페이스는 그대로 유지된다.
+ *
+ * <p>네이밍 규칙: ArchitectureTest serviceNaming 룰이 {@code ..service..} 패키지의 public top-level 클래스에
+ * {@code Service} 접미사를 의무화하므로 인터페이스 이름은 {@code ClaimExtractorService}이다 (도메인 어휘는 "ClaimExtractor"지만
+ * 코드 식별자는 stereotype 규칙을 우선한다).
+ *
+ * <p>본 인터페이스는 Phase 55 신뢰도 점수 4함수의 입력 생산자다 — 점수 산식이 요구하는 claim 단위 contract(정규화된 text + importance +
+ * sortOrder)를 본 인터페이스가 책임진다.
+ */
+public interface ClaimExtractorService {
+
+  /**
+   * Article 본문에서 claim 목록을 추출한다.
+   *
+   * <p>Stub은 fixture 고정값을 반환한다. 실구현체는 Gemini API를 호출한다. 본문이 null/blank이면 빈 리스트를 반환한다 (예외를 던지지 않는다 —
+   * 빈 본문은 정상 흐름).
+   *
+   * @param articleBody Article 본문 (null/blank 허용 — 빈 리스트 반환)
+   * @return 추출된 claim 목록 (sortOrder 오름차순)
+   */
+  List<ExtractedClaim> extract(String articleBody);
+
+  /**
+   * Claim을 정규화한다. {@code text}의 앞뒤 공백 제거 + 내부 연속 공백을 단일 공백으로 축소 + {@code importance}가 null이면 {@link
+   * com.truthscope.web.entity.enums.ClaimImportance#MEDIUM}으로 채운다.
+   *
+   * <p>정규화 이후 의미가 동일한 두 claim은 {@link ExtractedClaim#equals(Object)}로 같다고 판정된다 — 후속 dedupe 단계는
+   * {@code Stream.distinct()} 또는 {@code Set} 자료구조로 가능하다.
+   *
+   * @param raw 정규화 전 claim
+   * @return 정규화된 claim (입력 객체와 같은 인스턴스가 아닐 수 있다)
+   * @throws IllegalArgumentException {@code raw} 또는 {@code raw.text}가 null인 경우
+   */
+  ExtractedClaim normalize(ExtractedClaim raw);
+}

--- a/app/src/main/java/com/truthscope/web/service/claim/ClaimExtractorStubService.java
+++ b/app/src/main/java/com/truthscope/web/service/claim/ClaimExtractorStubService.java
@@ -3,7 +3,7 @@ package com.truthscope.web.service.claim;
 import com.truthscope.web.dto.response.ExtractedClaim;
 import com.truthscope.web.entity.enums.ClaimImportance;
 import java.util.List;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 /**
  * {@link ClaimExtractorService}의 Sprint 2 stub 구현.
@@ -12,10 +12,10 @@ import org.springframework.stereotype.Component;
  * {@code gemini-2.5-flash-lite} (폴백) 호출 구현체로 교체된다. {@code gemini-2.0-flash-lite}는 본 프로젝트에서 사용하지
  * 않는다.
  *
- * <p>stub은 Spring Context에서 단일 빈으로 등록된다. Sprint 3 실구현체 도입 시 본 stub의 {@code @Component}를 제거하거나
+ * <p>stub은 Spring Context에서 단일 빈으로 등록된다. Sprint 3 실구현체 도입 시 본 stub의 {@code @Service}를 제거하거나
  * {@code @Profile("!production")}으로 격리한다.
  */
-@Component
+@Service
 public class ClaimExtractorStubService implements ClaimExtractorService {
 
   private static final List<ExtractedClaim> FIXTURE =
@@ -51,6 +51,9 @@ public class ClaimExtractorStubService implements ClaimExtractorService {
     }
     if (raw.getText() == null) {
       throw new IllegalArgumentException("claim text는 null일 수 없습니다");
+    }
+    if (raw.getSortOrder() == null) {
+      throw new IllegalArgumentException("claim sortOrder는 null일 수 없습니다");
     }
     String canonicalText = raw.getText().trim().replaceAll("\\s+", " ");
     ClaimImportance canonicalImportance =

--- a/app/src/main/java/com/truthscope/web/service/claim/ClaimExtractorStubService.java
+++ b/app/src/main/java/com/truthscope/web/service/claim/ClaimExtractorStubService.java
@@ -1,0 +1,64 @@
+package com.truthscope.web.service.claim;
+
+import com.truthscope.web.dto.response.ExtractedClaim;
+import com.truthscope.web.entity.enums.ClaimImportance;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@link ClaimExtractorService}의 Sprint 2 stub 구현.
+ *
+ * <p>실제 Gemini API 호출 대신 fixture 3건을 반환한다. Sprint 3에서 {@code gemini-3.1-flash-lite-preview} (1순위) /
+ * {@code gemini-2.5-flash-lite} (폴백) 호출 구현체로 교체된다. {@code gemini-2.0-flash-lite}는 본 프로젝트에서 사용하지
+ * 않는다.
+ *
+ * <p>stub은 Spring Context에서 단일 빈으로 등록된다. Sprint 3 실구현체 도입 시 본 stub의 {@code @Component}를 제거하거나
+ * {@code @Profile("!production")}으로 격리한다.
+ */
+@Component
+public class ClaimExtractorStubService implements ClaimExtractorService {
+
+  private static final List<ExtractedClaim> FIXTURE =
+      List.of(
+          ExtractedClaim.builder()
+              .text("정부는 2026년 경제성장률 전망치를 2.1%로 발표했다.")
+              .importance(ClaimImportance.HIGH)
+              .sortOrder((short) 0)
+              .build(),
+          ExtractedClaim.builder()
+              .text("전문가들은 수출 회복세가 주요 요인이라고 분석했다.")
+              .importance(ClaimImportance.MEDIUM)
+              .sortOrder((short) 1)
+              .build(),
+          ExtractedClaim.builder()
+              .text("일부 학계는 글로벌 금리 인하 가능성을 변수로 지적했다.")
+              .importance(ClaimImportance.LOW)
+              .sortOrder((short) 2)
+              .build());
+
+  @Override
+  public List<ExtractedClaim> extract(String articleBody) {
+    if (articleBody == null || articleBody.isBlank()) {
+      return List.of();
+    }
+    return FIXTURE;
+  }
+
+  @Override
+  public ExtractedClaim normalize(ExtractedClaim raw) {
+    if (raw == null) {
+      throw new IllegalArgumentException("raw claim은 null일 수 없습니다");
+    }
+    if (raw.getText() == null) {
+      throw new IllegalArgumentException("claim text는 null일 수 없습니다");
+    }
+    String canonicalText = raw.getText().trim().replaceAll("\\s+", " ");
+    ClaimImportance canonicalImportance =
+        raw.getImportance() == null ? ClaimImportance.MEDIUM : raw.getImportance();
+    return ExtractedClaim.builder()
+        .text(canonicalText)
+        .importance(canonicalImportance)
+        .sortOrder(raw.getSortOrder())
+        .build();
+  }
+}

--- a/app/src/test/java/com/truthscope/web/service/claim/ClaimExtractorStubServiceTest.java
+++ b/app/src/test/java/com/truthscope/web/service/claim/ClaimExtractorStubServiceTest.java
@@ -68,7 +68,7 @@ class ClaimExtractorStubServiceTest {
 
     @Test
     @DisplayName("앞뒤_공백_+_내부_연속_공백이_다른_두_claim은_정규화_후_equals로_동일하다")
-    void duplicateInput_returnsDeduped() {
+    void 앞뒤_공백_내부_공백이_다른_두_claim은_정규화_후_equals로_동일하다() {
       ExtractedClaim raw1 =
           ExtractedClaim.builder()
               .text("  정부는   2026년    경제성장률을   발표했다.  ")
@@ -122,6 +122,21 @@ class ClaimExtractorStubServiceTest {
       assertThatThrownBy(() -> extractor.normalize(raw))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("text");
+    }
+
+    @Test
+    @DisplayName("sortOrder가_null이면_IllegalArgumentException을_던진다")
+    void sortOrder가_null이면_IllegalArgumentException을_던진다() {
+      ExtractedClaim raw =
+          ExtractedClaim.builder()
+              .text("주장 본문")
+              .importance(ClaimImportance.HIGH)
+              .sortOrder(null)
+              .build();
+
+      assertThatThrownBy(() -> extractor.normalize(raw))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("sortOrder");
     }
   }
 }

--- a/app/src/test/java/com/truthscope/web/service/claim/ClaimExtractorStubServiceTest.java
+++ b/app/src/test/java/com/truthscope/web/service/claim/ClaimExtractorStubServiceTest.java
@@ -1,0 +1,127 @@
+package com.truthscope.web.service.claim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.truthscope.web.dto.response.ExtractedClaim;
+import com.truthscope.web.entity.enums.ClaimImportance;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * ClaimExtractorStubService 단위 테스트.
+ *
+ * <p>Spring Context 불필요 — {@code new ClaimExtractorStubService()}로 직접 인스턴스화한다. Sprint 3 실 Gemini
+ * 구현체로 교체될 때 본 테스트는 stub 동작 박제로 보존된다 (계약 회귀 감지용).
+ */
+@DisplayName("ClaimExtractorStubService 단위 테스트")
+class ClaimExtractorStubServiceTest {
+
+  private ClaimExtractorService extractor;
+
+  @BeforeEach
+  void setUp() {
+    extractor = new ClaimExtractorStubService();
+  }
+
+  @Nested
+  @DisplayName("extract: 본문에서 claim 추출")
+  class Extract {
+
+    @Test
+    @DisplayName("정상_본문이면_fixture_claim_3건을_sortOrder_오름차순으로_반환한다")
+    void 정상_본문이면_fixture_claim_3건을_반환한다() {
+      String body = "정부는 2026년 경제성장률 전망치를 발표했다. 전문가들은 수출 회복세를 주요 요인으로 분석했다.";
+
+      List<ExtractedClaim> result = extractor.extract(body);
+
+      assertThat(result).hasSize(3);
+      assertThat(result)
+          .extracting(ExtractedClaim::getSortOrder)
+          .containsExactly((short) 0, (short) 1, (short) 2);
+      assertThat(result)
+          .extracting(ExtractedClaim::getImportance)
+          .containsExactly(ClaimImportance.HIGH, ClaimImportance.MEDIUM, ClaimImportance.LOW);
+      assertThat(result).allSatisfy(c -> assertThat(c.getText()).isNotBlank());
+    }
+
+    @ParameterizedTest(name = "입력 = [{0}]")
+    @DisplayName("null_또는_blank_본문이면_빈_리스트를_반환한다")
+    @NullSource
+    @ValueSource(strings = {"", " ", "   ", "\n", "\t"})
+    void null_또는_blank_본문이면_빈_리스트를_반환한다(String emptyBody) {
+      List<ExtractedClaim> result = extractor.extract(emptyBody);
+
+      assertThat(result).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("normalize: claim canonical form 생성")
+  class Normalize {
+
+    @Test
+    @DisplayName("앞뒤_공백_+_내부_연속_공백이_다른_두_claim은_정규화_후_equals로_동일하다")
+    void duplicateInput_returnsDeduped() {
+      ExtractedClaim raw1 =
+          ExtractedClaim.builder()
+              .text("  정부는   2026년    경제성장률을   발표했다.  ")
+              .importance(ClaimImportance.HIGH)
+              .sortOrder((short) 0)
+              .build();
+      ExtractedClaim raw2 =
+          ExtractedClaim.builder()
+              .text("정부는 2026년 경제성장률을 발표했다.")
+              .importance(ClaimImportance.HIGH)
+              .sortOrder((short) 0)
+              .build();
+
+      ExtractedClaim n1 = extractor.normalize(raw1);
+      ExtractedClaim n2 = extractor.normalize(raw2);
+
+      assertThat(n1.getText()).isEqualTo("정부는 2026년 경제성장률을 발표했다.");
+      assertThat(n1).isEqualTo(n2);
+      assertThat(List.of(n1, n2).stream().distinct().toList()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("importance가_null이면_MEDIUM으로_채워진다")
+    void null_importance면_MEDIUM으로_채워진다() {
+      ExtractedClaim raw =
+          ExtractedClaim.builder().text("주장 본문").importance(null).sortOrder((short) 0).build();
+
+      ExtractedClaim normalized = extractor.normalize(raw);
+
+      assertThat(normalized.getImportance()).isEqualTo(ClaimImportance.MEDIUM);
+    }
+
+    @Test
+    @DisplayName("raw가_null이면_IllegalArgumentException을_던진다")
+    void raw가_null이면_IllegalArgumentException을_던진다() {
+      assertThatThrownBy(() -> extractor.normalize(null))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("raw");
+    }
+
+    @Test
+    @DisplayName("text가_null이면_IllegalArgumentException을_던진다")
+    void text가_null이면_IllegalArgumentException을_던진다() {
+      ExtractedClaim raw =
+          ExtractedClaim.builder()
+              .text(null)
+              .importance(ClaimImportance.HIGH)
+              .sortOrder((short) 0)
+              .build();
+
+      assertThatThrownBy(() -> extractor.normalize(raw))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("text");
+    }
+  }
+}

--- a/core/src/main/java/com/truthscope/web/dto/response/ExtractedClaim.java
+++ b/core/src/main/java/com/truthscope/web/dto/response/ExtractedClaim.java
@@ -1,0 +1,34 @@
+package com.truthscope.web.dto.response;
+
+import com.truthscope.web.entity.enums.ClaimImportance;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * ClaimExtractor가 산출하는 단일 claim 값 객체.
+ *
+ * <p>{@link com.truthscope.web.entity.Claim} entity의 영속 전 contract 표현이다. id / article 참조 / 감사 필드는
+ * 영속 시점에 결정되므로 본 DTO에 없다.
+ *
+ * <p>{@code equals/hashCode}는 normalize 결과 dedupe에 사용되므로 {@code text} + {@code importance} + {@code
+ * sortOrder} 모두 포함한다.
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class ExtractedClaim {
+
+  /** Claim 문장 본문 (정규화 후 trim + 내부 공백 단일화) */
+  private String text;
+
+  /** Claim 중요도 (HIGH/MEDIUM/LOW) */
+  private ClaimImportance importance;
+
+  /** 원문 등장 순서 (0부터 시작) */
+  private Short sortOrder;
+}


### PR DESCRIPTION
<!-- SAFE_OP_START -->
Assumptions: 패키지명 `com.truthscope.web` 사용 (이슈 본문의 `com.checkmate.web`은 레거시). ArchitectureTest serviceNaming 룰이 `..service..` 패키지 public top-level 클래스에 `Service` 접미사를 의무화하므로 인터페이스명을 `ClaimExtractorService`로 한다 (도메인 어휘는 ClaimExtractor 유지, javadoc에 박제).
Scope: core/src/main/java/com/truthscope/web/dto/response/ExtractedClaim.java, app/src/main/java/com/truthscope/web/service/claim/ (2개 신규), app/src/test/java/com/truthscope/web/service/claim/ (1개 신규)
Out-of-scope: 실 Gemini API 호출 (Sprint 3), Claim entity 영속 로직, Article aggregate 연결, Controller wiring
<!-- SAFE_OP_END -->

## Done

표준 Done:

- [✅] **요구사항 목록**:
  - 입력: `String articleBody` (null/blank 허용)
  - 출력: `List<ExtractedClaim>` (extract), `ExtractedClaim` (normalize)
  - 에러: `normalize(null)` 또는 `normalize(raw with null text)` → `IllegalArgumentException`
  - 경계: 빈/공백 body → 빈 리스트, importance null → MEDIUM, 내부 연속 공백 → 단일 공백
- [✅] **산출물 목록**:
  - `core/src/main/java/com/truthscope/web/dto/response/ExtractedClaim.java`
  - `app/src/main/java/com/truthscope/web/service/claim/ClaimExtractorService.java`
  - `app/src/main/java/com/truthscope/web/service/claim/ClaimExtractorStubService.java`
  - `app/src/test/java/com/truthscope/web/service/claim/ClaimExtractorStubServiceTest.java`
- [✅] **수용 테스트**: JUnit 5 단위 테스트 7건(파라미터화 5건 포함). Spring Context 불필요. `./gradlew :app:test --tests *ClaimExtractor*` GREEN.

## Behavior Gates 자체 점검

- [✅] Gate 1 — Goal Defined (Done 위 명시)
- [✅] Gate 2 — Assumption Surfaced (SAFE_OP 마커 위)
- [✅] Gate 3 — Surgical Diff (요청한 인터페이스 + Stub + 테스트만, 인접 파일 변경 0)
- [✅] Gate 4 — Minimum Code (interface 2 메서드 + Stub fixture 3건만. 단일 사용처 추상화 / 발생 불가 시나리오 핸들링 없음)

---

## 관련 Issue

closes #25

## 변경 사항

Sprint 3 실 Gemini 호출 전 **contract 확정용** 입력 port + stub 구현. **Phase 55 신뢰도 점수 4함수의 입력 생산자** 역할.

### ExtractedClaim 값 객체 (core/dto/response)

`Claim` entity의 영속 전 contract 표현. `text` + `importance` + `sortOrder` + `@EqualsAndHashCode`로 normalize 결과 dedupe 지원.

### ClaimExtractorService 인터페이스 (app/service/claim)

- `List<ExtractedClaim> extract(String articleBody)` — Gemini API 호출 (stub은 fixture 고정). null/blank body는 빈 리스트.
- `ExtractedClaim normalize(ExtractedClaim raw)` — canonical form 생성. trim + 내부 연속 공백 단일화 + importance null → MEDIUM. 같은 의미의 두 claim은 `.equals()`로 동일 판정 → 후속 `Stream.distinct()` dedupe 가능.
- javadoc에 Gemini 모델 ID `gemini-3.1-flash-lite-preview` (1순위) / `gemini-2.5-flash-lite` (폴백) 박제. `gemini-2.0-flash-lite` 사용 금지 명시.

### ClaimExtractorStubService @Component

fixture 3건 (HIGH/MEDIUM/LOW + sortOrder 0/1/2). Sprint 3 실구현체로 교체 시 인터페이스 그대로 유지. `@Profile("!production")` 분리 정책은 Sprint 3 진입 시 결정.

### 단위 테스트 7건

- `Extract.정상_본문이면_fixture_claim_3건을_반환한다` (happy)
- `Extract.null_또는_blank_본문이면_빈_리스트를_반환한다` (parameterized 5건 — null/""/" "/"\n"/"\t")
- `Normalize.duplicateInput_returnsDeduped` (canonical form)
- `Normalize.null_importance면_MEDIUM으로_채워진다`
- `Normalize.raw가_null이면_IllegalArgumentException을_던진다`
- `Normalize.text가_null이면_IllegalArgumentException을_던진다`

## 체크리스트

- [✅] 빌드 성공 (`./gradlew build` GREEN)
- [✅] 관련 테스트 통과 (`./gradlew :app:test --tests *ClaimExtractor*` GREEN, 전체 test GREEN)
- [✅] Issue의 수용 기준 모두 충족
  - [✅] ClaimExtractor 인터페이스 메서드 2개 정의
  - [✅] ClaimExtractorStub 단위 테스트 3+ PASS (7건)
  - [✅] `gemini-3.1-flash-lite-preview` 모델 ID 코드/주석에 명시
  - [✅] `./gradlew spotlessApply / checkstyleMain / spotbugsMain / test / build` 모두 PASS
- [✅] 불필요한 console.log / System.out.println 제거 (없음)

## 네이밍 결정 (이슈 본문과의 차이)

이슈 본문은 인터페이스명을 `ClaimExtractor`로 명시하지만, BE 레포 `ArchitectureTest.serviceNaming` 룰이 `..service..` 패키지의 public top-level 클래스에 `Service` 접미사를 의무화한다. 패키지 위치를 옮기면 hexagonal 의미가 흐려지므로 **코드 식별자만 `*Service` 접미사**를 붙이고, **도메인 어휘 "ClaimExtractor"는 javadoc·이슈 본문·옵시디언 노트에서 유지**한다. Sprint 3 실구현체도 `GeminiClaimExtractorService` 등 동일 컨벤션으로 진입 가능.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 기사 본문에서 주장(claim)을 추출하고 정규화하는 기능이 추가되었습니다.
  * 추출된 주장은 중요도(높음/중간/낮음)와 등장 순서로 관리됩니다.

* **Tests**
  * 주장 추출 및 정규화 로직에 대한 단위 테스트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/truthscope-smu/truthscope-web-backend/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->