### PR TITLE
✨feat(claim): Gemini Claim Extractor BYOK 통합 (#74)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
 	testImplementation 'org.testcontainers:postgresql'
 	testImplementation 'org.testcontainers:junit-jupiter'
+	// BE #74 (S3-05) — WireMock for BYOK integration test (Gemini API cassette replay)
+	testImplementation 'org.wiremock:wiremock-standalone:3.10.0'
 }
 
 // throwaway 연구 코드(spike)는 워크스페이스 레벨 `truthscope-web/spike/` 독립 Java 프로젝트로 분리됨 (2026-05-04).

--- a/app/src/main/java/com/truthscope/web/audit/KeyFingerprinter.java
+++ b/app/src/main/java/com/truthscope/web/audit/KeyFingerprinter.java
@@ -1,0 +1,47 @@
+package com.truthscope.web.audit;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * BYOK userApiKey의 SHA-256 hex digest 앞 16 hex 문자(8바이트) 반환.
+ *
+ * <p>ADR-004 §(f) "key_fingerprint(해시 앞 8자)" 정합 — DISCUSS rev.3 Q6에서 SHA-256 hex 16자(=8바이트)로 명문화.
+ * 원본 키는 절대 반환·로그 박제 금지.
+ *
+ * <p>위치 선택: {@code com.truthscope.web.audit} (non-service 패키지) — ArchitectureTest의 {@code
+ * ..service..} Service 접미사 의무 룰을 회피.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class KeyFingerprinter {
+
+  private static final int FINGERPRINT_HEX_LENGTH = 16;
+  private static final int FINGERPRINT_BYTE_LENGTH = FINGERPRINT_HEX_LENGTH / 2;
+
+  /**
+   * userApiKey의 SHA-256 hex digest 앞 16 hex 문자 반환.
+   *
+   * @param userApiKey 사용자 Gemini API 키 (null/blank 금지)
+   * @return 16자 hex 문자열 (소문자)
+   * @throws IllegalArgumentException userApiKey가 null/blank인 경우
+   */
+  public static String fingerprint(String userApiKey) {
+    if (userApiKey == null || userApiKey.isBlank()) {
+      throw new IllegalArgumentException("userApiKey는 null/blank일 수 없습니다");
+    }
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(userApiKey.getBytes(StandardCharsets.UTF_8));
+      StringBuilder hex = new StringBuilder(FINGERPRINT_HEX_LENGTH);
+      for (int i = 0; i < FINGERPRINT_BYTE_LENGTH; i++) {
+        hex.append(String.format("%02x", hash[i]));
+      }
+      return hex.toString();
+    } catch (NoSuchAlgorithmException ex) {
+      throw new IllegalStateException("SHA-256 unavailable", ex);
+    }
+  }
+}

