### PR TITLE
🐛fix(gemini): 모델 ID -preview 제거로 GA ID 정정

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 | `@Setter` on Entity / `@Data` / `@ToString` on Entity | ArchUnit 룰 — `entityShouldNotExposeSetters` 통과 의무 |
 | `EntityType.ORDINAL` (Enum 매핑) | `@Enumerated(EnumType.STRING)` 강제 — 컬럼 추가/순서 변경 시 데이터 손상 방지 |
 | `FetchType.EAGER` 관계 매핑 | 모든 관계는 `LAZY` 의무 — N+1 회피 |
-| `gemini-2.0-flash-lite` 모델 사용/언급 | 1순위 `gemini-3.1-flash-lite-preview` / 2순위 `gemini-2.5-flash-lite`만 허용 |
+| `gemini-2.0-flash-lite` 모델 사용/언급 | 1순위 `gemini-3.1-flash-lite` / 2순위 `gemini-2.5-flash-lite`만 허용 |
 | `--no-verify` git push (pre-commit/CI hook 우회) | hook 실패 시 원인 수정 의무 |
 | `springdoc-openapi 2.8.6 이하` | Spring Boot 3.5.x 비호환 (HateoasProperties NoSuchMethodError) — **2.8.9+ 필수** |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,6 @@
 
 ## Gemini 모델 — 절대 변경 금지
 
-- 1순위: `gemini-3.1-flash-lite-preview`
+- 1순위: `gemini-3.1-flash-lite` (2026-05-27 GA 전환으로 `-preview` 제거)
 - 2순위 폴백: `gemini-2.5-flash-lite`
 - `gemini-2.0-flash-lite` 언급/사용 금지

--- a/app/src/main/java/com/truthscope/web/gemini/GeminiClient.java
+++ b/app/src/main/java/com/truthscope/web/gemini/GeminiClient.java
@@ -18,7 +18,8 @@ import org.springframework.web.client.RestClient;
  * <p>PLAN §4-1 rev.5 amend 정합:
  *
  * <ul>
