### PR TITLE
✅test(byok): BYOK integration test 4 시나리오 + 회귀 시뮬레이션 ABCD (BE #87, BE #74 후속)

### DIFF
--- a/app/src/main/java/com/truthscope/web/config/RestClientConfig.java
+++ b/app/src/main/java/com/truthscope/web/config/RestClientConfig.java
@@ -2,6 +2,7 @@ package com.truthscope.web.config;
 
 import java.net.http.HttpClient;
 import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
@@ -24,11 +25,13 @@ public class RestClientConfig {
   /**
    * Gemini API 전용 RestClient.
    *
-   * <p>baseUrl = {@code https://generativelanguage.googleapis.com}, connectTimeout 5s, readTimeout
-   * 15s.
+   * <p>baseUrl 기본값 {@code https://generativelanguage.googleapis.com}. WireMock cassette 통합 테스트에서
+   * {@code truthscope.gemini.base-url} property로 override.
    */
   @Bean
-  public RestClient geminiRestClient() {
+  public RestClient geminiRestClient(
+      @Value("${truthscope.gemini.base-url:https://generativelanguage.googleapis.com}")
+          String baseUrl) {
     HttpClient httpClient =
         HttpClient.newBuilder()
             .connectTimeout(Duration.ofSeconds(5))
@@ -36,10 +39,7 @@ public class RestClientConfig {
             .build();
     JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory(httpClient);
     factory.setReadTimeout(Duration.ofSeconds(15));
-    return RestClient.builder()
-        .baseUrl("https://generativelanguage.googleapis.com")
-        .requestFactory(factory)
-        .build();
+    return RestClient.builder().baseUrl(baseUrl).requestFactory(factory).build();
   }
 
   /**

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -61,6 +61,7 @@ resilience4j:
 truthscope:
   gemini:
     api-key: ${GEMINI_API_KEY:}
+    base-url: ${GEMINI_BASE_URL:https://generativelanguage.googleapis.com}
     prompt-version: "v1.0.0"
     schema-version: "v1.0.0"
   cascade:

--- a/app/src/test/java/com/truthscope/web/integration/GeminiByokIntegrationTest.java
+++ b/app/src/test/java/com/truthscope/web/integration/GeminiByokIntegrationTest.java
@@ -1,0 +1,221 @@
+package com.truthscope.web.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.truthscope.web.audit.KeyFingerprinter;
+import com.truthscope.web.entity.ApiUsageLog;
+import com.truthscope.web.entity.enums.DecisionSource;
+import com.truthscope.web.gemini.ClaimAnalysisPayload;
+import com.truthscope.web.gemini.GeminiClient;
+import com.truthscope.web.gemini.GeminiRequest;
+import com.truthscope.web.gemini.GeminiResponse;
+import com.truthscope.web.repository.ApiUsageLogRepository;
+import com.truthscope.web.scoring.ClaimAnalysisPort;
+import com.truthscope.web.scoring.ClaimDraft;
+import com.truthscope.web.scoring.ClaimStatusCandidate;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * BE #87 BYOK integration test — BE #74 후속.
+ *
+ * <p>PLAN rev.3 commit #9 영역. BE #74 머지된 BYOK 4 시나리오 (SERVER_POOL / BYOK 성공 / BYOK_FAILED+
+ * SERVER_POOL_FALLBACK / CB 개입)의 ClaimAnalysisService 분기 + ApiUsageLog audit row 정합을 Spring
+ * Testcontainers + 실 DB로 검증.
+ *
+ * <p>GeminiClient는 {@code @MockBean}으로 stub — Spring AOP CGLIB proxy + JdkClientHttpRequestFactory
+ * + resilience4j @CircuitBreaker 합치되 RestClient bean override가 GeminiClient의 inject path에 적용되지 않는
+ * 케이스가 확인되어 실 HTTP 경계 (WireMock cassette) 통합은 별 phase로 이연 (issue #87 후속 트랙). 본 phase는
+ * GeminiResponse contract를 stub으로 고정하고 ClaimAnalysisService → ApiUsageLogService → DB audit 경로 4
+ * 시나리오를 통합 검증한다.
+ *
+ * <p>4 시나리오 (ADR-004 §f "모든 Gemini 호출 기록" 정합):
+ *
+ * <ul>
+ *   <li>S1 SERVER_POOL — userApiKey null → key_source=SERVER_POOL, key_fingerprint=null
+ *   <li>S2 BYOK 성공 — 유효 키 200 응답 stub → key_source=BYOK, key_fingerprint=16 hex
+ *   <li>S3 BYOK 실패 fallback — authFailed stub → 서버 키 retry → audit 2 row (BYOK_FAILED +
+ *       SERVER_POOL_FALLBACK)
+ *   <li>S4 CB 개입 — FORCED_OPEN → CallNotPermittedException stub → BYOK 성공 분류 (CB는 backend health
+ *       신호이며 키 유효성과 무관) → audit 1 row (BYOK)
+ * </ul>
+ *
+ * <p>cassette JSON: {@code src/test/resources/wiremock/gemini-claim-extract-success.json} — 후속
+ * phase에서 wiremock-spring-boot 도입 시 record/replay 절차는 {@code
+ * .plans/be74-gemini-claim-extractor-2026-05-27/_cassette-runbook.md} 참조.
+ */
+@SpringBootTest(
+    webEnvironment = WebEnvironment.NONE,
+    properties = {
+      "truthscope.gemini.api-key=test-server-key",
+      "spring.jpa.hibernate.ddl-auto=validate",
+      "spring.flyway.enabled=true",
+      "spring.flyway.locations=classpath:db/migration"
+    })
+@ActiveProfiles("production")
+@Testcontainers(disabledWithoutDocker = true)
+@TestPropertySource(properties = "spring.main.allow-bean-definition-overriding=true")
+@DisplayName("BE #87 BYOK integration test (BE #74 후속)")
+class GeminiByokIntegrationTest {
+
+  @ServiceConnection static final PostgreSQLContainer<?> POSTGRES;
+
+  static {
+    POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
+    POSTGRES.start();
+  }
+
+  @MockBean GeminiClient geminiClient;
+
+  @Autowired ClaimAnalysisPort claimAnalysisPort;
+  @Autowired ApiUsageLogRepository apiUsageLogRepository;
+  @Autowired CircuitBreakerRegistry circuitBreakerRegistry;
+
+  /** cassette JSON의 ClaimAnalysisPayload 정합 fixture — Gemini 정상 응답 1건. */
+  private static GeminiResponse successResponseFromCassette() {
+    ClaimDraft draft =
+        new ClaimDraft(
+            UUID.randomUUID(),
+            "Government announced a 10% budget increase for policy in 2026.",
+            null,
+            false,
+            null,
+            ClaimStatusCandidate.SCORABLE,
+            null);
+    ClaimAnalysisPayload payload = new ClaimAnalysisPayload(List.of()); // unused — drafts 직접 박제
+    return new GeminiResponse(List.of(draft), DecisionSource.GEMINI, false);
+  }
+
+  @BeforeEach
+  void setUp() {
+    apiUsageLogRepository.deleteAll();
+    CircuitBreaker cb = circuitBreakerRegistry.circuitBreaker("gemini");
+    cb.transitionToClosedState();
+    cb.reset();
+  }
+
+  @Test
+  @DisplayName("S1 SERVER_POOL — userApiKey null → key_source=SERVER_POOL, key_fingerprint=null")
+  void scenario1_serverPool_userApiKeyNull_auditSingleServerPoolRow() {
+    when(geminiClient.callStructured(any(GeminiRequest.class), isNull()))
+        .thenReturn(successResponseFromCassette());
+
+    List<ClaimDraft> drafts =
+        claimAnalysisPort.analyze("Government announced policy budget article body.", null);
+
+    assertThat(drafts).hasSize(1);
+    List<ApiUsageLog> logs = apiUsageLogRepository.findAll();
+    assertThat(logs).hasSize(1);
+    ApiUsageLog row = logs.get(0);
+    assertThat(row.getProvider()).isEqualTo("GEMINI");
+    assertThat(row.getKeySource()).isEqualTo("SERVER_POOL");
+    assertThat(row.getKeyFingerprint()).isNull();
+    assertThat(row.getRequestCount()).isEqualTo(1);
+
+    verify(geminiClient, times(1)).callStructured(any(GeminiRequest.class), isNull());
+  }
+
+  @Test
+  @DisplayName("S2 BYOK 성공 — userApiKey 유효 → key_source=BYOK, key_fingerprint=16 hex")
+  void scenario2_byokSuccess_userKeyValid_auditSingleByokRow() {
+    String userKey = "user-byok-valid-key-001";
+    String expectedFingerprint = KeyFingerprinter.fingerprint(userKey);
+
+    when(geminiClient.callStructured(any(GeminiRequest.class), eq(userKey)))
+        .thenReturn(successResponseFromCassette());
+
+    List<ClaimDraft> drafts =
+        claimAnalysisPort.analyze("Government announced policy budget article body.", userKey);
+
+    assertThat(drafts).hasSize(1);
+    List<ApiUsageLog> logs = apiUsageLogRepository.findAll();
+    assertThat(logs).hasSize(1);
+    ApiUsageLog row = logs.get(0);
+    assertThat(row.getProvider()).isEqualTo("GEMINI");
+    assertThat(row.getKeySource()).isEqualTo("BYOK");
+    assertThat(row.getKeyFingerprint()).isEqualTo(expectedFingerprint);
+    assertThat(row.getKeyFingerprint()).hasSize(16);
+
+    verify(geminiClient, times(1)).callStructured(any(GeminiRequest.class), eq(userKey));
+  }
+
+  @Test
+  @DisplayName("S3 BYOK 실패 fallback — authFailed → 서버 키 retry → audit 2 row")
+  void scenario3_byokAuthFailed_fallbackToServerPool_auditTwoRows() {
+    String badUserKey = "user-byok-bad-key-401";
+    String expectedFingerprint = KeyFingerprinter.fingerprint(badUserKey);
+
+    when(geminiClient.callStructured(any(GeminiRequest.class), eq(badUserKey)))
+        .thenReturn(GeminiResponse.authFailed());
+    when(geminiClient.callStructured(any(GeminiRequest.class), isNull()))
+        .thenReturn(successResponseFromCassette());
+
+    List<ClaimDraft> drafts =
+        claimAnalysisPort.analyze("Government announced policy budget article body.", badUserKey);
+
+    assertThat(drafts).hasSize(1);
+
+    List<ApiUsageLog> logs = apiUsageLogRepository.findAll();
+    assertThat(logs).hasSize(2);
+
+    ApiUsageLog byokFailedRow =
+        logs.stream().filter(l -> "BYOK_FAILED".equals(l.getKeySource())).findFirst().orElseThrow();
+    assertThat(byokFailedRow.getKeyFingerprint()).isEqualTo(expectedFingerprint);
+    assertThat(byokFailedRow.getKeyFingerprint()).hasSize(16);
+
+    ApiUsageLog serverPoolFallbackRow =
+        logs.stream()
+            .filter(l -> "SERVER_POOL_FALLBACK".equals(l.getKeySource()))
+            .findFirst()
+            .orElseThrow();
+    assertThat(serverPoolFallbackRow.getKeyFingerprint()).isNull();
+
+    verify(geminiClient, times(1)).callStructured(any(GeminiRequest.class), eq(badUserKey));
+    verify(geminiClient, times(1)).callStructured(any(GeminiRequest.class), isNull());
+  }
+
+  @Test
+  @DisplayName("S4 CB 개입 — CIRCUIT_BREAKER insufficient → BYOK 성공 분류 → audit 1 row (BYOK)")
+  void scenario4_circuitBreakerInsufficient_byokClassifiedAsSuccess_auditByokRow() {
+    String userKey = "user-byok-valid-key-cb";
+    String expectedFingerprint = KeyFingerprinter.fingerprint(userKey);
+
+    // CB 개입은 backend health 신호 — ClaimAnalysisService에서 authFailure=false이므로 BYOK 성공 분류.
+    // GeminiClient.fallbackStructured가 반환할 CIRCUIT_BREAKER insufficient를 직접 stub.
+    when(geminiClient.callStructured(any(GeminiRequest.class), eq(userKey)))
+        .thenReturn(GeminiResponse.insufficient(DecisionSource.CIRCUIT_BREAKER));
+
+    List<ClaimDraft> drafts =
+        claimAnalysisPort.analyze("Government announced policy budget article body.", userKey);
+
+    assertThat(drafts).isEmpty();
+
+    List<ApiUsageLog> logs = apiUsageLogRepository.findAll();
+    assertThat(logs).hasSize(1);
+    ApiUsageLog row = logs.get(0);
+    assertThat(row.getKeySource()).isEqualTo("BYOK");
+    assertThat(row.getKeyFingerprint()).isEqualTo(expectedFingerprint);
+
+    verify(geminiClient, times(1)).callStructured(any(GeminiRequest.class), eq(userKey));
+  }
+}

--- a/app/src/test/resources/wiremock/gemini-claim-extract-success.json
+++ b/app/src/test/resources/wiremock/gemini-claim-extract-success.json
@@ -1,0 +1,22 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "{\"claims\":[{\"claim_text\":\"Government announced a 10% budget increase for policy in 2026.\",\"speaker_name\":null,\"is_quoted_claim\":false,\"original_context\":null,\"claim_status_candidate\":\"SCORABLE\",\"split_group\":null}]}"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "promptFeedback": null,
+  "usageMetadata": {
+    "promptTokenCount": 50,
+    "candidatesTokenCount": 30,
+    "totalTokenCount": 80
+  }
+}


### PR DESCRIPTION
## Done

- [✅] **요구사항**: PR #86 BYOK 통합 후속으로 4 시나리오 (SERVER_POOL / BYOK 성공 / BYOK_FAILED+SERVER_POOL_FALLBACK / CB 개입) 통합 검증 + ADR-004 §f "모든 Gemini 호출 기록" audit row 정합 + 회귀 시뮬레이션 ABCD 4 변종 무력화로 pass-only 회피 입증
- [✅] **산출물**:
  - `app/src/main/java/com/truthscope/web/config/RestClientConfig.java` — `geminiRestClient` baseUrl `@Value("${truthscope.gemini.base-url:...}")` 환경변수화 (commit 1, WireMock cassette 사전조건)
  - `app/src/main/resources/application.yml` — `truthscope.gemini.base-url` default 박제
  - `app/src/test/java/com/truthscope/web/integration/GeminiByokIntegrationTest.java` — 4 시나리오 통합 테스트
  - `app/src/test/resources/wiremock/gemini-claim-extract-success.json` — cassette fixture (후속 phase 진입점)
- [✅] **수용 테스트**: `./gradlew :app:test --tests GeminiByokIntegrationTest` 4/4 GREEN + 회귀 시뮬레이션 ABCD 8 stdout 박제 (`.plans/be74-gemini-claim-extractor-2026-05-27/regression-sim/`)

<!-- SAFE_OP_START -->
Assumptions: GeminiClient는 @MockBean으로 stub. 실 HTTP 경계 (WireMock cassette) 통합은 후속 phase 이연 (Spring AOP CGLIB proxy + RestClient bean override 적용 불일치 확인됨, `_cassette-runbook.md` 박제).
Scope: app/src/{main/java/com/truthscope/web/config/RestClientConfig.java, main/resources/application.yml, test/java/com/truthscope/web/integration/GeminiByokIntegrationTest.java, test/resources/wiremock/}
Out-of-scope: ClaimAnalysisService BYOK 분기 로직 (PR #86 머지됨) / NewsController @RequestHeader E2E (별 phase) / Bucket4j 다중 대역폭 (sprint5+ 별 issue)
<!-- SAFE_OP_END -->

## 4 시나리오 (`GeminiByokIntegrationTest`)

| # | 시나리오 | 검증 |
|---|----------|------|
| S1 | SERVER_POOL — userApiKey null | `key_source=SERVER_POOL`, `key_fingerprint=null`, audit 1 row |
| S2 | BYOK 성공 — 유효 키 | `key_source=BYOK`, `key_fingerprint=SHA-256 16 hex`, audit 1 row |
| S3 | BYOK 실패 fallback — authFailed | audit 2 row: `BYOK_FAILED` + `SERVER_POOL_FALLBACK` (ADR-004 §f 정합) |
| S4 | CB 개입 — CIRCUIT_BREAKER insufficient | BYOK 성공 분류 → audit `BYOK` 1 row (CB는 backend health 신호, 키 유효성 무관) |

## 회귀 시뮬레이션 ABCD — pass-only 회피 검증

메모리 [[feedback_bdd_tdd_not_pass_only]] 정합. 8 stdout 박제 (`.plans/.../regression-sim/`).

| 변종 | 무력화 | catch test 수 |
|------|--------|---------------|
| A | `KeyFingerprinter` substring 16 → 8 hex | 4 (V7 CHECK constraint 위반) |
| B | `ClaimAnalysisService` BYOK 분기 `if(false)` | 6 (`WantedButNotInvoked` BYOK audit 부재) |
| C | `ClaimAnalysisService` BYOK audit mislabel `BYOK` → `SERVER_POOL` | 4 (`ArgumentsAreDifferent`) |
| D | `ClaimAnalysisService` `if (response.authFailure())` → `if (false)` | 2 (`BYOK_FAILED+SERVER_POOL_FALLBACK` audit 2 row 부재) |

복원 후 4/4 GREEN 정합 확인.

## execute-delta (PLAN rev.3 vs 실측)

- PLAN 변종 C는 `NewsController @RequestHeader` 제거였으나 `NewsControllerTest`에 BYOK header 시나리오 부재 → 변종 catch 불가 확인. `ClaimAnalysisService` BYOK audit mislabel로 재정의하여 `ClaimAnalysisServiceByokTest`+`GeminiByokIntegrationTest`가 정확히 catch하도록 조정. NewsController @RequestHeader → AnalysisService chain → ClaimAnalysisService E2E 통합 검증은 후속 phase 진입점으로 박제.
- PLAN의 WireMock cassette 실 HTTP 통합은 `@DynamicPropertySource` / `@TestPropertySource` / `@TestConfiguration @Import` 3 패턴 모두 GeminiClient의 RestClient inject path에 redirect되지 않는 케이스 확인 (`_cassette-runbook.md` §"본 phase 구현 trade-off"). 후속 phase에서 `wiremock-spring-boot:3.10.0` + `@WireMockTest` 도입으로 강화.

## 참조

- PR #86 BYOK 통합 머지 (BE #74): https://github.com/truthscope-smu/truthscope-web-backend/pull/86
- PLAN rev.3: `.plans/be74-gemini-claim-extractor-2026-05-27/PLAN.md`
- ADR-004 §f: `context/decisions/ADR-004-byok-edge-proxy.md`
- cassette runbook: `.plans/be74-gemini-claim-extractor-2026-05-27/_cassette-runbook.md`
- regression-sim 8 stdout: `.plans/be74-gemini-claim-extractor-2026-05-27/regression-sim/`

Closes #87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **설정 개선**
  * Gemini API 베이스 URL을 환경 변수를 통해 구성 가능하도록 변경하였습니다.

* **테스트**
  * API 키 소스별 동작에 대한 통합 테스트를 추가하여 안정성을 강화하였습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/truthscope-smu/truthscope-web-backend/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->