### PR TITLE
🔧chore(sync): main→dev #61/#63 hotfix 동기화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,4 +29,11 @@
 # GEMINI_API_KEY=your_gemini_api_key
 # GOOGLE_FACTCHECK_API_KEY=your_factcheck_api_key
 # DEEPL_API_KEY=your_deepl_api_key
+# DATA_GO_KR_KEY=your_data_go_kr_serviceKey         # S3a 정책뉴스 + S3a' 보도자료 (한 키)
+# BIGKINDS_API_KEY=your_bigkinds_api_key            # [MVP 보류 — 2026-04 유료화 전환] 무상 경로: 뉴스빅데이터 해커톤 / 학술 공모 / 스타트업 지원 사업 선정 시 활성화 (context/references/bigkinds-support-programs.md 참조)
+# KOSIS_API_KEY=your_kosis_apiKey                   # S? KOSIS 통계 (Base64, = 패딩 포함 그대로)
+# GDELT_PROJECT_ID=your_gcp_project_id              # GDELT BigQuery (S7 Tier 1.5)
+# GOOGLE_APPLICATION_CREDENTIALS=keys/gdelt-sa.json # GDELT BigQuery service account JSON path
+# NAVER_CLIENT_ID=your_naver_client_id              # 네이버 뉴스 검색 API (developers.naver.com 즉시 발급, 25k건/일/앱)
+# NAVER_CLIENT_SECRET=your_naver_client_secret      # 네이버 뉴스 검색 API client secret
 # SERVER_PORT=8080

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,14 @@ application-local.yml
 **/application-local.yml
 
 # ===========================
+# Service Account Credentials (NEVER commit)
+# ===========================
+keys/
+**/keys/
+**/*-sa.json
+**/gdelt-*.json
+
+# ===========================
 # Gradle Wrapper (추적 필요)
 # ===========================
 # gradle/wrapper/gradle-wrapper.jar는 추적함 (팀원 환경 동일성)


### PR DESCRIPTION
## 목적

PR #61(.gitignore service account credential 보호) + PR #63(.env.example 데이터 소스 환경변수 7건 placeholder) main 머지 후 dev 동기화. 두 변경 모두 base=main으로 진입한 hotfix/docs라 dev에 forward 필요.

## 변경 내역

- main(`f3b03bb`) ← dev(`be8b371`). 차이 = 2 머지 커밋(PR #61, #63) + 그에 포함된 `.gitignore` 8줄 + `.env.example` 7줄.

## 안전성

- 두 변경 모두 코드 영향 0건 (docs/build artifact 외 패턴만 변경)
- dev에서 진행 중인 BE #25 PR(#62) base = dev라 본 sync 머지 후 자연 rebase 가능

## 머지 방식

merge commit `--no-ff` (atomic 보존)