- *   <li>{@link #PRIMARY_MODEL} = {@code gemini-3.1-flash-lite-preview} (domain-logic.md lock)
+ *   <li>{@link #PRIMARY_MODEL} = {@code gemini-3.1-flash-lite} (domain-logic.md lock, 2026-05-27 GA
+ *       전환으로 -preview 제거)
  *   <li>{@link #FALLBACK_MODEL} = {@code gemini-2.5-flash-lite} (domain-logic.md lock)
  *   <li>2단계 파싱: {@link GeminiGenerateContentResponse} wrapper 역직렬화 → {@code parts[0].text} 추출 →
  *       {@link ClaimAnalysisPayload} 역직렬화 (rev.5 amend Round 4 CX4-1)
@@ -32,7 +33,7 @@ import org.springframework.web.client.RestClient;
 @Profile("production")
 public class GeminiClient {
 
-  private static final String PRIMARY_MODEL = "gemini-3.1-flash-lite-preview";
+  private static final String PRIMARY_MODEL = "gemini-3.1-flash-lite";
   private static final String FALLBACK_MODEL = "gemini-2.5-flash-lite";
 
   private final RestClient restClient;

--- a/app/src/main/java/com/truthscope/web/service/claim/ClaimExtractorService.java
+++ b/app/src/main/java/com/truthscope/web/service/claim/ClaimExtractorService.java
@@ -6,8 +6,8 @@ import java.util.List;
 /**
  * Article 본문에서 사실 주장(claim)을 추출하고 정규화하는 input port.
  *
- * <p>Sprint 3 실구현체는 {@code gemini-3.1-flash-lite-preview} (1순위) / {@code gemini-2.5-flash-lite}
- * (폴백) 모델을 호출한다. {@code gemini-2.0-flash-lite}는 본 프로젝트에서 사용하지 않는다.
+ * <p>Sprint 3 실구현체는 {@code gemini-3.1-flash-lite} (1순위) / {@code gemini-2.5-flash-lite} (폴백) 모델을
+ * 호출한다. {@code gemini-2.0-flash-lite}는 본 프로젝트에서 사용하지 않는다.
  *
  * <p>Sprint 2 현 시점은 contract 확정용 stub({@link ClaimExtractorStubService})만 제공. Sprint 3에서 stub을 실 호출
  * 구현체로 교체할 때 본 인터페이스는 그대로 유지된다.

--- a/app/src/main/java/com/truthscope/web/service/claim/ClaimExtractorStubService.java
+++ b/app/src/main/java/com/truthscope/web/service/claim/ClaimExtractorStubService.java
@@ -10,9 +10,8 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * {@link ClaimExtractorService}의 Sprint 2 stub 구현.
  *
- * <p>실제 Gemini API 호출 대신 fixture 3건을 반환한다. Sprint 3에서 {@code gemini-3.1-flash-lite-preview} (1순위) /
- * {@code gemini-2.5-flash-lite} (폴백) 호출 구현체로 교체된다. {@code gemini-2.0-flash-lite}는 본 프로젝트에서 사용하지
- * 않는다.
+ * <p>실제 Gemini API 호출 대신 fixture 3건을 반환한다. Sprint 3에서 {@code gemini-3.1-flash-lite} (1순위) / {@code
+ * gemini-2.5-flash-lite} (폴백) 호출 구현체로 교체된다. {@code gemini-2.0-flash-lite}는 본 프로젝트에서 사용하지 않는다.
  *
  * <p>stub은 Spring Context에서 단일 빈으로 등록된다. Sprint 3 실구현체 도입 시 본 stub의 {@code @Service}를 제거하거나
  * {@code @Profile("!production")}으로 격리한다.


### PR DESCRIPTION
<!-- SAFE_OP_START -->
Assumptions: Google AI Studio Gemini 3.1 Flash-Lite GA 전환 (2026-05-27) + 이전 모델 ID `gemini-3.1-flash-lite-preview` API 404 확인 (PowerShell `Invoke-RestMethod` 실측).
Scope: app/src/main/java/.../gemini/GeminiClient.java (PRIMARY_MODEL 상수 + Javadoc), ClaimExtractorService.java + ClaimExtractorStubService.java (Javadoc 참조), CLAUDE.md + AGENTS.md (lock 표).
Out-of-scope: 박제 파일 (.plans/, ADR-008, docs/puml v1.x, docs/md v1.x) — ADR-022 박제 보존 정책 정합. 학교 제출 v1.5 자료. API 키 restriction (GCP Console 별 트랙).
<!-- SAFE_OP_END -->

## 요약

Gemini 3.1 Flash-Lite GA 전환으로 모델 ID `gemini-3.1-flash-lite-preview` API 404 회귀 해소. PRIMARY_MODEL 상수 + Javadoc + lock 7곳 정정.

## Done

- [✅] 운영 코드 3개 정정 (GeminiClient PRIMARY_MODEL + ClaimExtractor 2개 Javadoc)
- [✅] lock 표 2개 정정 (CLAUDE.md + AGENTS.md)
- [✅] `./gradlew spotlessApply compileJava` BUILD SUCCESSFUL 1m6s
- [✅] 신규 ADR-022 박제 (워크스페이스 context/decisions/)
- [ ] 머지 후 사용자 GCP Console에서 API 키 restriction 적용 (2026-06-19 cutoff 회피)

## 검증

PowerShell `Invoke-RestMethod` 실측:
- 이전 ID `gemini-3.1-flash-lite-preview` → HTTP 404
- 신규 ID `gemini-3.1-flash-lite` → HTTP 200 + candidates 응답

## Out-of-scope (별 트랙)

박제 보존 50+ 파일은 ADR-022 정책 정합. 학교 제출 v1.5 자료는 사용자 결정 보류 (2026-06-08 마감 D-12).

Co-authored-by: KWONSEOK02 <gwonseok02@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* AI 모델 버전을 일관되게 업데이트하여 전체 시스템에 적용했습니다. 문서 및 구성 파일에 반영되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/truthscope-smu/truthscope-web-backend/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->