### PR TITLE
📝docs(env): .env.example에 데이터 소스 환경변수 7건 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,4 +29,11 @@
 # GEMINI_API_KEY=your_gemini_api_key
 # GOOGLE_FACTCHECK_API_KEY=your_factcheck_api_key
 # DEEPL_API_KEY=your_deepl_api_key
+# DATA_GO_KR_KEY=your_data_go_kr_serviceKey         # S3a 정책뉴스 + S3a' 보도자료 (한 키)
+# BIGKINDS_API_KEY=your_bigkinds_api_key            # [MVP 보류 — 2026-04 유료화 전환] 무상 경로: 뉴스빅데이터 해커톤 / 학술 공모 / 스타트업 지원 사업 선정 시 활성화 (context/references/bigkinds-support-programs.md 참조)
+# KOSIS_API_KEY=your_kosis_apiKey                   # S? KOSIS 통계 (Base64, = 패딩 포함 그대로)
+# GDELT_PROJECT_ID=your_gcp_project_id              # GDELT BigQuery (S7 Tier 1.5)
+# GOOGLE_APPLICATION_CREDENTIALS=keys/gdelt-sa.json # GDELT BigQuery service account JSON path
+# NAVER_CLIENT_ID=your_naver_client_id              # 네이버 뉴스 검색 API (developers.naver.com 즉시 발급, 25k건/일/앱)
+# NAVER_CLIENT_SECRET=your_naver_client_secret      # 네이버 뉴스 검색 API client secret
 # SERVER_PORT=8080


### PR DESCRIPTION
<!-- SAFE_OP_START -->
Assumptions: 없음
Scope: .env.example (root)
Out-of-scope: 실제 시크릿 값 없음. application.yml / application-local.yml / 코드 / 테스트 미변경
<!-- SAFE_OP_END -->

## Done

```
요구사항: Sprint 2 데이터 소스 작업에 필요한 환경변수 명을 placeholder로 .env.example에 박제 / 변경: .env.example / 검증: 추가 라인 7건 모두 your_* placeholder, 실제 시크릿 0건 (git grep로 확인 가능)
```

## Behavior Gates 자체 점검

- [✅] Gate 1 — Goal Defined (Micro-Done)
- [✅] Gate 2 — Assumption Surfaced (SAFE_OP 마커 위)
- [✅] Gate 3 — Surgical Diff (.env.example 7줄 추가만, 기존 라인 미변경)
- [✅] Gate 4 — Minimum Code (placeholder + 짧은 주석만)

trivial 트리거 충족: 7 LOC + 새 의존성 0 + 새 파일 0 + 동작 변경 0 (docs-only, 공개 인터페이스/UX/관측성/성능 모두 미영향).

---

## 관련 Issue

해당 이슈 없음 (Sprint 2 데이터 소스 작업 사전 docs 정리).

## 변경 사항

`.env.example`에 다음 환경변수 placeholder 추가:

- `DATA_GO_KR_KEY` — S3a 정책뉴스 + S3a' 보도자료 (한 키)
- `BIGKINDS_API_KEY` — MVP 보류(2026-04 유료화) 명시 + 무상 경로 reference
- `KOSIS_API_KEY` — Base64 padding(`=`) 포함 그대로
- `GDELT_PROJECT_ID` — GDELT BigQuery (S7 Tier 1.5)
- `GOOGLE_APPLICATION_CREDENTIALS` — `keys/gdelt-sa.json` 경로 컨벤션 명시 (실제 JSON은 PR #61의 `.gitignore` 보호 패턴으로 추적 제외)
- `NAVER_CLIENT_ID` / `NAVER_CLIENT_SECRET` — 네이버 뉴스 검색 API (developers.naver.com 즉시 발급, 25k건/일/앱)

## 체크리스트

- [✅] 빌드 성공 (코드 변경 없음 — N/A)
- [✅] 관련 테스트 통과 (코드 변경 없음 — N/A)
- [✅] Issue의 수용 기준 모두 충족 (해당 이슈 없음, docs)
- [✅] 불필요한 console.log / System.out.println 제거 (N/A)
- [✅] 실 시크릿 0건 (모든 추가 라인이 `your_*` placeholder)

## 머지 순서 권장

PR #61 (`chore/gitignore-keys-protection`) 머지 후 본 PR 머지. `GOOGLE_APPLICATION_CREDENTIALS=keys/gdelt-sa.json` 라인이 가리키는 `keys/` 경로가 `.gitignore` 보호 패턴으로 먼저 박제되어야 일관됨.
