### PR TITLE
✅test(arch): ArchUnit BYOK userApiKey log redaction rule (BE #90, BE #74 후속 트랙 4)

### DIFF
--- a/app/src/test/java/com/truthscope/web/architecture/ArchitectureTest.java
+++ b/app/src/test/java/com/truthscope/web/architecture/ArchitectureTest.java
@@ -1,6 +1,7 @@
 package com.truthscope.web.architecture;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
 import static com.tngtech.archunit.library.Architectures.layeredArchitecture;
@@ -158,4 +159,33 @@ class ArchitectureTest {
           .allowEmptyShould(true)
           .because(
               "CONVENTIONS: 요청 DTO는 record 타입 (Java 17+) — immutable + 자동 equals/hashCode/toString.");
+
+  // ── BYOK userApiKey log redaction (ADR-004 §f, BE #90 트랙 4) ──
+
+  @ArchTest
+  static final ArchRule claimAnalysisServiceMustUseKeyFingerprinter =
+      classes()
+          .that()
+          .haveSimpleName("ClaimAnalysisService")
+          .should()
+          .dependOnClassesThat()
+          .haveFullyQualifiedName("com.truthscope.web.audit.KeyFingerprinter")
+          .allowEmptyShould(true)
+          .because(
+              "ADR-004 §f BYOK audit fingerprint 강제 — ClaimAnalysisService는 userApiKey 원본 대신 KeyFingerprinter.fingerprint() 결과만 audit에 박제. 의존 부재 시 원본 키 누출 path 발생.");
+
+  @ArchTest
+  static final ArchRule byokClassesShouldNotHaveSlf4jLoggerField =
+      fields()
+          .that()
+          .areDeclaredInClassesThat()
+          .haveSimpleName("ClaimAnalysisService")
+          .or()
+          .areDeclaredInClassesThat()
+          .haveSimpleName("GeminiClient")
+          .should()
+          .notHaveRawType("org.slf4j.Logger")
+          .allowEmptyShould(true)
+          .because(
+              "ADR-004 §f userApiKey log redaction — BYOK 처리 클래스(ClaimAnalysisService + GeminiClient)는 SLF4J Logger field 금지. Logger field 부재로 userApiKey 원본 log 박제 path 정적 차단. logging 필요 시 AOP @Around 분리 또는 KeyFingerprinter 결과만 박제.");
 }


### PR DESCRIPTION
## Done

- [✅] **요구사항**: ADR-004 §f userApiKey 원본 log 박제 path를 ArchUnit 정적 분석으로 차단
- [✅] **산출물**: `ArchitectureTest.java` rule 2건 추가
  - `claimAnalysisServiceMustUseKeyFingerprinter` — ClaimAnalysisService → KeyFingerprinter 의존 강제
  - `byokClassesShouldNotHaveSlf4jLoggerField` — ClaimAnalysisService/GeminiClient SLF4J Logger field 금지
- [✅] **수용 테스트**: `./gradlew :app:test --tests ArchitectureTest` 12/12 GREEN + 회귀 시뮬레이션 변종 E 박제 (`.plans/be90-archunit-byok-log-redaction/variant-e-{fail,restore}.txt`)

<!-- SAFE_OP_START -->
Assumptions: BYOK 처리 클래스에서 로깅이 필요하면 AOP @Around 또는 별 layer로 분리 (KeyFingerprinter 결과만 박제). 현재 그 두 클래스 모두 Logger field 없음 — rule이 baseline 동작 유지.
Scope: app/src/test/java/com/truthscope/web/architecture/ArchitectureTest.java
Out-of-scope: AOP logging layer 신규 (필요 시 별 phase) / userApiKey method body argument flow 분석 (ArchUnit 표준 API 한계로 본 phase 제외) / 다른 BYOK 처리 confidential field log redaction rule
<!-- SAFE_OP_END -->

## 회귀 시뮬레이션 — 변종 E

GeminiClient에 Logger field 추가 시 정확히 catch:

```
ArchitectureTest > byokClassesShouldNotHaveSlf4jLoggerField FAILED
    java.lang.AssertionError at ArchRule.java:94
12 tests completed, 1 failed
```

복원 후 12/12 GREEN. 메모리 [[feedback_bdd_tdd_not_pass_only]] 정합.

## 참조

- BE #87 PR #88 cassette runbook §"본 phase 구현 trade-off": <https://github.com/truthscope-smu/truthscope-web-backend/pull/88>
- ADR-004 §f: `context/decisions/ADR-004-byok-edge-proxy.md`
- 우선순위 박제: 메모리 [[project_truthscope_be74_followup_tracks_priority]] 트랙 4

Closes #90