--- a/app/src/main/java/com/truthscope/web/controller/NewsController.java
+++ b/app/src/main/java/com/truthscope/web/controller/NewsController.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,14 +22,20 @@ public class NewsController {
   private final AnalysisService analysisService;
 
   /**
-   * 뉴스 기사 분석 요청
+   * 뉴스 기사 분석 요청.
+   *
+   * <p>BE #74 amend: BYOK 사용자 키를 {@code X-User-Gemini-Key} 헤더로 1회성 수신 (ADR-004 §c). 헤더 부재 시 서버 기본 키
+   * 사용.
    *
    * @param request 분석할 뉴스 기사 URL
+   * @param userApiKey BYOK 사용자 Gemini API 키 (헤더 옵션, 없으면 서버 기본 키)
    * @return 생성된 세션 ID와 상태 (201 Created)
    */
   @PostMapping
-  public ResponseEntity<AnalysisResponse> analyze(@Valid @RequestBody AnalysisRequest request) {
-    AnalysisResponse response = analysisService.analyze(request);
+  public ResponseEntity<AnalysisResponse> analyze(
+      @Valid @RequestBody AnalysisRequest request,
+      @RequestHeader(name = "X-User-Gemini-Key", required = false) String userApiKey) {
+    AnalysisResponse response = analysisService.analyze(request, userApiKey);
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 }

--- a/app/src/main/java/com/truthscope/web/gemini/GeminiClient.java
+++ b/app/src/main/java/com/truthscope/web/gemini/GeminiClient.java
@@ -61,8 +61,7 @@ public class GeminiClient {
    */
   @CircuitBreaker(name = "gemini", fallbackMethod = "fallbackStructured")
   public GeminiResponse callStructured(GeminiRequest req, @Nullable String overrideApiKey) {
-    String effectiveKey =
-        (overrideApiKey != null && !overrideApiKey.isBlank()) ? overrideApiKey : this.apiKey;
+    String effectiveKey = resolveEffectiveKey(overrideApiKey);
     GeminiGenerateContentResponse wrapper =
         restClient
             .post()
@@ -116,8 +115,7 @@ public class GeminiClient {
     }
 
     // 1차 5xx/429/timeout — 2차 FALLBACK_MODEL 재시도. effectiveKey 사용 (this.apiKey 하드코딩 금지)
-    String effectiveKey =
-        (overrideApiKey != null && !overrideApiKey.isBlank()) ? overrideApiKey : this.apiKey;
+    String effectiveKey = resolveEffectiveKey(overrideApiKey);
     try {
       GeminiGenerateContentResponse fallbackWrapper =
           restClient
@@ -132,6 +130,16 @@ public class GeminiClient {
     } catch (RuntimeException | JsonProcessingException ex) {
       return GeminiResponse.insufficient(DecisionSource.HEURISTIC_FALLBACK);
     }
+  }
+
+  /**
+   * BYOK overrideApiKey가 있으면 사용, 없으면 서버 기본 키 (CodeRabbit refactor — 중복 계산 헬퍼).
+   *
+   * @param overrideApiKey BYOK 사용자 키 (null/blank → 서버 기본)
+   * @return 실제 사용할 키
+   */
+  private String resolveEffectiveKey(@Nullable String overrideApiKey) {
+    return (overrideApiKey != null && !overrideApiKey.isBlank()) ? overrideApiKey : this.apiKey;
   }
 
   /**

--- a/app/src/main/java/com/truthscope/web/gemini/GeminiClient.java
+++ b/app/src/main/java/com/truthscope/web/gemini/GeminiClient.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.truthscope.web.entity.enums.DecisionSource;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import jakarta.annotation.Nullable;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
@@ -15,7 +16,9 @@ import org.springframework.web.client.RestClient;
 /**
  * Gemini API 클라이언트 — production 프로파일 전용.
  *
- * <p>PLAN §4-1 rev.5 amend 정합:
+ * <p>BE #74 amend: BYOK overrideApiKey 인자 추가. null/blank → 서버 기본 키 사용, 명시 → 사용자 키 1회성 사용.
+ * fallbackStructured 내부 2차 FALLBACK_MODEL 호출도 effectiveKey 사용 (this.apiKey 하드코딩 금지). BYOK 401/403 →
+ * {@link GeminiResponse#authFailed()} 신호 (서버 키 fallback 트리거).
  *
  * <ul>
  *   <li>{@link #PRIMARY_MODEL} = {@code gemini-3.1-flash-lite} (domain-logic.md lock, 2026-05-27 GA
@@ -52,18 +55,19 @@ public class GeminiClient {
   /**
    * Gemini API 에 structured output 요청을 전송하고 {@link GeminiResponse} 를 반환.
    *
-   * <p>PRIMARY 모델로 시도, CircuitBreaker 개입 또는 오류 시 {@link #fallbackStructured} 로 위임.
-   *
    * @param req Gemini 요청 DTO
+   * @param overrideApiKey BYOK 사용자 키 (null/blank → 서버 기본 키 사용)
    * @return 정규화된 응답
    */
   @CircuitBreaker(name = "gemini", fallbackMethod = "fallbackStructured")
-  public GeminiResponse callStructured(GeminiRequest req) {
+  public GeminiResponse callStructured(GeminiRequest req, @Nullable String overrideApiKey) {
+    String effectiveKey =
+        (overrideApiKey != null && !overrideApiKey.isBlank()) ? overrideApiKey : this.apiKey;
     GeminiGenerateContentResponse wrapper =
         restClient
             .post()
             .uri("/v1beta/models/{model}:generateContent", PRIMARY_MODEL)
-            .header("x-goog-api-key", apiKey)
+            .header("x-goog-api-key", effectiveKey)
             .body(req)
             .retrieve()
             .body(GeminiGenerateContentResponse.class);
@@ -76,39 +80,50 @@ public class GeminiClient {
   }
 
   /**
-   * CircuitBreaker fallback — status 분기 처리 (rev.5 amend Round 4 CX4-2).
+   * CircuitBreaker fallback — status 분기 처리.
    *
    * <ul>
-   *   <li>{@link CallNotPermittedException} → CB open 상태 → {@link DecisionSource#CIRCUIT_BREAKER}
-   *   <li>{@link HttpClientErrorException} 4xx (400/401/403) → Gemini 측 거부 → {@link
-   *       DecisionSource#GEMINI} (운영 의미 보존)
-   *   <li>1차 5xx/429/timeout → 2차 {@link #FALLBACK_MODEL} 재시도 → 성공 시 {@link DecisionSource#GEMINI}
+   *   <li>{@link CallNotPermittedException} → CB open → {@link DecisionSource#CIRCUIT_BREAKER}
+   *   <li>BYOK 호출 시 401/403 → {@link GeminiResponse#authFailed()} (서버 키 fallback 트리거)
+   *   <li>서버 기본 키 4xx 또는 400 (요청 body 오류, BYOK 무관) → {@link DecisionSource#GEMINI} insufficient
+   *   <li>1차 5xx/429/timeout → 2차 {@link #FALLBACK_MODEL} 재시도 + effectiveKey 사용
    *   <li>2차 모델도 실패 → {@link DecisionSource#HEURISTIC_FALLBACK}
    * </ul>
    *
    * @param req 원본 요청
+   * @param overrideApiKey BYOK 사용자 키 (null → 서버 기본)
    * @param throwable callStructured 에서 전파된 예외
    * @return 정규화된 응답
    */
-  public GeminiResponse fallbackStructured(GeminiRequest req, Throwable throwable) {
+  public GeminiResponse fallbackStructured(
+      GeminiRequest req, @Nullable String overrideApiKey, Throwable throwable) {
     if (throwable instanceof CallNotPermittedException) {
       return GeminiResponse.insufficient(DecisionSource.CIRCUIT_BREAKER);
     }
 
     if (throwable instanceof HttpClientErrorException httpEx) {
       int statusCode = httpEx.getStatusCode().value();
+      // BE #74 amend: BYOK 키 사용 중 401/403 → authFailed 신호 (서버 키 fallback 트리거)
+      if ((statusCode == 401 || statusCode == 403)
+          && overrideApiKey != null
+          && !overrideApiKey.isBlank()) {
+        return GeminiResponse.authFailed();
+      }
+      // 400 (요청 body 오류, BYOK 무관) + 서버 키 401/403 → 일반 GEMINI insufficient
       if (statusCode == 400 || statusCode == 401 || statusCode == 403) {
         return GeminiResponse.insufficient(DecisionSource.GEMINI);
       }
     }
 
-    // 1차 5xx / 429 / timeout — 2차 FALLBACK_MODEL 재시도
+    // 1차 5xx/429/timeout — 2차 FALLBACK_MODEL 재시도. effectiveKey 사용 (this.apiKey 하드코딩 금지)
+    String effectiveKey =
+        (overrideApiKey != null && !overrideApiKey.isBlank()) ? overrideApiKey : this.apiKey;
     try {
       GeminiGenerateContentResponse fallbackWrapper =
           restClient
               .post()
               .uri("/v1beta/models/{model}:generateContent", FALLBACK_MODEL)
-              .header("x-goog-api-key", apiKey)
+              .header("x-goog-api-key", effectiveKey)
               .body(req)
               .retrieve()
               .body(GeminiGenerateContentResponse.class);
@@ -122,9 +137,6 @@ public class GeminiClient {
   /**
    * wrapper 응답을 2단계 파싱하여 {@link GeminiResponse} 반환.
    *
-   * <p>empty candidates, SAFETY blockReason, parts[0].text 파싱 실패 등 비정상 응답은 {@link
-   * GeminiResponse#insufficient} 로 처리.
-   *
    * @param wrapper Gemini API 응답 wrapper (nullable)
    * @return 정규화된 응답
    * @throws JsonProcessingException 2단계 파싱 실패 시 (호출부에서 catch)
@@ -135,19 +147,16 @@ public class GeminiClient {
       return GeminiResponse.insufficient(DecisionSource.GEMINI);
     }
 
-    // promptFeedback.blockReason 확인
     if (wrapper.promptFeedback() != null && wrapper.promptFeedback().blockReason() != null) {
       return GeminiResponse.insufficient(DecisionSource.GEMINI);
     }
 
-    // empty candidates 확인
     if (wrapper.candidates() == null || wrapper.candidates().isEmpty()) {
       return GeminiResponse.insufficient(DecisionSource.GEMINI);
     }
 
     GeminiGenerateContentResponse.Candidate candidate = wrapper.candidates().get(0);
 
-    // SAFETY finishReason 확인
     if ("SAFETY".equals(candidate.finishReason())) {
       return GeminiResponse.insufficient(DecisionSource.GEMINI);
     }
@@ -163,7 +172,6 @@ public class GeminiClient {
       return GeminiResponse.insufficient(DecisionSource.GEMINI);
     }
 
-    // 2단계 파싱: parts[0].text → ClaimAnalysisPayload
     ClaimAnalysisPayload payload = objectMapper.readValue(text, ClaimAnalysisPayload.class);
     return GeminiResponse.from(payload, wrapper);
   }

--- a/app/src/main/java/com/truthscope/web/gemini/GeminiResponse.java
+++ b/app/src/main/java/com/truthscope/web/gemini/GeminiResponse.java
@@ -7,32 +7,45 @@ import java.util.List;
 /**
  * GeminiClient 내부 정규화 응답 DTO — cascade 파이프라인 입력 계약.
  *
- * <p>Gemini API 응답 variant (SAFETY 차단 / empty candidates / 2단계 파싱 실패 / CircuitBreaker 개입)를 단일
- * 인터페이스로 추상화. static factory 2종으로만 생성 (rev.5 amend Round 4 CX4-1).
+ * <p>Gemini API 응답 variant (SAFETY 차단 / empty candidates / 2단계 파싱 실패 / CircuitBreaker 개입 / BYOK
+ * AUTH 실패)를 단일 인터페이스로 추상화. static factory 3종으로만 생성.
+ *
+ * <p>BE #74 amend: {@code authFailure} 필드 + {@link #authFailed()} factory 추가. BYOK 호출 시 HTTP
+ * 401/403 발생을 별 신호로 분기 — ClaimAnalysisService가 fallback 트리거에 사용. 정상 SAFETY/empty/parse failure는
+ * BYOK 성공으로 분류 (재호출 X).
  *
  * @param claims 추출된 {@link ClaimDraft} 목록 — 결과 없으면 빈 목록
  * @param decisionSource 결정 source 분류
+ * @param authFailure BYOK 호출 시 인증 실패 (HTTP 401/403) 신호. 기본 false.
  */
-public record GeminiResponse(List<ClaimDraft> claims, DecisionSource decisionSource) {
+public record GeminiResponse(
+    List<ClaimDraft> claims, DecisionSource decisionSource, boolean authFailure) {
 
   public GeminiResponse {
     claims = (claims == null) ? List.of() : List.copyOf(claims);
   }
 
   /**
-   * 응답 불충분 (차단 / 파싱 실패 / CircuitBreaker 개입) 시 생성.
+   * 응답 불충분 (차단 / 파싱 실패 / CircuitBreaker 개입) 시 생성. authFailure = false.
    *
    * @param source 결정 source
    * @return claims = 빈 목록 인스턴스
    */
   public static GeminiResponse insufficient(DecisionSource source) {
-    return new GeminiResponse(List.of(), source);
+    return new GeminiResponse(List.of(), source, false);
   }
 
   /**
-   * Gemini 정상 응답 + 2단계 파싱 성공 시 생성.
+   * BYOK 호출 시 HTTP 401/403 인증 실패 전용. ClaimAnalysisService가 서버 기본 키로 fallback 트리거.
    *
-   * <p>{@link ClaimAnalysisPayload#toClaimDrafts()} 로 변환 후 {@link DecisionSource#GEMINI} 박제.
+   * @return claims = 빈 목록, decisionSource = GEMINI, authFailure = true
+   */
+  public static GeminiResponse authFailed() {
+    return new GeminiResponse(List.of(), DecisionSource.GEMINI, true);
+  }
+
+  /**
+   * Gemini 정상 응답 + 2단계 파싱 성공 시 생성. authFailure = false.
    *
    * @param payload 2단계 파싱 완료 payload
    * @param wrapper Gemini API 응답 wrapper (현재 미사용 — 향후 usageMetadata 로깅 확장용)
@@ -40,6 +53,6 @@ public record GeminiResponse(List<ClaimDraft> claims, DecisionSource decisionSou
    */
   public static GeminiResponse from(
       ClaimAnalysisPayload payload, GeminiGenerateContentResponse wrapper) {
-    return new GeminiResponse(payload.toClaimDrafts(), DecisionSource.GEMINI);
+    return new GeminiResponse(payload.toClaimDrafts(), DecisionSource.GEMINI, false);
   }
 }

--- a/app/src/main/java/com/truthscope/web/service/AnalysisService.java
+++ b/app/src/main/java/com/truthscope/web/service/AnalysisService.java
@@ -18,6 +18,7 @@ import com.truthscope.web.scoring.SourceTransparencySummary;
 import com.truthscope.web.scoring.TruthLabel;
 import com.truthscope.web.scoring.TruthLabelDeriver;
 import com.truthscope.web.service.verification.VerificationCascadeService;
+import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -57,10 +58,10 @@ public class AnalysisService {
    *
    * <p>어느 단계에서든 RuntimeException 발생 시 세션을 FAILED로 전이한다. markFailed 자체 실패 시 원본 예외에 suppressed로 추가.
    */
-  public AnalysisResponse analyze(AnalysisRequest request) {
+  public AnalysisResponse analyze(AnalysisRequest request, @Nullable String userApiKey) {
     UUID sessionId = transactionService.createPendingSession();
     try {
-      return runPipeline(request, sessionId);
+      return runPipeline(request, sessionId, userApiKey);
     } catch (RuntimeException ex) {
       try {
         transactionService.markFailed(sessionId);
@@ -71,14 +72,20 @@ public class AnalysisService {
     }
   }
 
-  private AnalysisResponse runPipeline(AnalysisRequest request, UUID sessionId) {
+  /** Backward compat — userApiKey null 위임. */
+  public AnalysisResponse analyze(AnalysisRequest request) {
+    return analyze(request, null);
+  }
+
+  private AnalysisResponse runPipeline(
+      AnalysisRequest request, UUID sessionId, @Nullable String userApiKey) {
     ExtractedArticle extracted = contentExtractService.extract(request.url());
     UUID articleId =
         transactionService
             .persistArticleAndUpdateStatus(sessionId, request.url(), extracted)
             .getArticleId();
 
-    List<ClaimDraft> drafts = claimAnalysisPort.analyze(extracted.getBody());
+    List<ClaimDraft> drafts = claimAnalysisPort.analyze(extracted.getBody(), userApiKey);
     List<com.truthscope.web.entity.Claim> savedClaims =
         transactionService.persistClaims(articleId, drafts);
     List<ClaimVerificationSignal> signals = verificationCascadeService.cascade(drafts);

--- a/app/src/main/java/com/truthscope/web/service/audit/ApiUsageLogService.java
+++ b/app/src/main/java/com/truthscope/web/service/audit/ApiUsageLogService.java
@@ -41,6 +41,7 @@ public class ApiUsageLogService {
             .usageDate(LocalDate.now())
             .requestCount(1)
             .tokenCount(tokenCount)
+            .keySource("SERVER_POOL")
             .build();
     repository.save(log);
   }

--- a/app/src/main/java/com/truthscope/web/service/audit/ApiUsageLogService.java
+++ b/app/src/main/java/com/truthscope/web/service/audit/ApiUsageLogService.java
@@ -2,6 +2,7 @@ package com.truthscope.web.service.audit;
 
 import com.truthscope.web.entity.ApiUsageLog;
 import com.truthscope.web.repository.ApiUsageLogRepository;
+import jakarta.annotation.Nullable;
 import java.time.LocalDate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,13 +36,27 @@ public class ApiUsageLogService {
    * @param tokenCount 토큰 사용량 (0 이면 unknown)
    */
   public void record(String provider, int tokenCount) {
+    record(provider, tokenCount, "SERVER_POOL", null);
+  }
+
+  /**
+   * BE #74 amend — BYOK 분류 + key fingerprint 기록.
+   *
+   * @param provider API provider 이름 (예: "GEMINI")
+   * @param tokenCount 토큰 사용량 (0 이면 unknown)
+   * @param keySource 키 source 분류 — BYOK / SERVER_POOL / BYOK_FAILED / SERVER_POOL_FALLBACK
+   * @param keyFingerprint SHA-256 hex 앞 16자 (BYOK 키 사용 시). 서버 키 사용 시 null.
+   */
+  public void record(
+      String provider, int tokenCount, String keySource, @Nullable String keyFingerprint) {
     ApiUsageLog log =
         ApiUsageLog.builder()
             .provider(provider)
             .usageDate(LocalDate.now())
             .requestCount(1)
             .tokenCount(tokenCount)
-            .keySource("SERVER_POOL")
+            .keySource(keySource)
+            .keyFingerprint(keyFingerprint)
             .build();
     repository.save(log);
   }

--- a/app/src/main/java/com/truthscope/web/service/claim/ClaimAnalysisService.java
+++ b/app/src/main/java/com/truthscope/web/service/claim/ClaimAnalysisService.java
@@ -1,5 +1,6 @@
 package com.truthscope.web.service.claim;
 
+import com.truthscope.web.audit.KeyFingerprinter;
 import com.truthscope.web.claim.validation.ClaimSchemaValidator;
 import com.truthscope.web.claim.validation.HeuristicValidator;
 import com.truthscope.web.claim.validation.Tier3ReasonValidator;
@@ -11,6 +12,7 @@ import com.truthscope.web.scoring.ClaimAnalysisPort;
 import com.truthscope.web.scoring.ClaimDraft;
 import com.truthscope.web.scoring.ClaimStatusCandidate;
 import com.truthscope.web.service.audit.ApiUsageLogService;
+import jakarta.annotation.Nullable;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
@@ -45,20 +47,31 @@ public class ClaimAnalysisService implements ClaimAnalysisPort {
   private final ApiUsageLogService apiUsageLogService;
 
   @Override
-  public List<ClaimDraft> analyze(String articleBody) {
+  public List<ClaimDraft> analyze(String articleBody, @Nullable String userApiKey) {
     if (articleBody == null || articleBody.isBlank()) {
       return List.of();
     }
-    // 1. PromptShield XML 격리 더하기 mini-CoVe template
     String prompt = promptShield.assemble(articleBody);
-    // 2. GeminiClient.callStructured (Resilience4j CircuitBreaker 자동 적용 더하기 2단계 파싱 더하기 fallback 분기)
     GeminiRequest request = buildRequest(prompt);
-    GeminiResponse response = geminiClient.callStructured(request, null);
-    // rev.5 amend I-01 (review): v1.x 단순 카운터 단계로 성공/실패 미구분. v2 트랙에서 GeminiResponse.decisionSource
-    // 기반 분기 의무 (GEMINI / CIRCUIT_BREAKER / HEURISTIC_FALLBACK 별 카운트).
-    apiUsageLogService.record("GEMINI", 0);
-    // 3. Schema Validator 더하기 4. Tier3ReasonValidator 적용 — claimStatusCandidate 갱신 후 Wave 2 cascade
-    // 입력
+
+    GeminiResponse response;
+    if (userApiKey != null && !userApiKey.isBlank()) {
+      response = geminiClient.callStructured(request, userApiKey);
+      // BE #74: BYOK 인증 실패 시 서버 기본 키로 1회 재시도. ADR-004 §f "모든 Gemini 호출 기록" 정합 — audit 2 row.
+      // CB 개입(CIRCUIT_BREAKER)은 BYOK 실패로 분류하지 않음 — CB는 backend health 신호, 키 유효성과 무관.
+      // 정상 SAFETY/empty/parse failure도 BYOK 실패가 아니라 정상 응답의 한 case.
+      if (response.authFailure()) {
+        String fingerprint = KeyFingerprinter.fingerprint(userApiKey);
+        apiUsageLogService.record("GEMINI", 0, "BYOK_FAILED", fingerprint);
+        response = geminiClient.callStructured(request, null);
+        apiUsageLogService.record("GEMINI", 0, "SERVER_POOL_FALLBACK", null);
+      } else {
+        apiUsageLogService.record("GEMINI", 0, "BYOK", KeyFingerprinter.fingerprint(userApiKey));
+      }
+    } else {
+      response = geminiClient.callStructured(request, null);
+      apiUsageLogService.record("GEMINI", 0, "SERVER_POOL", null);
+    }
     return response.claims().stream().map(this::applyValidators).toList();
   }
 

--- a/app/src/main/java/com/truthscope/web/service/claim/ClaimAnalysisService.java
+++ b/app/src/main/java/com/truthscope/web/service/claim/ClaimAnalysisService.java
@@ -53,7 +53,7 @@ public class ClaimAnalysisService implements ClaimAnalysisPort {
     String prompt = promptShield.assemble(articleBody);
     // 2. GeminiClient.callStructured (Resilience4j CircuitBreaker 자동 적용 더하기 2단계 파싱 더하기 fallback 분기)
     GeminiRequest request = buildRequest(prompt);
-    GeminiResponse response = geminiClient.callStructured(request);
+    GeminiResponse response = geminiClient.callStructured(request, null);
     // rev.5 amend I-01 (review): v1.x 단순 카운터 단계로 성공/실패 미구분. v2 트랙에서 GeminiResponse.decisionSource
     // 기반 분기 의무 (GEMINI / CIRCUIT_BREAKER / HEURISTIC_FALLBACK 별 카운트).
     apiUsageLogService.record("GEMINI", 0);

--- a/app/src/main/java/com/truthscope/web/service/claim/ClaimAnalysisStubService.java
+++ b/app/src/main/java/com/truthscope/web/service/claim/ClaimAnalysisStubService.java
@@ -3,6 +3,7 @@ package com.truthscope.web.service.claim;
 import com.truthscope.web.scoring.ClaimAnalysisPort;
 import com.truthscope.web.scoring.ClaimDraft;
 import com.truthscope.web.scoring.ClaimStatusCandidate;
+import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.context.annotation.Profile;
@@ -49,7 +50,8 @@ public class ClaimAnalysisStubService implements ClaimAnalysisPort {
 
   @Override
   @Transactional(readOnly = true)
-  public List<ClaimDraft> analyze(String articleBody) {
+  public List<ClaimDraft> analyze(String articleBody, @Nullable String userApiKey) {
+    // userApiKey 무시 — stub은 fixture 반환
     if (articleBody == null || articleBody.isBlank()) {
       return List.of();
     }

--- a/app/src/main/resources/db/migration/V7__add_key_source_to_api_usage_logs.sql
+++ b/app/src/main/resources/db/migration/V7__add_key_source_to_api_usage_logs.sql
@@ -1,0 +1,11 @@
+-- BE #74 (S3-05) Gemini Claim Extractor BYOK 통합 — ADR-004 §(d) + §(f) 정합
+-- key_source: BYOK 사용 분류 (BYOK / SERVER_POOL / BYOK_FAILED / SERVER_POOL_FALLBACK)
+-- key_fingerprint: SHA-256 hex digest 앞 16자 (=8바이트). 원문 키 영구 저장 금지
+
+ALTER TABLE api_usage_logs
+  ADD COLUMN key_source VARCHAR(20) NOT NULL DEFAULT 'SERVER_POOL',
+  ADD COLUMN key_fingerprint VARCHAR(16);
+
+ALTER TABLE api_usage_logs
+  ADD CONSTRAINT ck_api_usage_logs_key_source
+  CHECK (key_source IN ('BYOK', 'SERVER_POOL', 'BYOK_FAILED', 'SERVER_POOL_FALLBACK'));

--- a/app/src/main/resources/db/migration/V7__add_key_source_to_api_usage_logs.sql
+++ b/app/src/main/resources/db/migration/V7__add_key_source_to_api_usage_logs.sql
@@ -9,3 +9,12 @@ ALTER TABLE api_usage_logs
 ALTER TABLE api_usage_logs
   ADD CONSTRAINT ck_api_usage_logs_key_source
   CHECK (key_source IN ('BYOK', 'SERVER_POOL', 'BYOK_FAILED', 'SERVER_POOL_FALLBACK'));
+
+-- CodeRabbit reviewfix: BYOK/BYOK_FAILED는 사용자 키 사용이므로 key_fingerprint 16자 NOT NULL,
+-- SERVER_POOL/SERVER_POOL_FALLBACK은 서버 기본 키 사용이므로 key_fingerprint NULL (ADR-004 §f 정합).
+ALTER TABLE api_usage_logs
+  ADD CONSTRAINT ck_api_usage_logs_key_source_fingerprint
+  CHECK (
+    (key_source IN ('BYOK', 'BYOK_FAILED') AND key_fingerprint IS NOT NULL AND char_length(key_fingerprint) = 16)
+    OR (key_source IN ('SERVER_POOL', 'SERVER_POOL_FALLBACK') AND key_fingerprint IS NULL)
+  );

--- a/app/src/test/java/com/truthscope/web/audit/KeyFingerprinterTest.java
+++ b/app/src/test/java/com/truthscope/web/audit/KeyFingerprinterTest.java
@@ -1,0 +1,62 @@
+package com.truthscope.web.audit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("KeyFingerprinter 단위 테스트")
+class KeyFingerprinterTest {
+
+  @Test
+  @DisplayName("fingerprint_정상키_16자_hex_반환")
+  void fingerprint_정상키_16자_hex_반환() {
+    String result = KeyFingerprinter.fingerprint("AIzaSyTestKeyExample0123456789");
+
+    assertThat(result).hasSize(16);
+    assertThat(result).matches("[0-9a-f]{16}");
+  }
+
+  @Test
+  @DisplayName("fingerprint_동일입력_동일출력_결정적_해시")
+  void fingerprint_동일입력_동일출력() {
+    String input = "AIzaSyTestKey";
+    String result1 = KeyFingerprinter.fingerprint(input);
+    String result2 = KeyFingerprinter.fingerprint(input);
+
+    assertThat(result1).isEqualTo(result2);
+  }
+
+  @Test
+  @DisplayName("fingerprint_다른입력_다른출력")
+  void fingerprint_다른입력_다른출력() {
+    String result1 = KeyFingerprinter.fingerprint("key-A");
+    String result2 = KeyFingerprinter.fingerprint("key-B");
+
+    assertThat(result1).isNotEqualTo(result2);
+  }
+
+  @Test
+  @DisplayName("fingerprint_null_IllegalArgumentException")
+  void fingerprint_null_예외() {
+    assertThatThrownBy(() -> KeyFingerprinter.fingerprint(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("userApiKey");
+  }
+
+  @Test
+  @DisplayName("fingerprint_blank_IllegalArgumentException")
+  void fingerprint_blank_예외() {
+    assertThatThrownBy(() -> KeyFingerprinter.fingerprint("   "))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("userApiKey");
+  }
+
+  @Test
+  @DisplayName("fingerprint_empty_IllegalArgumentException")
+  void fingerprint_empty_예외() {
+    assertThatThrownBy(() -> KeyFingerprinter.fingerprint(""))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/app/src/test/java/com/truthscope/web/controller/NewsControllerTest.java
+++ b/app/src/test/java/com/truthscope/web/controller/NewsControllerTest.java
@@ -44,7 +44,7 @@ class NewsControllerTest {
             .status("EXTRACTING")
             .build();
 
-    given(analysisService.analyze(any(AnalysisRequest.class))).willReturn(response);
+    given(analysisService.analyze(any(AnalysisRequest.class), any())).willReturn(response);
 
     mockMvc
         .perform(

--- a/app/src/test/java/com/truthscope/web/drift/VerificationCascadeIntegrationTest.java
+++ b/app/src/test/java/com/truthscope/web/drift/VerificationCascadeIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.truthscope.web.drift;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -166,7 +167,7 @@ class VerificationCascadeIntegrationTest {
     ClaimDraft fixtureDraft =
         new ClaimDraft(
             claimId, testClaimText, null, false, null, ClaimStatusCandidate.SCORABLE, null);
-    when(claimAnalysisPort.analyze(anyString())).thenReturn(List.of(fixtureDraft));
+    when(claimAnalysisPort.analyze(anyString(), any())).thenReturn(List.of(fixtureDraft));
 
     // When
     var response =
@@ -241,7 +242,7 @@ class VerificationCascadeIntegrationTest {
             null,
             ClaimStatusCandidate.SCORABLE,
             null);
-    when(claimAnalysisPort.analyze(anyString())).thenReturn(List.of(fixtureDraft));
+    when(claimAnalysisPort.analyze(anyString(), any())).thenReturn(List.of(fixtureDraft));
 
     // When: analyze 실행 — HybridCascadeService 가 실제 어댑터 없이 빈 snapshots 반환 예상
     // (외부 API 키 없음 + test-key 환경 → 어댑터 호출 실패 or empty 반환 → Tier 3 경로)

--- a/app/src/test/java/com/truthscope/web/gemini/GeminiClientTest.java
+++ b/app/src/test/java/com/truthscope/web/gemini/GeminiClientTest.java
@@ -116,7 +116,7 @@ class GeminiClientTest {
     GeminiGenerateContentResponse wrapper = buildSuccessWrapper("정부는 GDP 성장률 3%를 발표했다.");
     stubRestClient(wrapper);
 
-    GeminiResponse response = geminiClient.callStructured(DUMMY_REQUEST);
+    GeminiResponse response = geminiClient.callStructured(DUMMY_REQUEST, null);
 
     assertThat(response.decisionSource()).isEqualTo(DecisionSource.GEMINI);
     assertThat(response.claims()).hasSize(1);
@@ -135,7 +135,7 @@ class GeminiClientTest {
     CallNotPermittedException cbException =
         CallNotPermittedException.createCallNotPermittedException(cbMock);
 
-    GeminiResponse response = geminiClient.fallbackStructured(DUMMY_REQUEST, cbException);
+    GeminiResponse response = geminiClient.fallbackStructured(DUMMY_REQUEST, null, cbException);
 
     assertThat(response.decisionSource()).isEqualTo(DecisionSource.CIRCUIT_BREAKER);
     assertThat(response.claims()).isEmpty();
@@ -148,7 +148,7 @@ class GeminiClientTest {
         HttpClientErrorException.create(
             org.springframework.http.HttpStatus.BAD_REQUEST, "Bad Request", null, null, null);
 
-    GeminiResponse response = geminiClient.fallbackStructured(DUMMY_REQUEST, badRequest);
+    GeminiResponse response = geminiClient.fallbackStructured(DUMMY_REQUEST, null, badRequest);
 
     assertThat(response.decisionSource()).isEqualTo(DecisionSource.GEMINI);
     assertThat(response.claims()).isEmpty();
@@ -161,7 +161,7 @@ class GeminiClientTest {
         HttpClientErrorException.create(
             org.springframework.http.HttpStatus.FORBIDDEN, "Forbidden", null, null, null);
 
-    GeminiResponse response = geminiClient.fallbackStructured(DUMMY_REQUEST, forbidden);
+    GeminiResponse response = geminiClient.fallbackStructured(DUMMY_REQUEST, null, forbidden);
 
     assertThat(response.decisionSource()).isEqualTo(DecisionSource.GEMINI);
     assertThat(response.claims()).isEmpty();
@@ -181,7 +181,7 @@ class GeminiClientTest {
     doReturn(fallbackWrapper).when(responseSpec).body(GeminiGenerateContentResponse.class);
 
     RuntimeException serverError = new RuntimeException("503 Service Unavailable");
-    GeminiResponse response = geminiClient.fallbackStructured(DUMMY_REQUEST, serverError);
+    GeminiResponse response = geminiClient.fallbackStructured(DUMMY_REQUEST, null, serverError);
 
     assertThat(response.decisionSource()).isEqualTo(DecisionSource.GEMINI);
     assertThat(response.claims()).hasSize(1);
@@ -194,7 +194,7 @@ class GeminiClientTest {
     when(restClient.post()).thenThrow(new RuntimeException("네트워크 불가"));
 
     RuntimeException primaryError = new RuntimeException("1차 5xx 오류");
-    GeminiResponse response = geminiClient.fallbackStructured(DUMMY_REQUEST, primaryError);
+    GeminiResponse response = geminiClient.fallbackStructured(DUMMY_REQUEST, null, primaryError);
 
     assertThat(response.decisionSource()).isEqualTo(DecisionSource.HEURISTIC_FALLBACK);
     assertThat(response.claims()).isEmpty();
@@ -216,7 +216,7 @@ class GeminiClientTest {
 
     stubRestClient(wrapper);
 
-    GeminiResponse response = geminiClient.callStructured(DUMMY_REQUEST);
+    GeminiResponse response = geminiClient.callStructured(DUMMY_REQUEST, null);
 
     assertThat(response.decisionSource()).isEqualTo(DecisionSource.GEMINI);
     assertThat(response.claims()).isEmpty();
@@ -236,7 +236,7 @@ class GeminiClientTest {
 
     stubRestClient(wrapper);
 
-    GeminiResponse response = geminiClient.callStructured(DUMMY_REQUEST);
+    GeminiResponse response = geminiClient.callStructured(DUMMY_REQUEST, null);
 
     assertThat(response.decisionSource()).isEqualTo(DecisionSource.GEMINI);
     assertThat(response.claims()).isEmpty();
@@ -256,7 +256,7 @@ class GeminiClientTest {
 
     stubRestClient(wrapper);
 
-    GeminiResponse response = geminiClient.callStructured(DUMMY_REQUEST);
+    GeminiResponse response = geminiClient.callStructured(DUMMY_REQUEST, null);
 
     assertThat(response.decisionSource()).isEqualTo(DecisionSource.GEMINI);
     assertThat(response.claims()).isEmpty();
@@ -275,7 +275,7 @@ class GeminiClientTest {
     doReturn(fallbackWrapper).when(responseSpec).body(GeminiGenerateContentResponse.class);
 
     ResourceAccessException timeout = new ResourceAccessException("Read timed out");
-    GeminiResponse response = geminiClient.fallbackStructured(DUMMY_REQUEST, timeout);
+    GeminiResponse response = geminiClient.fallbackStructured(DUMMY_REQUEST, null, timeout);
 
     assertThat(response.decisionSource()).isEqualTo(DecisionSource.GEMINI);
     assertThat(response.claims()).hasSize(1);

--- a/app/src/test/java/com/truthscope/web/integration/VerificationPipelineIntegrationTest.java
+++ b/app/src/test/java/com/truthscope/web/integration/VerificationPipelineIntegrationTest.java
@@ -235,7 +235,7 @@ class VerificationPipelineIntegrationTest {
       ClaimDraft scorableDraft =
           new ClaimDraft(
               UUID.randomUUID(), claimText, null, false, null, ClaimStatusCandidate.SCORABLE, null);
-      when(claimAnalysisPort.analyze(anyString())).thenReturn(List.of(scorableDraft));
+      when(claimAnalysisPort.analyze(anyString(), any())).thenReturn(List.of(scorableDraft));
 
       // When: POST /api/v1/analysis-sessions
       MvcResult result =
@@ -333,7 +333,7 @@ class VerificationPipelineIntegrationTest {
               null,
               ClaimStatusCandidate.SCORABLE,
               null);
-      when(claimAnalysisPort.analyze(anyString())).thenReturn(List.of(scorableDraft));
+      when(claimAnalysisPort.analyze(anyString(), any())).thenReturn(List.of(scorableDraft));
 
       // When: POST
       MvcResult result =
@@ -408,7 +408,7 @@ class VerificationPipelineIntegrationTest {
       ClaimDraft scorableDraft =
           new ClaimDraft(
               claimId, claimText, null, false, null, ClaimStatusCandidate.SCORABLE, null);
-      when(claimAnalysisPort.analyze(anyString())).thenReturn(List.of(scorableDraft));
+      when(claimAnalysisPort.analyze(anyString(), any())).thenReturn(List.of(scorableDraft));
 
       // When: production 흐름 → POST + Aggregator static method 직접 호출
       mockMvc
@@ -473,7 +473,7 @@ class VerificationPipelineIntegrationTest {
       ClaimDraft scorableDraft =
           new ClaimDraft(
               UUID.randomUUID(), claimText, null, false, null, ClaimStatusCandidate.SCORABLE, null);
-      when(claimAnalysisPort.analyze(anyString())).thenReturn(List.of(scorableDraft));
+      when(claimAnalysisPort.analyze(anyString(), any())).thenReturn(List.of(scorableDraft));
 
       // When + Then: JSON path + Content-Type 정합
       String uuidRegex =
@@ -535,7 +535,7 @@ class VerificationPipelineIntegrationTest {
               null,
               ClaimStatusCandidate.INSUFFICIENT_CANDIDATE,
               null);
-      when(claimAnalysisPort.analyze(anyString()))
+      when(claimAnalysisPort.analyze(anyString(), any()))
           .thenReturn(List.of(scorableDraft, insufficientDraft));
 
       // factcheck_cache: SCORABLE만 hit + INSUFFICIENT는 miss
@@ -637,7 +637,7 @@ class VerificationPipelineIntegrationTest {
               null,
               ClaimStatusCandidate.SCORABLE,
               null);
-      when(claimAnalysisPort.analyze(anyString())).thenReturn(List.of(scorableDraft));
+      when(claimAnalysisPort.analyze(anyString(), any())).thenReturn(List.of(scorableDraft));
 
       // When
       MvcResult result =
@@ -689,7 +689,7 @@ class VerificationPipelineIntegrationTest {
               .domain("example.com")
               .build();
       when(contentExtractService.extract(anyString())).thenReturn(fixtureArticle);
-      when(claimAnalysisPort.analyze(anyString())).thenReturn(List.of());
+      when(claimAnalysisPort.analyze(anyString(), any())).thenReturn(List.of());
 
       // When
       MvcResult result =

--- a/app/src/test/java/com/truthscope/web/service/claim/ClaimAnalysisServiceByokTest.java
+++ b/app/src/test/java/com/truthscope/web/service/claim/ClaimAnalysisServiceByokTest.java
@@ -1,0 +1,144 @@
+package com.truthscope.web.service.claim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.truthscope.web.claim.validation.ClaimSchemaValidator;
+import com.truthscope.web.claim.validation.Tier3ReasonValidator;
+import com.truthscope.web.entity.enums.DecisionSource;
+import com.truthscope.web.gemini.GeminiClient;
+import com.truthscope.web.gemini.GeminiRequest;
+import com.truthscope.web.gemini.GeminiResponse;
+import com.truthscope.web.prompt.PromptShield;
+import com.truthscope.web.scoring.ClaimDraft;
+import com.truthscope.web.scoring.ClaimStatusCandidate;
+import com.truthscope.web.service.audit.ApiUsageLogService;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * ClaimAnalysisService BYOK 분기 단위 테스트 (BE #74).
+ *
+ * <p>4 시나리오: SERVER_POOL / BYOK 성공 / BYOK_FAILED+SERVER_POOL_FALLBACK / CB 개입 시 BYOK 분류 유지.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ClaimAnalysisService BYOK 분기 단위 테스트")
+class ClaimAnalysisServiceByokTest {
+
+  @Mock private GeminiClient geminiClient;
+  @Mock private PromptShield promptShield;
+  @Mock private ClaimSchemaValidator schemaValidator;
+  @Mock private Tier3ReasonValidator tier3Validator;
+  @Mock private ApiUsageLogService apiUsageLogService;
+
+  private ClaimAnalysisService service;
+
+  private static final String SAMPLE_ARTICLE = "정부는 2025년 GDP 성장률이 3%라고 발표했다.";
+  private static final String ASSEMBLED_PROMPT = "<prompt>XML 격리된 본문</prompt>";
+  private static final String USER_KEY = "AIzaSyUserKeyExample";
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new ClaimAnalysisService(
+            geminiClient, promptShield, schemaValidator, tier3Validator, apiUsageLogService);
+  }
+
+  private ClaimDraft buildDraft() {
+    return new ClaimDraft(
+        UUID.randomUUID(), "claim text", null, false, null, ClaimStatusCandidate.SCORABLE, null);
+  }
+
+  @Test
+  @DisplayName("Scenario1_userApiKey_null_서버키_호출_SERVER_POOL_audit")
+  void scenario1_userApiKeyNull_serverPool() {
+    ClaimDraft draft = buildDraft();
+    GeminiResponse response = new GeminiResponse(List.of(draft), DecisionSource.GEMINI, false);
+    when(promptShield.assemble(SAMPLE_ARTICLE)).thenReturn(ASSEMBLED_PROMPT);
+    when(geminiClient.callStructured(any(GeminiRequest.class), isNull())).thenReturn(response);
+    when(schemaValidator.isValid(draft)).thenReturn(true);
+    when(tier3Validator.validate(draft)).thenReturn(Optional.empty());
+
+    List<ClaimDraft> result = service.analyze(SAMPLE_ARTICLE, null);
+
+    assertThat(result).hasSize(1);
+    verify(geminiClient, times(1)).callStructured(any(GeminiRequest.class), isNull());
+    verify(apiUsageLogService, times(1)).record("GEMINI", 0, "SERVER_POOL", null);
+  }
+
+  @Test
+  @DisplayName("Scenario2_userApiKey_명시_BYOK_성공_BYOK_audit")
+  void scenario2_byokSuccess() {
+    ClaimDraft draft = buildDraft();
+    GeminiResponse response = new GeminiResponse(List.of(draft), DecisionSource.GEMINI, false);
+    when(promptShield.assemble(SAMPLE_ARTICLE)).thenReturn(ASSEMBLED_PROMPT);
+    when(geminiClient.callStructured(any(GeminiRequest.class), eq(USER_KEY))).thenReturn(response);
+    when(schemaValidator.isValid(draft)).thenReturn(true);
+    when(tier3Validator.validate(draft)).thenReturn(Optional.empty());
+
+    List<ClaimDraft> result = service.analyze(SAMPLE_ARTICLE, USER_KEY);
+
+    assertThat(result).hasSize(1);
+    verify(geminiClient, times(1)).callStructured(any(GeminiRequest.class), eq(USER_KEY));
+    verify(geminiClient, never()).callStructured(any(GeminiRequest.class), isNull());
+    verify(apiUsageLogService, times(1)).record(eq("GEMINI"), anyInt(), eq("BYOK"), anyString());
+  }
+
+  @Test
+  @DisplayName("Scenario3_userApiKey_authFailure_BYOK_FAILED_SERVER_POOL_FALLBACK_audit_2row")
+  void scenario3_byokAuthFailed_fallback_audit2row() {
+    ClaimDraft draft = buildDraft();
+    GeminiResponse authFailed = GeminiResponse.authFailed();
+    GeminiResponse fallbackResponse =
+        new GeminiResponse(List.of(draft), DecisionSource.GEMINI, false);
+    when(promptShield.assemble(SAMPLE_ARTICLE)).thenReturn(ASSEMBLED_PROMPT);
+    when(geminiClient.callStructured(any(GeminiRequest.class), eq(USER_KEY)))
+        .thenReturn(authFailed);
+    when(geminiClient.callStructured(any(GeminiRequest.class), isNull()))
+        .thenReturn(fallbackResponse);
+    when(schemaValidator.isValid(draft)).thenReturn(true);
+    when(tier3Validator.validate(draft)).thenReturn(Optional.empty());
+
+    List<ClaimDraft> result = service.analyze(SAMPLE_ARTICLE, USER_KEY);
+
+    assertThat(result).hasSize(1);
+    verify(geminiClient, times(1)).callStructured(any(GeminiRequest.class), eq(USER_KEY));
+    verify(geminiClient, times(1)).callStructured(any(GeminiRequest.class), isNull());
+    // audit 2 row — ADR-004 §f "모든 Gemini 호출 기록" 정합
+    verify(apiUsageLogService, times(1))
+        .record(eq("GEMINI"), anyInt(), eq("BYOK_FAILED"), anyString());
+    verify(apiUsageLogService, times(1)).record("GEMINI", 0, "SERVER_POOL_FALLBACK", null);
+  }
+
+  @Test
+  @DisplayName("Scenario4_userApiKey_명시_CIRCUIT_BREAKER_개입_BYOK_분류_유지_fallback_없음")
+  void scenario4_byokWithCircuitBreaker_noFallback() {
+    GeminiResponse cbResponse = GeminiResponse.insufficient(DecisionSource.CIRCUIT_BREAKER);
+    when(promptShield.assemble(SAMPLE_ARTICLE)).thenReturn(ASSEMBLED_PROMPT);
+    when(geminiClient.callStructured(any(GeminiRequest.class), eq(USER_KEY)))
+        .thenReturn(cbResponse);
+
+    List<ClaimDraft> result = service.analyze(SAMPLE_ARTICLE, USER_KEY);
+
+    assertThat(result).isEmpty();
+    verify(geminiClient, times(1)).callStructured(any(GeminiRequest.class), eq(USER_KEY));
+    // CB는 backend health 신호이고 키 유효성과 무관 → fallback 없음 + BYOK audit 1건만
+    verify(geminiClient, never()).callStructured(any(GeminiRequest.class), isNull());
+    verify(apiUsageLogService, times(1)).record(eq("GEMINI"), anyInt(), eq("BYOK"), anyString());
+  }
+}

--- a/app/src/test/java/com/truthscope/web/service/claim/ClaimAnalysisServiceTest.java
+++ b/app/src/test/java/com/truthscope/web/service/claim/ClaimAnalysisServiceTest.java
@@ -68,7 +68,7 @@ class ClaimAnalysisServiceTest {
     List<ClaimDraft> result = service.analyze(null);
 
     assertThat(result).isEmpty();
-    verify(geminiClient, never()).callStructured(any());
+    verify(geminiClient, never()).callStructured(any(), any());
   }
 
   @Test
@@ -77,17 +77,17 @@ class ClaimAnalysisServiceTest {
     List<ClaimDraft> result = service.analyze("   ");
 
     assertThat(result).isEmpty();
-    verify(geminiClient, never()).callStructured(any());
+    verify(geminiClient, never()).callStructured(any(), any());
   }
 
   @Test
   @DisplayName("Gemini_정상_호출_schema_통과_tier3_empty시_SCORABLE_ClaimDraft_반환")
   void gemini_정상_schema_통과_tier3_empty_SCORABLE_반환() {
     ClaimDraft geminDraft = buildDraft("정부 발표 claim", ClaimStatusCandidate.SCORABLE);
-    GeminiResponse response = new GeminiResponse(List.of(geminDraft), DecisionSource.GEMINI);
+    GeminiResponse response = new GeminiResponse(List.of(geminDraft), DecisionSource.GEMINI, false);
 
     when(promptShield.assemble(SAMPLE_ARTICLE)).thenReturn(ASSEMBLED_PROMPT);
-    when(geminiClient.callStructured(any(GeminiRequest.class))).thenReturn(response);
+    when(geminiClient.callStructured(any(GeminiRequest.class), any())).thenReturn(response);
     when(schemaValidator.isValid(geminDraft)).thenReturn(true);
     when(tier3Validator.validate(geminDraft)).thenReturn(Optional.empty());
 
@@ -102,10 +102,10 @@ class ClaimAnalysisServiceTest {
   @DisplayName("Gemini_정상_호출_schema_실패시_INSUFFICIENT_CANDIDATE_강제")
   void schemaValidator_실패_INSUFFICIENT_CANDIDATE_강제() {
     ClaimDraft geminDraft = buildDraft("", ClaimStatusCandidate.SCORABLE);
-    GeminiResponse response = new GeminiResponse(List.of(geminDraft), DecisionSource.GEMINI);
+    GeminiResponse response = new GeminiResponse(List.of(geminDraft), DecisionSource.GEMINI, false);
 
     when(promptShield.assemble(SAMPLE_ARTICLE)).thenReturn(ASSEMBLED_PROMPT);
-    when(geminiClient.callStructured(any(GeminiRequest.class))).thenReturn(response);
+    when(geminiClient.callStructured(any(GeminiRequest.class), any())).thenReturn(response);
     when(schemaValidator.isValid(geminDraft)).thenReturn(false);
 
     List<ClaimDraft> result = service.analyze(SAMPLE_ARTICLE);
@@ -121,10 +121,10 @@ class ClaimAnalysisServiceTest {
   @DisplayName("Gemini_정상_호출_tier3_OUT_OF_SCOPE시_OUT_OF_SCOPE_CANDIDATE_강제")
   void tier3Validator_OUT_OF_SCOPE_candidate_강제() {
     ClaimDraft geminDraft = buildDraft("정치적 의견", ClaimStatusCandidate.SCORABLE);
-    GeminiResponse response = new GeminiResponse(List.of(geminDraft), DecisionSource.GEMINI);
+    GeminiResponse response = new GeminiResponse(List.of(geminDraft), DecisionSource.GEMINI, false);
 
     when(promptShield.assemble(SAMPLE_ARTICLE)).thenReturn(ASSEMBLED_PROMPT);
-    when(geminiClient.callStructured(any(GeminiRequest.class))).thenReturn(response);
+    when(geminiClient.callStructured(any(GeminiRequest.class), any())).thenReturn(response);
     when(schemaValidator.isValid(geminDraft)).thenReturn(true);
     when(tier3Validator.validate(geminDraft))
         .thenReturn(Optional.of(HeuristicValidator.Tier3ReasonCandidate.OUT_OF_SCOPE));
@@ -140,10 +140,10 @@ class ClaimAnalysisServiceTest {
   @DisplayName("Gemini_정상_호출_tier3_TIME_SENSITIVE시_TIME_SENSITIVE_CANDIDATE_강제")
   void tier3Validator_TIME_SENSITIVE_candidate_강제() {
     ClaimDraft geminDraft = buildDraft("현재 상황 주장", ClaimStatusCandidate.SCORABLE);
-    GeminiResponse response = new GeminiResponse(List.of(geminDraft), DecisionSource.GEMINI);
+    GeminiResponse response = new GeminiResponse(List.of(geminDraft), DecisionSource.GEMINI, false);
 
     when(promptShield.assemble(SAMPLE_ARTICLE)).thenReturn(ASSEMBLED_PROMPT);
-    when(geminiClient.callStructured(any(GeminiRequest.class))).thenReturn(response);
+    when(geminiClient.callStructured(any(GeminiRequest.class), any())).thenReturn(response);
     when(schemaValidator.isValid(geminDraft)).thenReturn(true);
     when(tier3Validator.validate(geminDraft))
         .thenReturn(Optional.of(HeuristicValidator.Tier3ReasonCandidate.TIME_SENSITIVE));
@@ -159,10 +159,10 @@ class ClaimAnalysisServiceTest {
   @DisplayName("Gemini_정상_호출_tier3_INSUFFICIENT시_INSUFFICIENT_CANDIDATE_강제")
   void tier3Validator_INSUFFICIENT_candidate_강제() {
     ClaimDraft geminDraft = buildDraft("근거 없는 주장", ClaimStatusCandidate.SCORABLE);
-    GeminiResponse response = new GeminiResponse(List.of(geminDraft), DecisionSource.GEMINI);
+    GeminiResponse response = new GeminiResponse(List.of(geminDraft), DecisionSource.GEMINI, false);
 
     when(promptShield.assemble(SAMPLE_ARTICLE)).thenReturn(ASSEMBLED_PROMPT);
-    when(geminiClient.callStructured(any(GeminiRequest.class))).thenReturn(response);
+    when(geminiClient.callStructured(any(GeminiRequest.class), any())).thenReturn(response);
     when(schemaValidator.isValid(geminDraft)).thenReturn(true);
     when(tier3Validator.validate(geminDraft))
         .thenReturn(Optional.of(HeuristicValidator.Tier3ReasonCandidate.INSUFFICIENT));
@@ -177,10 +177,10 @@ class ClaimAnalysisServiceTest {
   @Test
   @DisplayName("ApiUsageLogService_record_가_항상_호출된다")
   void apiUsageLogService_record_항상_호출() {
-    GeminiResponse emptyResponse = new GeminiResponse(List.of(), DecisionSource.GEMINI);
+    GeminiResponse emptyResponse = new GeminiResponse(List.of(), DecisionSource.GEMINI, false);
 
     when(promptShield.assemble(SAMPLE_ARTICLE)).thenReturn(ASSEMBLED_PROMPT);
-    when(geminiClient.callStructured(any(GeminiRequest.class))).thenReturn(emptyResponse);
+    when(geminiClient.callStructured(any(GeminiRequest.class), any())).thenReturn(emptyResponse);
 
     service.analyze(SAMPLE_ARTICLE);
 
@@ -192,10 +192,11 @@ class ClaimAnalysisServiceTest {
   void 여러_claim_각각_validator_독립_적용() {
     ClaimDraft draft1 = buildDraft("정상 claim", ClaimStatusCandidate.SCORABLE);
     ClaimDraft draft2 = buildDraft("빈 텍스트", ClaimStatusCandidate.SCORABLE);
-    GeminiResponse response = new GeminiResponse(List.of(draft1, draft2), DecisionSource.GEMINI);
+    GeminiResponse response =
+        new GeminiResponse(List.of(draft1, draft2), DecisionSource.GEMINI, false);
 
     when(promptShield.assemble(SAMPLE_ARTICLE)).thenReturn(ASSEMBLED_PROMPT);
-    when(geminiClient.callStructured(any(GeminiRequest.class))).thenReturn(response);
+    when(geminiClient.callStructured(any(GeminiRequest.class), any())).thenReturn(response);
     when(schemaValidator.isValid(draft1)).thenReturn(true);
     when(schemaValidator.isValid(draft2)).thenReturn(false);
     when(tier3Validator.validate(draft1)).thenReturn(Optional.empty());

--- a/app/src/test/java/com/truthscope/web/service/claim/ClaimAnalysisServiceTest.java
+++ b/app/src/test/java/com/truthscope/web/service/claim/ClaimAnalysisServiceTest.java
@@ -95,7 +95,7 @@ class ClaimAnalysisServiceTest {
 
     assertThat(result).hasSize(1);
     assertThat(result.get(0).claimStatusCandidate()).isEqualTo(ClaimStatusCandidate.SCORABLE);
-    verify(apiUsageLogService, times(1)).record(anyString(), anyInt());
+    verify(apiUsageLogService, times(1)).record(anyString(), anyInt(), anyString(), any());
   }
 
   @Test
@@ -184,7 +184,7 @@ class ClaimAnalysisServiceTest {
 
     service.analyze(SAMPLE_ARTICLE);
 
-    verify(apiUsageLogService, times(1)).record("GEMINI", 0);
+    verify(apiUsageLogService, times(1)).record("GEMINI", 0, "SERVER_POOL", null);
   }
 
   @Test

--- a/core/src/main/java/com/truthscope/web/entity/ApiUsageLog.java
+++ b/core/src/main/java/com/truthscope/web/entity/ApiUsageLog.java
@@ -47,4 +47,10 @@ public class ApiUsageLog {
 
   @Column(name = "token_count")
   private Integer tokenCount;
+
+  @Column(name = "key_source", nullable = false, length = 20)
+  private String keySource;
+
+  @Column(name = "key_fingerprint", length = 16)
+  private String keyFingerprint;
 }

--- a/core/src/main/java/com/truthscope/web/scoring/ClaimAnalysisPort.java
+++ b/core/src/main/java/com/truthscope/web/scoring/ClaimAnalysisPort.java
@@ -1,5 +1,6 @@
 package com.truthscope.web.scoring;
 
+import jakarta.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -7,6 +8,9 @@ import java.util.List;
  *
  * <p>구현체는 기사 본문({@code articleBody}) 을 분석하여 {@link ClaimDraft} 목록을 반환한다. 반환 목록이 비어 있으면 기사에서 검증 가능한
  * claim 이 추출되지 않은 것이다.
+ *
+ * <p>BE #74 amend: BYOK 지원 — {@code userApiKey} 인자가 추가된 2-arg 메서드가 정본. 기존 1-arg 시그니처는 default 메서드로
+ * backward compat 유지.
  */
 public interface ClaimAnalysisPort {
 
@@ -14,7 +18,18 @@ public interface ClaimAnalysisPort {
    * 기사 본문을 분석하여 claim 후보 목록을 반환한다.
    *
    * @param articleBody 분석 대상 기사 본문 텍스트 (non-null)
+   * @param userApiKey BYOK 사용자 Gemini API 키 (null → 서버 기본 키 사용)
    * @return 추출된 {@link ClaimDraft} 목록 (비어 있을 수 있음)
    */
-  List<ClaimDraft> analyze(String articleBody);
+  List<ClaimDraft> analyze(String articleBody, @Nullable String userApiKey);
+
+  /**
+   * Backward-compat: BYOK 없는 호출 — {@code userApiKey} null 위임.
+   *
+   * @param articleBody 분석 대상 기사 본문 텍스트
+   * @return 추출된 {@link ClaimDraft} 목록
+   */
+  default List<ClaimDraft> analyze(String articleBody) {
+    return analyze(articleBody, null);
+  }
 }


### PR DESCRIPTION
<!-- SAFE_OP_START -->
Assumptions: PR #85 (모델 ID GA 정정) 머지 대기 — base dev rebase 시 PRIMARY_MODEL 상수만 충돌 가능(file region overlap 0). DISCUSS rev.3 + PLAN rev.3 cross-review 4 round (Claude PROCEED-CONDITIONS / Codex BLOCK→REVISE 진척) 후 진입.
Scope: app/.../controller/NewsController + service/AnalysisService + service/claim/ClaimAnalysisService + service/claim/ClaimAnalysisStubService + service/audit/ApiUsageLogService + audit/KeyFingerprinter(신규) + gemini/GeminiClient + gemini/GeminiResponse + core/.../scoring/ClaimAnalysisPort + core/.../entity/ApiUsageLog + db/migration/V7 + 테스트 5종.
Out-of-scope: Bucket4j BYOK 다중 대역폭(ADR-004 §d 후속 phase), ArchUnit log redaction rule, WireMock cassette integration test(별 트랙), 회귀 시뮬레이션 ABCD(별 트랙), S4-01 Vercel Edge Proxy 통합(FE #45), FM13 base_url 검증 강제(RestClientConfig 기존 baseUrl로 보호).
<!-- SAFE_OP_END -->

## 요약

BE #74 (S3-05) Gemini Claim Extractor BYOK 통합 — ADR-004 §c (1회성 헤더) + §d (key_source 분류) + §f (key_fingerprint redaction, 모든 호출 기록) 정합. NewsController `X-User-Gemini-Key` 헤더 수신 → AnalysisService → ClaimAnalysisService → GeminiClient.callStructured 키 override chain. BYOK 401/403 시 `GeminiResponse.authFailed()` 신호로 서버 기본 키 1회 fallback (audit 2 row).

## 변경 핵심

- **신규**: `KeyFingerprinter` (SHA-256 hex 16자 / `com.truthscope.web.audit` 패키지 — ArchUnit `..service..` 회피), `V7__add_key_source_to_api_usage_logs.sql`
- **시그니처 amend**: `ClaimAnalysisPort.analyze(body, userApiKey)` abstract + default backward compat, `GeminiClient.callStructured(req, overrideApiKey)` + `fallbackStructured(req, overrideApiKey, throwable)`, `ApiUsageLogService.record(provider, tokenCount, keySource, keyFingerprint)` 4-arg overload, `AnalysisService.analyze(request, userApiKey)`, `GeminiResponse(claims, decisionSource, authFailure)` 3-arg record
- **`@Transactional` 미추가** — 외부 HTTP 호출 시 DB 커넥션 점유 회피 (현행 `ClaimAnalysisService` 패턴 유지)

## Done

- [✅] 운영 코드 amend (Controller + AnalysisService + ClaimAnalysisService + Stub + GeminiClient + ApiUsageLogService + entity + Port + DecisionSource enum 무변경)
- [✅] V7 migration + entity 필드 + Hibernate `ddl-auto: validate` 정합
- [✅] BYOK 분기 4 시나리오 (SERVER_POOL / BYOK / BYOK_FAILED+SERVER_POOL_FALLBACK / CB 분류 유지)
- [✅] ADR-004 §f "모든 Gemini 호출 기록" — fallback 시 audit 2 row
- [✅] `./gradlew check` GREEN (spotless + checkstyle + spotbugs + test + ArchUnit 6m31s)
- [✅] 단위 테스트 — `KeyFingerprinterTest` (6 cases) + `ClaimAnalysisServiceByokTest` (4 시나리오)
- [✅] 호출부 갱신 — `NewsControllerTest` + `VerificationCascadeIntegrationTest` + `VerificationPipelineIntegrationTest` + `ClaimAnalysisServiceTest` + `GeminiClientTest`
- [ ] **후속 트랙**: WireMock cassette integration test + 회귀 시뮬레이션 ABCD (PLAN rev.3 commit #9 영역, 별 PR로 진행)

## 검증

- 사전 cross-review 4 round (Claude code-reviewer + Codex 5.5 read-only sandbox)
- DISCUSS rev.1 → rev.2 → rev.3 progressive amend (포트 stale → 출력 contract → BYOK runtime → audit 2 row → KeyFingerprinter 위치 → Port default 방향)
- PLAN rev.1 → rev.2 → rev.3 progressive amend (8 amend 누적)
- 코드 1줄 안 짠 시점에 cross-review로 7+ 회귀 사전 차단 (포트 stale, audit 시그니처 결함, BYOK 판별 로직, ArchUnit 위반 등)

## Atomic commit 10개

1. 🗃️db(audit): V7 migration
2. ✨feat(audit): KeyFingerprinter + ApiUsageLog entity 필드
3. ✨feat(gemini): GeminiResponse.authFailed factory + GeminiClient BYOK override
4. ♻️refactor(audit): ApiUsageLogService.record 4-arg overload
5. ✨feat(claim): ClaimAnalysisPort BYOK 시그니처 + ClaimAnalysisService BYOK 분기 + audit 2 row
6. ♻️refactor(api): AnalysisService + NewsController userApiKey chain
7. 🔧chore(test): WireMock dep + 호출부 stub 갱신
8. ✅test(audit): ClaimAnalysisServiceTest 4-arg verify
9. ✅test(byok): KeyFingerprinter + ClaimAnalysisServiceByok 단위 테스트
10. ✅test(stub): claimAnalysisPort 2-arg stub 갱신 + any import

## Out-of-scope (별 트랙)

- WireMock cassette `gemini-claim-extract-success.json` + `GeminiByokIntegrationTest`
- 회귀 시뮬레이션 ABCD 4 변종 무력화 + 예상 fail test stdout
- Bucket4j BYOK 다중 대역폭 (ADR-004 §d 후속 phase)
- ArchUnit `userApiKey` log redaction rule

## 참조

- DISCUSS rev.3: `truthscope-web/.plans/be74-gemini-claim-extractor-2026-05-27/DISCUSS.md`
- PLAN rev.3: 동일 폴더 `PLAN.md`
- ADR-004 BYOK Edge Proxy, ADR-022 Gemini GA
- 선행 PR #85 (모델 ID GA 정정)

Co-authored-by: KWONSEOK02 <gwonseok02@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 사용자 API 키 (BYOK) 지원 추가
  * BYOK 인증 실패 시 자동 폴백 처리
  * API 사용량 로그에 키 소스 및 지문 정보 추가

* **테스트**
  * BYOK 기능 통합 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/truthscope-smu/truthscope-web-backend/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->