### PR TITLE
✨feat(article): 기사 검증 결과 조회 API 추가

### DIFF
--- a/app/src/main/java/com/truthscope/web/controller/ArticleController.java
+++ b/app/src/main/java/com/truthscope/web/controller/ArticleController.java
@@ -2,7 +2,9 @@ package com.truthscope.web.controller;
 
 import com.truthscope.web.dto.request.AttachToSessionRequest;
 import com.truthscope.web.dto.response.ArticleResponse;
+import com.truthscope.web.dto.response.ArticleVerificationResponse;
 import com.truthscope.web.service.ArticleService;
+import com.truthscope.web.service.ArticleVerificationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -25,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ArticleController {
 
   private final ArticleService articleService;
+  private final ArticleVerificationService articleVerificationService;
 
   @Operation(summary = "기사 ID로 조회", description = "추출된 기사를 ID로 조회한다.")
   @ApiResponses({
@@ -47,5 +50,15 @@ public class ArticleController {
   public ArticleResponse attachToSession(
       @PathVariable UUID id, @Valid @RequestBody AttachToSessionRequest request) {
     return articleService.attachToSession(id, request.sessionId());
+  }
+
+  @Operation(summary = "기사 검증 결과 조회", description = "기사 ID로 분석 검증 결과(점수/판정/claim별 결과)를 조회한다.")
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "조회 성공"),
+    @ApiResponse(responseCode = "404", description = "기사/세션 미존재")
+  })
+  @GetMapping("/{id}/verification")
+  public ArticleVerificationResponse findVerification(@PathVariable UUID id) {
+    return articleVerificationService.getVerification(id);
   }
 }

--- a/app/src/main/java/com/truthscope/web/repository/ClaimRepository.java
+++ b/app/src/main/java/com/truthscope/web/repository/ClaimRepository.java
@@ -4,8 +4,14 @@ import com.truthscope.web.entity.Claim;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ClaimRepository extends JpaRepository<Claim, UUID> {
 
   List<Claim> findByArticleId(UUID articleId);
+
+  @Query(
+      "SELECT c FROM Claim c WHERE c.article.id = :articleId ORDER BY c.sortOrder ASC NULLS LAST")
+  List<Claim> findByArticleIdOrderBySortOrderAsc(@Param("articleId") UUID articleId);
 }

--- a/app/src/main/java/com/truthscope/web/repository/VerificationResultRepository.java
+++ b/app/src/main/java/com/truthscope/web/repository/VerificationResultRepository.java
@@ -1,11 +1,23 @@
 package com.truthscope.web.repository;
 
 import com.truthscope.web.entity.VerificationResult;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface VerificationResultRepository extends JpaRepository<VerificationResult, UUID> {
 
   Optional<VerificationResult> findByClaimId(UUID claimId);
+
+  /**
+   * claim_id 목록에 해당하는 검증 결과를 claim과 함께 단일 쿼리로 조회한다 (H2 N+1 제거).
+   *
+   * <p>JOIN FETCH로 claim을 함께 로드하므로 호출 측에서 {@code result.getClaim().getId()} 접근 시 LAZY 프록시 초기화 추가
+   * 쿼리가 발생하지 않는다. JPQL {@code IN :claimIds}는 빈 컬렉션 파라미터도 안전하게 처리한다(Hibernate 6).
+   */
+  @Query("SELECT vr FROM VerificationResult vr JOIN FETCH vr.claim WHERE vr.claim.id IN :claimIds")
+  List<VerificationResult> findByClaimIdIn(@Param("claimIds") List<UUID> claimIds);
 }

--- a/app/src/main/java/com/truthscope/web/service/ArticleVerificationService.java
+++ b/app/src/main/java/com/truthscope/web/service/ArticleVerificationService.java
@@ -1,0 +1,139 @@
+package com.truthscope.web.service;
+
+import com.truthscope.web.converter.ArticleVerificationConverter;
+import com.truthscope.web.dto.response.ArticleVerificationResponse;
+import com.truthscope.web.dto.response.ClaimItemSource;
+import com.truthscope.web.entity.AnalysisSession;
+import com.truthscope.web.entity.Article;
+import com.truthscope.web.entity.Claim;
+import com.truthscope.web.entity.VerificationResult;
+import com.truthscope.web.entity.enums.Tier3Reason;
+import com.truthscope.web.exception.NotFoundException;
+import com.truthscope.web.repository.ArticleRepository;
+import com.truthscope.web.repository.ClaimRepository;
+import com.truthscope.web.repository.VerificationResultRepository;
+import com.truthscope.web.scoring.ClaimScoreStatus;
+import com.truthscope.web.scoring.ScoreBandPolicy;
+import com.truthscope.web.scoring.TruthLabelDeriver;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 기사 검증 결과 조회 서비스 (UC-140 결과 카드 표시, EO).
+ *
+ * <p>T4: articleId → ArticleVerificationResponse. session null 가드(RC-01), 소유권 골격(UC-140 A1),
+ * per-claim 도출(R-004 score null 언박싱 방어, RC-06 SCORABLE 상호 배타).
+ */
+@Service
+@RequiredArgsConstructor
+public class ArticleVerificationService {
+
+  private final ArticleRepository articleRepository;
+  private final ClaimRepository claimRepository;
+  private final VerificationResultRepository verificationResultRepository;
+  private final ScoreBandPolicy bandPolicy; // ScoringPolicyConfig @Bean (AnalysisService와 동일)
+
+  /**
+   * 기사 ID로 검증 결과를 조회한다.
+   *
+   * @param articleId 조회할 기사 ID
+   * @return ArticleVerificationResponse
+   * @throws NotFoundException 기사 또는 분석 세션이 존재하지 않는 경우
+   */
+  @Transactional(readOnly = true)
+  public ArticleVerificationResponse getVerification(UUID articleId) {
+    Article article =
+        articleRepository
+            .findById(articleId)
+            .orElseThrow(() -> new NotFoundException("기사를 찾을 수 없습니다"));
+
+    AnalysisSession session = article.getSession();
+    if (session == null) { // RC-01 Critical
+      throw new NotFoundException("기사에 분석 세션이 없습니다: " + articleId);
+    }
+
+    // 소유권 골격(UC-140 A1): session.getMember()!=null && 인증사용자 불일치면 403.
+    //   현재 SecurityConfig.permitAll + 인증 principal 부재 -> 익명/소유자없음 공개 허용(MVP).
+    //   throw 없음 -> OpenAPI 403 미기재. 인증 배선 phase에서 ForbiddenException + throw 추가.
+
+    String articleLabel = deriveArticleLabel(session.getTotalScore());
+    List<Claim> claims = claimRepository.findByArticleIdOrderBySortOrderAsc(articleId);
+    List<ClaimItemSource> claimSources = buildClaimSources(claims);
+
+    return ArticleVerificationConverter.toResponse(article, session, articleLabel, claimSources);
+  }
+
+  /** 기사 단위 라벨 도출. totalScore null이면 null (검증 가능 claim 0건). */
+  private String deriveArticleLabel(Short totalScore) {
+    if (totalScore == null) {
+      return null;
+    }
+    return TruthLabelDeriver.deriveTruthLabel(totalScore.intValue(), bandPolicy).name();
+  }
+
+  /**
+   * claim 목록을 ClaimItemSource 목록으로 구성한다.
+   *
+   * <p>H3: claim 0건이면 빈 IN 절(PostgreSQL syntax error) 방지 + 불필요한 조회 생략. bulk 조회(C-01/F-02 N+1 완화)는
+   * JOIN FETCH로 claim을 함께 로드하므로 {@code r.getClaim().getId()} 접근 시 추가 쿼리가 없다(H2).
+   */
+  private List<ClaimItemSource> buildClaimSources(List<Claim> claims) {
+    if (claims.isEmpty()) {
+      return List.of();
+    }
+    List<UUID> claimIds = claims.stream().map(Claim::getId).toList();
+    Map<UUID, VerificationResult> resultMap =
+        verificationResultRepository.findByClaimIdIn(claimIds).stream()
+            .collect(Collectors.toMap(r -> r.getClaim().getId(), Function.identity()));
+    return claims.stream()
+        .map(claim -> toClaimSource(claim, resultMap.get(claim.getId())))
+        .toList();
+  }
+
+  /** 단일 claim + 검증 결과를 ClaimItemSource로 변환한다 (truthLabel/claimScoreStatus 도출 포함). */
+  private ClaimItemSource toClaimSource(Claim claim, VerificationResult result) {
+    // R-004 score null 언박싱 방어 — 명시 블록
+    Short rawScore = Optional.ofNullable(result).map(VerificationResult::getScore).orElse(null);
+    String truthLabel =
+        (rawScore != null)
+            ? TruthLabelDeriver.deriveTruthLabel(rawScore.intValue(), bandPolicy).name()
+            : null;
+
+    // H1/RC-06: SCORABLE이면 claimScoreStatus=null (truthLabel과 상호 배타)
+    ClaimScoreStatus derivedStatus =
+        (result != null) ? deriveStatus(result.getTier3Reason()) : null;
+    String claimScoreStatus =
+        (derivedStatus != null && derivedStatus != ClaimScoreStatus.SCORABLE)
+            ? derivedStatus.name()
+            : null;
+
+    return new ClaimItemSource(claim, result, truthLabel, claimScoreStatus);
+  }
+
+  /**
+   * Tier3Reason → ClaimScoreStatus 매핑 헬퍼.
+   *
+   * <p>tier3Reason=null이면 SCORABLE (Tier 1/2 판정 완료). 비판정(INSUFFICIENT/TIME_SENSITIVE/OUT_OF_SCOPE)은
+   * 대응 status를 반환한다. 호출 측에서 SCORABLE인 경우 DTO claimScoreStatus는 null로 세팅된다 (RC-06 상호 배타).
+   *
+   * @param tier3Reason VerificationResult.tier3Reason, null이면 SCORABLE
+   * @return 대응 ClaimScoreStatus
+   */
+  private static ClaimScoreStatus deriveStatus(Tier3Reason tier3Reason) {
+    if (tier3Reason == null) {
+      return ClaimScoreStatus.SCORABLE;
+    }
+    return switch (tier3Reason) {
+      case INSUFFICIENT -> ClaimScoreStatus.INSUFFICIENT;
+      case TIME_SENSITIVE -> ClaimScoreStatus.TIME_SENSITIVE;
+      case OUT_OF_SCOPE -> ClaimScoreStatus.OUT_OF_SCOPE;
+    };
+  }
+}

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -30,6 +30,11 @@ spring:
       name: admin
       password: ${ADMIN_PASSWORD:admin}
 
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false # epoch 배열 대신 ISO-8601 문자열
+    time-zone: UTC
+
 server:
   port: ${SERVER_PORT:8080}
 

--- a/app/src/test/java/com/truthscope/web/controller/ArticleControllerTest.java
+++ b/app/src/test/java/com/truthscope/web/controller/ArticleControllerTest.java
@@ -14,6 +14,7 @@ import com.truthscope.web.exception.ConflictException;
 import com.truthscope.web.exception.GlobalExceptionHandler;
 import com.truthscope.web.exception.NotFoundException;
 import com.truthscope.web.service.ArticleService;
+import com.truthscope.web.service.ArticleVerificationService;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -35,6 +36,9 @@ class ArticleControllerTest {
   @Autowired private MockMvc mockMvc;
 
   @MockitoBean private ArticleService articleService;
+
+  // findVerification 엔드포인트 추가로 컨트롤러 의존 주입됨 — WebMvcTest 컨텍스트 로드용 mock
+  @MockitoBean private ArticleVerificationService articleVerificationService;
 
   @Test
   @DisplayName("GET /api/v1/articles/{id} — 200 + ArticleResponse 반환")

--- a/app/src/test/java/com/truthscope/web/controller/ArticleVerificationControllerIntegrationTest.java
+++ b/app/src/test/java/com/truthscope/web/controller/ArticleVerificationControllerIntegrationTest.java
@@ -1,0 +1,260 @@
+package com.truthscope.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.truthscope.web.entity.AnalysisSession;
+import com.truthscope.web.entity.Article;
+import com.truthscope.web.entity.Claim;
+import com.truthscope.web.entity.VerificationResult;
+import com.truthscope.web.entity.enums.SessionStatus;
+import com.truthscope.web.entity.enums.Verdict;
+import com.truthscope.web.repository.AnalysisSessionRepository;
+import com.truthscope.web.repository.ArticleRepository;
+import com.truthscope.web.repository.ClaimRepository;
+import com.truthscope.web.repository.VerificationResultRepository;
+import com.truthscope.web.support.AbstractIntegrationTest;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * ArticleController.findVerification 통합 테스트 (T7).
+ *
+ * <p>PLAN 통합 테스트 전략 반영:
+ *
+ * <ul>
+ *   <li>GET /api/v1/articles/{id}/verification 200 + JSON 단언
+ *   <li>(rev.2) ISO-8601 직렬화 단언: $.claims[0].verifiedAt이 ISO 문자열(epoch 배열 아님)
+ *   <li>(F-03) $.claims[0].isQuotedClaim 키 존재 단언
+ *   <li>(C-5) $.claims[0].evidence == [] 단언
+ *   <li>(F-05) claims[] sort_order 오름차순 단언
+ *   <li>미존재 id 404 + GlobalExceptionHandler envelope
+ * </ul>
+ *
+ * <p>fixture: VerificationResult 1건 이상 + sort_order 0/1/2 Claim 3건 + totalScore=70 (회귀 시뮬 A용
+ * MOSTLY_FACT 밴드 60-79).
+ *
+ * <p>AbstractIntegrationTest 상속: @SpringBootTest(RANDOM_PORT) + Testcontainers PostgreSQL Singleton
+ * + create-drop. MockMvc는 @AutoConfigureMockMvc로 주입.
+ */
+@AutoConfigureMockMvc
+class ArticleVerificationControllerIntegrationTest extends AbstractIntegrationTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ArticleRepository articleRepository;
+  @Autowired private AnalysisSessionRepository sessionRepository;
+  @Autowired private ClaimRepository claimRepository;
+  @Autowired private VerificationResultRepository verificationResultRepository;
+
+  // fixture 저장 엔티티
+  private Article savedArticle;
+  private AnalysisSession savedSession;
+  private Claim savedClaim0;
+  private Claim savedClaim1;
+  private Claim savedClaim2;
+  private VerificationResult savedResult;
+
+  @BeforeEach
+  void setup() {
+    // FK 안전 순서: VerificationResult → Claim → Article → AnalysisSession
+    verificationResultRepository.deleteAllInBatch();
+    claimRepository.deleteAllInBatch();
+    articleRepository.deleteAllInBatch();
+    sessionRepository.deleteAllInBatch();
+
+    // 회귀 시뮬 A fixture: totalScore=70 (MOSTLY_FACT 밴드 60-79).
+    // factMin 기본값=80 이라 totalScore>=80이면 FACT 원래 맞아 상수 치환 FAIL 검출 불가.
+    savedSession =
+        sessionRepository.saveAndFlush(
+            AnalysisSession.builder()
+                .status(SessionStatus.COMPLETED)
+                .requestedAt(LocalDateTime.now().minusMinutes(5))
+                .completedAt(LocalDateTime.now().minusMinutes(1))
+                .totalScore((short) 70)
+                .tier1Count((short) 1)
+                .tier2Count((short) 0)
+                .tier3Count((short) 0)
+                .member(null) // 익명 세션 (공개 허용 MVP)
+                .build());
+
+    savedArticle =
+        articleRepository.saveAndFlush(
+            Article.extract(
+                "https://example.com/news/verification-integ",
+                "검증 통합테스트 기사",
+                "통합테스트 본문",
+                "ko",
+                "example.com"));
+    // 세션 부착 (attachTo는 DDD 비즈니스 메서드 — setter 금지)
+    savedArticle.attachTo(savedSession);
+    savedArticle = articleRepository.saveAndFlush(savedArticle);
+
+    // sort_order 0/1/2 Claim 3건 — F-05 순서 단언용
+    savedClaim0 =
+        claimRepository.saveAndFlush(
+            Claim.builder()
+                .article(savedArticle)
+                .text("첫 번째 claim — sort_order=0")
+                .sortOrder((short) 0)
+                .isQuotedClaim(false)
+                .build());
+    savedClaim1 =
+        claimRepository.saveAndFlush(
+            Claim.builder()
+                .article(savedArticle)
+                .text("두 번째 claim — sort_order=1")
+                .sortOrder((short) 1)
+                .isQuotedClaim(true)
+                .build());
+    savedClaim2 =
+        claimRepository.saveAndFlush(
+            Claim.builder()
+                .article(savedArticle)
+                .text("세 번째 claim — sort_order=2")
+                .sortOrder((short) 2)
+                .isQuotedClaim(false)
+                .build());
+
+    // VerificationResult: claim0에만 부착 (1건 이상 fixture 요구 충족 + 회귀 시뮬 B 전제)
+    savedResult =
+        verificationResultRepository.saveAndFlush(
+            VerificationResult.builder()
+                .claim(savedClaim0)
+                .tier((short) 1)
+                .verdict(Verdict.SUPPORTED)
+                .score((short) 70)
+                .verifiedAt(LocalDateTime.now().minusMinutes(2))
+                .build());
+  }
+
+  // ── 1. 200 happy path ────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("GET /api/v1/articles/{id}/verification — 200 + articleLabel MOSTLY_FACT")
+  void findVerification_happyPath_200_articleLabel() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/articles/" + savedArticle.getId() + "/verification"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.articleId").value(savedArticle.getId().toString()))
+        .andExpect(jsonPath("$.articleLabel").value("MOSTLY_FACT"))
+        .andExpect(jsonPath("$.totalScore").value(70))
+        .andExpect(jsonPath("$.status").value("COMPLETED"));
+  }
+
+  @Test
+  @DisplayName("(rev.2) verifiedAt ISO-8601 직렬화 단언 — epoch 배열 아님")
+  void findVerification_verifiedAt_isIso8601String_notEpochArray() throws Exception {
+    // C-2 Critical: write-dates-as-timestamps=false 설정 단언
+    // epoch 배열은 "[2026,5,30,...]" 형태, ISO는 "2026-05-30T..." 형태
+    String body =
+        mockMvc
+            .perform(get("/api/v1/articles/" + savedArticle.getId() + "/verification"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.claims[0].verifiedAt").isString())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    // ISO-8601 패턴: "2026-..." 으로 시작하고 "T"를 포함해야 함 (epoch 배열 "[" 으로 시작하지 않음)
+    assertThat(body).contains("\"verifiedAt\":");
+    assertThat(body).doesNotContain("\"verifiedAt\":["); // epoch 배열 형태 아님
+  }
+
+  @Test
+  @DisplayName("(F-03) isQuotedClaim 키 존재 단언 — Lombok is-getter Jackson 키 보존")
+  void findVerification_isQuotedClaim_keyPresent() throws Exception {
+    // F-03: @JsonProperty("isQuotedClaim") 적용 여부 — 미적용 시 키가 "quotedClaim"으로 나옴
+    mockMvc
+        .perform(get("/api/v1/articles/" + savedArticle.getId() + "/verification"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.claims[0].isQuotedClaim").isBoolean())
+        .andExpect(jsonPath("$.claims[0].isQuotedClaim").value(false))
+        .andExpect(jsonPath("$.claims[1].isQuotedClaim").value(true));
+  }
+
+  @Test
+  @DisplayName("(C-5) evidence=[] 빈 배열 계약 단언")
+  void findVerification_evidence_isEmptyArray() throws Exception {
+    // C-5: 66a 빈 배열 계약 — 66b에서 채움
+    mockMvc
+        .perform(get("/api/v1/articles/" + savedArticle.getId() + "/verification"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.claims[0].evidence").isArray())
+        .andExpect(jsonPath("$.claims[0].evidence").isEmpty());
+  }
+
+  @Test
+  @DisplayName("(F-05) claims[] sort_order 오름차순 단언 — 0/1/2 순서")
+  void findVerification_claims_orderedBySortOrderAsc() throws Exception {
+    // F-05: findByArticleIdOrderBySortOrderAsc(@Query NULLS LAST) 정렬 검증
+    mockMvc
+        .perform(get("/api/v1/articles/" + savedArticle.getId() + "/verification"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.claims").isArray())
+        .andExpect(jsonPath("$.claims.length()").value(3))
+        .andExpect(jsonPath("$.claims[0].claimText").value("첫 번째 claim — sort_order=0"))
+        .andExpect(jsonPath("$.claims[1].claimText").value("두 번째 claim — sort_order=1"))
+        .andExpect(jsonPath("$.claims[2].claimText").value("세 번째 claim — sort_order=2"));
+  }
+
+  @Test
+  @DisplayName("VerificationResult 있는 claim — verdict 단언")
+  void findVerification_claimWithResult_verdictPresent() throws Exception {
+    // 회귀 시뮬 B 전제: VerificationResult 1건 이상 존재 + claims[0].verdict 단언
+    mockMvc
+        .perform(get("/api/v1/articles/" + savedArticle.getId() + "/verification"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.claims[0].verdict").value("SUPPORTED"))
+        .andExpect(jsonPath("$.claims[0].score").value(70))
+        .andExpect(jsonPath("$.claims[0].truthLabel").value("MOSTLY_FACT"))
+        // RC-06: SCORABLE(tier3Reason null) claim은 claimScoreStatus=null (truthLabel과 상호 배타)
+        .andExpect(jsonPath("$.claims[0].claimScoreStatus").value(nullValue()));
+  }
+
+  @Test
+  @DisplayName("VerificationResult 없는 claim — verdict/truthLabel null 단언")
+  void findVerification_claimWithoutResult_verdictNull() throws Exception {
+    // claim1, claim2는 VerificationResult 없음 — 미검증 claim
+    // Jackson 기본 설정: null 필드는 "null"로 직렬화(NON_NULL 미설정) → value(nullValue()) 사용
+    mockMvc
+        .perform(get("/api/v1/articles/" + savedArticle.getId() + "/verification"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.claims[1].verdict").value(nullValue()))
+        .andExpect(jsonPath("$.claims[1].truthLabel").value(nullValue()))
+        .andExpect(jsonPath("$.claims[2].verdict").value(nullValue()));
+  }
+
+  // ── 2. 404 처리 ───────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("GET /api/v1/articles/{id}/verification — 미존재 id → 404 + envelope")
+  void findVerification_notFoundId_returns404() throws Exception {
+    UUID unknownId = UUID.randomUUID();
+
+    mockMvc
+        .perform(get("/api/v1/articles/" + unknownId + "/verification"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.statusCode").value(404));
+  }
+
+  // ── 3. sourceTransparency null (66a 계약) ─────────────────────────────────
+
+  @Test
+  @DisplayName("sourceTransparency=null 단언 — 66a 계약, 66b에서 채움")
+  void findVerification_sourceTransparency_isNull() throws Exception {
+    // 66a 계약: sourceTransparency=null (Jackson 기본: null 필드는 "null"로 직렬화)
+    mockMvc
+        .perform(get("/api/v1/articles/" + savedArticle.getId() + "/verification"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.sourceTransparency").value(nullValue()));
+  }
+}

--- a/app/src/test/java/com/truthscope/web/service/ArticleVerificationServiceTest.java
+++ b/app/src/test/java/com/truthscope/web/service/ArticleVerificationServiceTest.java
@@ -1,0 +1,451 @@
+package com.truthscope.web.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.when;
+
+import com.truthscope.web.dto.response.ArticleVerificationResponse;
+import com.truthscope.web.entity.AnalysisSession;
+import com.truthscope.web.entity.Article;
+import com.truthscope.web.entity.Claim;
+import com.truthscope.web.entity.VerificationResult;
+import com.truthscope.web.entity.enums.SessionStatus;
+import com.truthscope.web.entity.enums.Tier3Reason;
+import com.truthscope.web.entity.enums.Verdict;
+import com.truthscope.web.exception.NotFoundException;
+import com.truthscope.web.repository.ArticleRepository;
+import com.truthscope.web.repository.ClaimRepository;
+import com.truthscope.web.repository.VerificationResultRepository;
+import com.truthscope.web.scoring.ScoreBandPolicy;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * ArticleVerificationService 단위 테스트 (T6).
+ *
+ * <p>PLAN 테스트 전략 Unit 반영: totalScore-&gt;articleLabel 밴드 도출, score-&gt;truthLabel,
+ * tier3Reason-&gt;claimScoreStatus, totalScore null이면 articleLabel null, R-004 score=null이면 NPE 없이
+ * truthLabel null, RC-01 session null이면 NotFoundException(404), articleId 미존재 404, member null 공개
+ * 허용, RC-06 SCORABLE이면 claimScoreStatus null.
+ *
+ * <p>회귀 시뮬레이션 무력화 A fixture: totalScore=70 (MOSTLY_FACT 밴드 60-79). factMin 기본값=80이므로
+ * totalScore&gt;=80이면 FACT가 원래 맞아 상수 치환 FAIL 검출 불가.
+ *
+ * <p>참고: claim 0건 테스트는 H3 조기 반환으로 findByClaimIdIn을 호출하지 않으므로 해당 stub을 두지 않는다(strict Mockito
+ * UnnecessaryStubbing 회피).
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ArticleVerificationService 단위 테스트")
+class ArticleVerificationServiceTest {
+
+  @Mock private ArticleRepository articleRepository;
+  @Mock private ClaimRepository claimRepository;
+  @Mock private VerificationResultRepository verificationResultRepository;
+
+  // ScoreBandPolicy(80, 60, 40, 20) — 기본값과 동일. MOSTLY_FACT 밴드: 60..79
+  private static final ScoreBandPolicy BAND_POLICY = new ScoreBandPolicy(80, 60, 40, 20);
+
+  private ArticleVerificationService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new ArticleVerificationService(
+            articleRepository, claimRepository, verificationResultRepository, BAND_POLICY);
+  }
+
+  // -----------------------------------------------------------------------------------------
+  // 헬퍼 팩토리
+  // -----------------------------------------------------------------------------------------
+
+  /** 분석 세션에 부착된 기사 생성. Article.extract() 사용(static factory — DDD 원칙). */
+  private Article buildArticleWithSession(AnalysisSession session) {
+    Article article =
+        Article.extract("https://example.com/news", "테스트 기사", "본문", "ko", "example.com");
+    article.attachTo(session);
+    return article;
+  }
+
+  /** 세션에 부착되지 않은 기사 생성 (session null 가드 테스트용). */
+  private Article buildArticleWithoutSession() {
+    return Article.extract("https://example.com/news", "세션 없는 기사", "본문", "ko", "example.com");
+  }
+
+  /**
+   * COMPLETED 세션 생성. totalScore 지정.
+   *
+   * <p>completeCascade를 직접 호출할 수 없으므로 Builder로 필드를 직접 채운다. member 필드는 null로 세팅(익명 공개).
+   */
+  private AnalysisSession buildSession(Short totalScore) {
+    return AnalysisSession.builder()
+        .id(UUID.randomUUID())
+        .status(SessionStatus.COMPLETED)
+        .totalScore(totalScore)
+        .completedAt(LocalDateTime.now())
+        .member(null) // 익명 세션 (공개 허용 MVP)
+        .build();
+  }
+
+  private Claim buildClaim(UUID id, String text, Short sortOrder) {
+    return Claim.builder().id(id).text(text).sortOrder(sortOrder).isQuotedClaim(false).build();
+  }
+
+  /**
+   * VerificationResult 생성.
+   *
+   * <p>claim 연결은 claim 필드 직접 설정 — Claim.getId()를 resultMap 키로 사용하므로 claim.id와 result.claim.id가 일치해야
+   * 한다.
+   */
+  private VerificationResult buildResult(Claim claim, Short score, Tier3Reason tier3Reason) {
+    return VerificationResult.builder()
+        .id(UUID.randomUUID())
+        .claim(claim)
+        .tier((short) 1)
+        .verdict(Verdict.SUPPORTED)
+        .score(score)
+        .tier3Reason(tier3Reason)
+        .verifiedAt(LocalDateTime.now())
+        .build();
+  }
+
+  // -----------------------------------------------------------------------------------------
+  // 1. 기사 단위 articleLabel 도출 (totalScore -> articleLabel 밴드)
+  // -----------------------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("articleLabel 도출 (totalScore 밴드)")
+  class ArticleLabelDerivation {
+
+    @Test
+    @DisplayName("totalScore=70이면 MOSTLY_FACT (회귀 시뮬 무력화 A fixture)")
+    void totalScore_70이면_MOSTLY_FACT() {
+      // 회귀 무력화 A fixture: totalScore=70 (MOSTLY_FACT 밴드 60-79)
+      // 상수 "FACT"로 치환 시 expected: MOSTLY_FACT but was: FACT
+      AnalysisSession session = buildSession((short) 70);
+      Article article = buildArticleWithSession(session);
+      UUID articleId = article.getId();
+
+      when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
+      when(claimRepository.findByArticleIdOrderBySortOrderAsc(articleId)).thenReturn(List.of());
+
+      ArticleVerificationResponse response = service.getVerification(articleId);
+
+      assertThat(response.getArticleLabel()).isEqualTo("MOSTLY_FACT");
+    }
+
+    @Test
+    @DisplayName("totalScore=80이면 FACT")
+    void totalScore_80이면_FACT() {
+      AnalysisSession session = buildSession((short) 80);
+      Article article = buildArticleWithSession(session);
+      UUID articleId = article.getId();
+
+      when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
+      when(claimRepository.findByArticleIdOrderBySortOrderAsc(articleId)).thenReturn(List.of());
+
+      ArticleVerificationResponse response = service.getVerification(articleId);
+
+      assertThat(response.getArticleLabel()).isEqualTo("FACT");
+    }
+
+    @Test
+    @DisplayName("totalScore null이면 articleLabel null (검증 가능 claim 0건)")
+    void totalScore_null이면_articleLabel_null() {
+      AnalysisSession session = buildSession(null);
+      Article article = buildArticleWithSession(session);
+      UUID articleId = article.getId();
+
+      when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
+      when(claimRepository.findByArticleIdOrderBySortOrderAsc(articleId)).thenReturn(List.of());
+
+      ArticleVerificationResponse response = service.getVerification(articleId);
+
+      assertThat(response.getArticleLabel()).isNull();
+    }
+  }
+
+  // -----------------------------------------------------------------------------------------
+  // 2. claim 단위 truthLabel 도출 (score -> truthLabel)
+  // -----------------------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("claim truthLabel 도출 (score 밴드)")
+  class ClaimTruthLabelDerivation {
+
+    @Test
+    @DisplayName("score=75이면 truthLabel=MOSTLY_FACT (tier3Reason null이므로 SCORABLE 경로)")
+    void score_75이면_truthLabel_MOSTLY_FACT() {
+      AnalysisSession session = buildSession((short) 75);
+      Article article = buildArticleWithSession(session);
+      UUID articleId = article.getId();
+      UUID claimId = UUID.randomUUID();
+
+      Claim claim = buildClaim(claimId, "테스트 claim", (short) 0);
+      VerificationResult result =
+          buildResult(claim, (short) 75, null); // tier3Reason=null → SCORABLE
+
+      when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
+      when(claimRepository.findByArticleIdOrderBySortOrderAsc(articleId))
+          .thenReturn(List.of(claim));
+      when(verificationResultRepository.findByClaimIdIn(List.of(claimId)))
+          .thenReturn(List.of(result));
+
+      ArticleVerificationResponse response = service.getVerification(articleId);
+
+      assertThat(response.getClaims()).hasSize(1);
+      assertThat(response.getClaims().get(0).getTruthLabel()).isEqualTo("MOSTLY_FACT");
+    }
+
+    @Test
+    @DisplayName("score=80이면 truthLabel=FACT")
+    void score_80이면_truthLabel_FACT() {
+      AnalysisSession session = buildSession((short) 80);
+      Article article = buildArticleWithSession(session);
+      UUID articleId = article.getId();
+      UUID claimId = UUID.randomUUID();
+
+      Claim claim = buildClaim(claimId, "팩트 claim", (short) 0);
+      VerificationResult result = buildResult(claim, (short) 80, null);
+
+      when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
+      when(claimRepository.findByArticleIdOrderBySortOrderAsc(articleId))
+          .thenReturn(List.of(claim));
+      when(verificationResultRepository.findByClaimIdIn(List.of(claimId)))
+          .thenReturn(List.of(result));
+
+      ArticleVerificationResponse response = service.getVerification(articleId);
+
+      assertThat(response.getClaims().get(0).getTruthLabel()).isEqualTo("FACT");
+    }
+
+    @Test
+    @DisplayName("R-004: score=null이면 NPE 없이 truthLabel=null")
+    void score_null이면_NPE_없이_truthLabel_null() {
+      // R-004 score null 언박싱 방어 — Short rawScore 언박싱 NPE 발생하면 안 됨
+      AnalysisSession session = buildSession(null);
+      Article article = buildArticleWithSession(session);
+      UUID articleId = article.getId();
+      UUID claimId = UUID.randomUUID();
+
+      Claim claim = buildClaim(claimId, "비판정 claim", (short) 0);
+      // score=null, tier3Reason=INSUFFICIENT
+      VerificationResult result = buildResult(claim, null, Tier3Reason.INSUFFICIENT);
+
+      when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
+      when(claimRepository.findByArticleIdOrderBySortOrderAsc(articleId))
+          .thenReturn(List.of(claim));
+      when(verificationResultRepository.findByClaimIdIn(List.of(claimId)))
+          .thenReturn(List.of(result));
+
+      // NPE가 발생하지 않아야 함
+      ArticleVerificationResponse response = service.getVerification(articleId);
+
+      assertThat(response.getClaims()).hasSize(1);
+      assertThat(response.getClaims().get(0).getTruthLabel()).isNull();
+    }
+  }
+
+  // -----------------------------------------------------------------------------------------
+  // 3. tier3Reason -> claimScoreStatus 도출
+  // -----------------------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("claimScoreStatus 도출 (tier3Reason 매핑)")
+  class ClaimScoreStatusDerivation {
+
+    @Test
+    @DisplayName("tier3Reason=INSUFFICIENT이면 claimScoreStatus=INSUFFICIENT")
+    void tier3Reason_INSUFFICIENT이면_claimScoreStatus_INSUFFICIENT() {
+      AnalysisSession session = buildSession(null);
+      Article article = buildArticleWithSession(session);
+      UUID articleId = article.getId();
+      UUID claimId = UUID.randomUUID();
+
+      Claim claim = buildClaim(claimId, "근거 부족 claim", (short) 0);
+      VerificationResult result = buildResult(claim, null, Tier3Reason.INSUFFICIENT);
+
+      when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
+      when(claimRepository.findByArticleIdOrderBySortOrderAsc(articleId))
+          .thenReturn(List.of(claim));
+      when(verificationResultRepository.findByClaimIdIn(List.of(claimId)))
+          .thenReturn(List.of(result));
+
+      ArticleVerificationResponse response = service.getVerification(articleId);
+
+      assertThat(response.getClaims().get(0).getClaimScoreStatus()).isEqualTo("INSUFFICIENT");
+    }
+
+    @Test
+    @DisplayName("tier3Reason=TIME_SENSITIVE이면 claimScoreStatus=TIME_SENSITIVE")
+    void tier3Reason_TIME_SENSITIVE이면_claimScoreStatus_TIME_SENSITIVE() {
+      AnalysisSession session = buildSession(null);
+      Article article = buildArticleWithSession(session);
+      UUID articleId = article.getId();
+      UUID claimId = UUID.randomUUID();
+
+      Claim claim = buildClaim(claimId, "시점 의존 claim", (short) 0);
+      VerificationResult result = buildResult(claim, null, Tier3Reason.TIME_SENSITIVE);
+
+      when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
+      when(claimRepository.findByArticleIdOrderBySortOrderAsc(articleId))
+          .thenReturn(List.of(claim));
+      when(verificationResultRepository.findByClaimIdIn(List.of(claimId)))
+          .thenReturn(List.of(result));
+
+      ArticleVerificationResponse response = service.getVerification(articleId);
+
+      assertThat(response.getClaims().get(0).getClaimScoreStatus()).isEqualTo("TIME_SENSITIVE");
+    }
+
+    @Test
+    @DisplayName("tier3Reason=OUT_OF_SCOPE이면 claimScoreStatus=OUT_OF_SCOPE")
+    void tier3Reason_OUT_OF_SCOPE이면_claimScoreStatus_OUT_OF_SCOPE() {
+      AnalysisSession session = buildSession(null);
+      Article article = buildArticleWithSession(session);
+      UUID articleId = article.getId();
+      UUID claimId = UUID.randomUUID();
+
+      Claim claim = buildClaim(claimId, "범위 외 claim", (short) 0);
+      VerificationResult result = buildResult(claim, null, Tier3Reason.OUT_OF_SCOPE);
+
+      when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
+      when(claimRepository.findByArticleIdOrderBySortOrderAsc(articleId))
+          .thenReturn(List.of(claim));
+      when(verificationResultRepository.findByClaimIdIn(List.of(claimId)))
+          .thenReturn(List.of(result));
+
+      ArticleVerificationResponse response = service.getVerification(articleId);
+
+      assertThat(response.getClaims().get(0).getClaimScoreStatus()).isEqualTo("OUT_OF_SCOPE");
+    }
+
+    @Test
+    @DisplayName(
+        "RC-06: tier3Reason=null(SCORABLE)이면 claimScoreStatus=null, truthLabel만 set (상호 배타)")
+    void tier3Reason_null이면_claimScoreStatus_null_RC06() {
+      // PLAN RC-06: SCORABLE이면 DTO claimScoreStatus는 null, truthLabel과 상호 배타.
+      // 서비스가 deriveStatus()=SCORABLE을 null로 치환한다.
+      AnalysisSession session = buildSession((short) 75);
+      Article article = buildArticleWithSession(session);
+      UUID articleId = article.getId();
+      UUID claimId = UUID.randomUUID();
+
+      Claim claim = buildClaim(claimId, "정상 판정 claim", (short) 0);
+      VerificationResult result =
+          buildResult(claim, (short) 75, null); // tier3Reason=null → SCORABLE
+
+      when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
+      when(claimRepository.findByArticleIdOrderBySortOrderAsc(articleId))
+          .thenReturn(List.of(claim));
+      when(verificationResultRepository.findByClaimIdIn(List.of(claimId)))
+          .thenReturn(List.of(result));
+
+      ArticleVerificationResponse response = service.getVerification(articleId);
+
+      assertThat(response.getClaims().get(0).getClaimScoreStatus())
+          .isNull(); // RC-06: SCORABLE → null
+      assertThat(response.getClaims().get(0).getTruthLabel()).isEqualTo("MOSTLY_FACT"); // 상호 배타
+    }
+  }
+
+  // -----------------------------------------------------------------------------------------
+  // 4. 가드 검증 (RC-01, 404, 공개 허용)
+  // -----------------------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("가드 및 404 처리")
+  class Guards {
+
+    @Test
+    @DisplayName("RC-01: session null이면 NotFoundException(404)")
+    void session_null이면_NotFoundException() {
+      // Article은 존재하지만 session이 null인 상태
+      Article article = buildArticleWithoutSession();
+      UUID articleId = article.getId();
+
+      when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
+
+      assertThatExceptionOfType(NotFoundException.class)
+          .isThrownBy(() -> service.getVerification(articleId))
+          .withMessageContaining("분석 세션이 없습니다");
+    }
+
+    @Test
+    @DisplayName("articleId 미존재이면 NotFoundException(404)")
+    void articleId_미존재이면_NotFoundException() {
+      UUID unknownId = UUID.randomUUID();
+
+      when(articleRepository.findById(unknownId)).thenReturn(Optional.empty());
+
+      assertThatExceptionOfType(NotFoundException.class)
+          .isThrownBy(() -> service.getVerification(unknownId))
+          .withMessageContaining("기사를 찾을 수 없습니다");
+    }
+
+    @Test
+    @DisplayName("member null 세션(익명)이면 403 throw 없이 정상 응답 (공개 허용 MVP)")
+    void member_null_이면_공개_허용() {
+      // session.getMember()=null → 익명 세션 → 403 throw 없음 (OpenAPI 403 미기재)
+      AnalysisSession session = buildSession((short) 70); // member=null (buildSession 기본값)
+      Article article = buildArticleWithSession(session);
+      UUID articleId = article.getId();
+
+      when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
+      when(claimRepository.findByArticleIdOrderBySortOrderAsc(articleId)).thenReturn(List.of());
+
+      // NotFoundException 또는 다른 예외가 발생하지 않아야 함
+      ArticleVerificationResponse response = service.getVerification(articleId);
+
+      assertThat(response).isNotNull();
+      assertThat(response.getArticleId()).isEqualTo(articleId);
+    }
+
+    @Test
+    @DisplayName("claims 없으면 응답 claims 빈 리스트")
+    void claims_없으면_빈_리스트() {
+      AnalysisSession session = buildSession(null);
+      Article article = buildArticleWithSession(session);
+      UUID articleId = article.getId();
+
+      when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
+      when(claimRepository.findByArticleIdOrderBySortOrderAsc(articleId)).thenReturn(List.of());
+
+      ArticleVerificationResponse response = service.getVerification(articleId);
+
+      assertThat(response.getClaims()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("VerificationResult 없는 claim(미검증)이면 truthLabel/claimScoreStatus null")
+    void verificationResult_없으면_미검증_claim() {
+      AnalysisSession session = buildSession(null);
+      Article article = buildArticleWithSession(session);
+      UUID articleId = article.getId();
+      UUID claimId = UUID.randomUUID();
+
+      Claim claim = buildClaim(claimId, "미검증 claim", (short) 0);
+      // result 없음 — findByClaimIdIn 결과 비어있음
+
+      when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
+      when(claimRepository.findByArticleIdOrderBySortOrderAsc(articleId))
+          .thenReturn(List.of(claim));
+      when(verificationResultRepository.findByClaimIdIn(List.of(claimId))).thenReturn(List.of());
+
+      ArticleVerificationResponse response = service.getVerification(articleId);
+
+      assertThat(response.getClaims()).hasSize(1);
+      assertThat(response.getClaims().get(0).getTruthLabel()).isNull();
+      assertThat(response.getClaims().get(0).getClaimScoreStatus()).isNull();
+      assertThat(response.getClaims().get(0).getVerdict()).isNull();
+    }
+  }
+}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -18,6 +18,9 @@ dependencies {
 	// @JdbcTypeCode(SqlTypes.JSON) — Hibernate 6 JSONB 매핑. spring-data-jpa는 hibernate-core를 optional로 둠 단계로 core compileClasspath에 자동 부재. compileOnly 명시 의무. 런타임은 app 모듈 spring-boot-starter-data-jpa 제공.
 	compileOnly 'org.hibernate.orm:hibernate-core'
 
+	// @JsonProperty — DTO JSON 키 보존(F-03). spring-data-jpa의 jackson-databind는 optional 전이라 core compileClasspath 부재. compileOnly 명시. 런타임은 app 모듈 spring-boot-starter-web 제공.
+	compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
+
 	// 테스트 assertion — app 모듈 idiom(AssertJ) 정합. spring-boot BOM이 버전 관리.
 	testImplementation 'org.assertj:assertj-core'
 }

--- a/core/src/main/java/com/truthscope/web/converter/ArticleVerificationConverter.java
+++ b/core/src/main/java/com/truthscope/web/converter/ArticleVerificationConverter.java
@@ -1,0 +1,81 @@
+package com.truthscope.web.converter;
+
+import com.truthscope.web.dto.response.ArticleVerificationResponse;
+import com.truthscope.web.dto.response.ArticleVerificationResponse.ClaimVerificationItem;
+import com.truthscope.web.dto.response.ClaimItemSource;
+import com.truthscope.web.entity.AnalysisSession;
+import com.truthscope.web.entity.Article;
+import com.truthscope.web.entity.Claim;
+import com.truthscope.web.entity.VerificationResult;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Article + AnalysisSession + ClaimItemSource 목록 → ArticleVerificationResponse 순수 변환 유틸리티.
+ *
+ * <p>집계·도출 호출 없음 — 서비스가 계산한 값을 전달받아 매핑만 수행한다 (CONVENTIONS Converter 규칙).
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ArticleVerificationConverter {
+
+  /**
+   * Article, AnalysisSession, 도출된 articleLabel, ClaimItemSource 목록을 ArticleVerificationResponse로
+   * 변환한다.
+   *
+   * <p>evidence=[], sourceTransparency=null — 66b에서 채움 (C-5, 66a 계약).
+   *
+   * @param article 대상 기사 엔티티
+   * @param session 기사에 연결된 분석 세션
+   * @param articleLabel TruthLabel.name() 도출값, null 가능 (totalScore null이면 null)
+   * @param claimSources claim별 검증 결과 소스 목록 (T4 서비스가 구성 후 전달)
+   */
+  public static ArticleVerificationResponse toResponse(
+      Article article,
+      AnalysisSession session,
+      String articleLabel,
+      List<ClaimItemSource> claimSources) {
+
+    List<ClaimVerificationItem> claimItems =
+        claimSources.stream().map(ArticleVerificationConverter::toClaimItem).toList();
+
+    return ArticleVerificationResponse.builder()
+        .articleId(article.getId())
+        .url(article.getUrl())
+        .title(article.getTitle())
+        .status(session.getStatus().name())
+        .analysisCompletedAt(session.getCompletedAt())
+        .totalScore(session.getTotalScore())
+        .articleLabel(articleLabel)
+        .coverage(session.getCoverage())
+        .tier1Count(session.getTier1Count())
+        .tier2Count(session.getTier2Count())
+        .tier3Count(session.getTier3Count())
+        .sourceTransparency(null) // 66a=null, 66b에서 채움
+        .claims(claimItems)
+        .build();
+  }
+
+  private static ClaimVerificationItem toClaimItem(ClaimItemSource source) {
+    Claim claim = source.claim();
+    VerificationResult result = source.result();
+
+    return ClaimVerificationItem.builder()
+        .claimId(claim.getId())
+        .claimText(claim.getText())
+        .speakerName(claim.getSpeakerName())
+        .isQuotedClaim(claim.isQuotedClaim())
+        .originalContext(claim.getOriginalContext())
+        .tier(result != null ? result.getTier() : null)
+        .score(result != null ? result.getScore() : null)
+        // M1: verdict는 DB NOT NULL이나 Java 객체 수준 null 방어
+        .verdict(result != null && result.getVerdict() != null ? result.getVerdict().name() : null)
+        .reason(result != null ? result.getReason() : null)
+        .disclaimer(result != null ? result.getDisclaimer() : null)
+        .verifiedAt(result != null ? result.getVerifiedAt() : null)
+        .truthLabel(source.truthLabel())
+        .claimScoreStatus(source.claimScoreStatus())
+        // evidence=[] 빈 배열 계약 (C-5, 66b에서 채움)
+        .build();
+  }
+}

--- a/core/src/main/java/com/truthscope/web/dto/response/ArticleVerificationResponse.java
+++ b/core/src/main/java/com/truthscope/web/dto/response/ArticleVerificationResponse.java
@@ -1,0 +1,103 @@
+package com.truthscope.web.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.truthscope.web.scoring.CoverageSummary;
+import com.truthscope.web.scoring.SourceTransparencySummary;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 기사 검증 결과 조회 응답 DTO (UC-140 결과 카드 표시, EO). */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ArticleVerificationResponse {
+
+  /** Article ID */
+  private UUID articleId;
+
+  /** 기사 URL */
+  private String url;
+
+  /** 제목 */
+  private String title;
+
+  /** SessionStatus.name() */
+  private String status;
+
+  /** 기사 단위 검증완료 시각 (session.completedAt) */
+  private LocalDateTime analysisCompletedAt;
+
+  /** null = 검증가능 claim 0건 */
+  private Short totalScore;
+
+  /** TruthLabel.name() 도출값, null 가능 */
+  private String articleLabel;
+
+  /** JSONB record 그대로 (Jackson 직렬화) */
+  private CoverageSummary coverage;
+
+  /** 단일 출처: AnalysisSession 최상위 Short (C-4) */
+  private Short tier1Count;
+
+  private Short tier2Count;
+
+  private Short tier3Count;
+
+  /** 66a=null, 66b에서 채움 */
+  private SourceTransparencySummary sourceTransparency;
+
+  @Builder.Default private List<ClaimVerificationItem> claims = List.of();
+
+  /** claim별 검증 결과 항목 */
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class ClaimVerificationItem {
+
+    private UUID claimId;
+
+    /** FE 매핑: Phase 67에서 claim 키로 rename (C-6) */
+    private String claimText;
+
+    private String speakerName;
+
+    /** F-03: Lombok is-getter Jackson 키 보존 */
+    @JsonProperty("isQuotedClaim")
+    private boolean isQuotedClaim;
+
+    private String originalContext;
+
+    /** null = 미검증 claim */
+    private Short tier;
+
+    /** null = 비판정/미검증. FE 매핑: confidence (C-02) */
+    private Short score;
+
+    /** Verdict.name(). VerificationResult 존재 시 NOT NULL */
+    private String verdict;
+
+    private String reason;
+
+    /** Tier2만 원문, 아니면 null */
+    private String disclaimer;
+
+    /** claim 단위 검증시각 */
+    private LocalDateTime verifiedAt;
+
+    /** 도출값 (SCORABLE이고 score!=null), 아니면 null */
+    private String truthLabel;
+
+    /** 도출값 (비판정), SCORABLE이면 null. FE 매핑: status (RC-06) */
+    private String claimScoreStatus;
+
+    /** 66b 빈 배열 계약 (C-5) */
+    @Builder.Default private List<Object> evidence = List.of();
+  }
+}

--- a/core/src/main/java/com/truthscope/web/dto/response/ClaimItemSource.java
+++ b/core/src/main/java/com/truthscope/web/dto/response/ClaimItemSource.java
@@ -1,0 +1,18 @@
+package com.truthscope.web.dto.response;
+
+import com.truthscope.web.entity.Claim;
+import com.truthscope.web.entity.VerificationResult;
+
+/**
+ * claim별 검증 결과 조립 입력 레코드 (ArticleVerificationConverter 입력).
+ *
+ * <p>응답 조립 내부용 — 직렬화 대상이 아니다. 서비스(app)가 도출값(truthLabel/claimScoreStatus)을 계산해 채운 뒤 Converter(core)에
+ * 전달한다. converter 패키지에 두면 ArchUnit converterNaming 룰(클래스명 *Converter 강제)에 걸리므로 dto.response에 둔다.
+ *
+ * @param claim Claim 엔티티 (non-null)
+ * @param result VerificationResult 엔티티, null이면 미검증 claim
+ * @param truthLabel TruthLabel.name() 도출값, SCORABLE이고 score!=null인 경우만 non-null
+ * @param claimScoreStatus ClaimScoreStatus.name() 도출값, SCORABLE이면 null (truthLabel과 상호 배타)
+ */
+public record ClaimItemSource(
+    Claim claim, VerificationResult result, String truthLabel, String claimScoreStatus) {}

--- a/core/src/test/java/com/truthscope/web/converter/ArticleVerificationConverterTest.java
+++ b/core/src/test/java/com/truthscope/web/converter/ArticleVerificationConverterTest.java
@@ -1,0 +1,404 @@
+package com.truthscope.web.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.truthscope.web.dto.response.ArticleVerificationResponse;
+import com.truthscope.web.dto.response.ArticleVerificationResponse.ClaimVerificationItem;
+import com.truthscope.web.dto.response.ClaimItemSource;
+import com.truthscope.web.entity.AnalysisSession;
+import com.truthscope.web.entity.Article;
+import com.truthscope.web.entity.Claim;
+import com.truthscope.web.entity.VerificationResult;
+import com.truthscope.web.entity.enums.SessionStatus;
+import com.truthscope.web.entity.enums.Verdict;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * ArticleVerificationConverter 단위 테스트 (T6 선택).
+ *
+ * <p>PLAN 테스트 전략 Unit 반영: claim 매핑(text/speaker/isQuotedClaim/verdict/disclaimer/verifiedAt),
+ * evidence=[], sourceTransparency=null.
+ *
+ * <p>Converter는 Spring bean이 아닌 static 순수 변환 유틸리티이므로 Mockito 없이 직접 호출한다.
+ */
+@DisplayName("ArticleVerificationConverter 단위 테스트")
+class ArticleVerificationConverterTest {
+
+  // -----------------------------------------------------------------------------------------
+  // 헬퍼 팩토리
+  // -----------------------------------------------------------------------------------------
+
+  private AnalysisSession buildSession(Short totalScore) {
+    return AnalysisSession.builder()
+        .id(UUID.randomUUID())
+        .status(SessionStatus.COMPLETED)
+        .totalScore(totalScore)
+        .completedAt(LocalDateTime.of(2026, 5, 30, 12, 0, 0))
+        .member(null)
+        .build();
+  }
+
+  private Article buildArticle(AnalysisSession session) {
+    Article article =
+        Article.extract(
+            "https://news.example.com/article/1", "기사 제목", "본문 텍스트", "ko", "news.example.com");
+    if (session != null) {
+      article.attachTo(session);
+    }
+    return article;
+  }
+
+  private Claim buildClaim(
+      UUID id,
+      String text,
+      String speakerName,
+      boolean isQuotedClaim,
+      String originalContext,
+      Short sortOrder) {
+    return Claim.builder()
+        .id(id)
+        .text(text)
+        .speakerName(speakerName)
+        .isQuotedClaim(isQuotedClaim)
+        .originalContext(originalContext)
+        .sortOrder(sortOrder)
+        .build();
+  }
+
+  private VerificationResult buildResult(
+      Claim claim, Short score, String disclaimer, LocalDateTime verifiedAt) {
+    return VerificationResult.builder()
+        .id(UUID.randomUUID())
+        .claim(claim)
+        .tier((short) 2)
+        .verdict(Verdict.SUPPORTED)
+        .score(score)
+        .reason("검증 근거")
+        .disclaimer(disclaimer)
+        .verifiedAt(verifiedAt)
+        .build();
+  }
+
+  // -----------------------------------------------------------------------------------------
+  // 1. claim 매핑 기본 필드
+  // -----------------------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("claim 매핑 (text/speaker/isQuotedClaim/verdict/disclaimer/verifiedAt)")
+  class ClaimMapping {
+
+    @Test
+    @DisplayName("claimText, speakerName, isQuotedClaim, originalContext가 Claim에서 올바르게 매핑된다")
+    void claim_기본_필드_매핑() {
+      AnalysisSession session = buildSession((short) 75);
+      Article article = buildArticle(session);
+      UUID claimId = UUID.randomUUID();
+      LocalDateTime verifiedAt = LocalDateTime.of(2026, 5, 30, 10, 0, 0);
+
+      Claim claim = buildClaim(claimId, "정부 발표 claim 텍스트", "홍길동", true, "원문 맥락", (short) 0);
+      VerificationResult result = buildResult(claim, (short) 75, null, verifiedAt);
+      ClaimItemSource source = new ClaimItemSource(claim, result, "MOSTLY_FACT", null);
+
+      ArticleVerificationResponse response =
+          ArticleVerificationConverter.toResponse(article, session, "MOSTLY_FACT", List.of(source));
+
+      assertThat(response.getClaims()).hasSize(1);
+      ClaimVerificationItem item = response.getClaims().get(0);
+      assertThat(item.getClaimText()).isEqualTo("정부 발표 claim 텍스트");
+      assertThat(item.getSpeakerName()).isEqualTo("홍길동");
+      assertThat(item.isQuotedClaim()).isTrue();
+      assertThat(item.getOriginalContext()).isEqualTo("원문 맥락");
+    }
+
+    @Test
+    @DisplayName("verdict가 VerificationResult.verdict.name()으로 매핑된다")
+    void verdict_매핑() {
+      AnalysisSession session = buildSession((short) 75);
+      Article article = buildArticle(session);
+      UUID claimId = UUID.randomUUID();
+
+      Claim claim = buildClaim(claimId, "claim", null, false, null, (short) 0);
+      VerificationResult result = buildResult(claim, (short) 75, null, LocalDateTime.now());
+      ClaimItemSource source = new ClaimItemSource(claim, result, "MOSTLY_FACT", null);
+
+      ArticleVerificationResponse response =
+          ArticleVerificationConverter.toResponse(article, session, "MOSTLY_FACT", List.of(source));
+
+      assertThat(response.getClaims().get(0).getVerdict()).isEqualTo("SUPPORTED");
+    }
+
+    @Test
+    @DisplayName("Tier 2 disclaimer가 그대로 매핑된다")
+    void disclaimer_Tier2_매핑() {
+      AnalysisSession session = buildSession((short) 70);
+      Article article = buildArticle(session);
+      UUID claimId = UUID.randomUUID();
+      String disclaimerText = "AI 분석이며 기관 검증이 아닙니다. 참고 용도로만 활용하세요.";
+
+      Claim claim = buildClaim(claimId, "AI 분석 claim", null, false, null, (short) 0);
+      VerificationResult result =
+          buildResult(claim, (short) 70, disclaimerText, LocalDateTime.now());
+      ClaimItemSource source = new ClaimItemSource(claim, result, "MOSTLY_FACT", null);
+
+      ArticleVerificationResponse response =
+          ArticleVerificationConverter.toResponse(article, session, "MOSTLY_FACT", List.of(source));
+
+      assertThat(response.getClaims().get(0).getDisclaimer()).isEqualTo(disclaimerText);
+    }
+
+    @Test
+    @DisplayName("Tier 1(disclaimer=null)이면 disclaimer null")
+    void disclaimer_Tier1_null() {
+      AnalysisSession session = buildSession((short) 80);
+      Article article = buildArticle(session);
+      UUID claimId = UUID.randomUUID();
+
+      Claim claim = buildClaim(claimId, "Tier 1 claim", null, false, null, (short) 0);
+      VerificationResult result = buildResult(claim, (short) 80, null, LocalDateTime.now());
+      ClaimItemSource source = new ClaimItemSource(claim, result, "FACT", null);
+
+      ArticleVerificationResponse response =
+          ArticleVerificationConverter.toResponse(article, session, "FACT", List.of(source));
+
+      assertThat(response.getClaims().get(0).getDisclaimer()).isNull();
+    }
+
+    @Test
+    @DisplayName("verifiedAt이 VerificationResult에서 올바르게 매핑된다")
+    void verifiedAt_매핑() {
+      AnalysisSession session = buildSession((short) 75);
+      Article article = buildArticle(session);
+      UUID claimId = UUID.randomUUID();
+      LocalDateTime verifiedAt = LocalDateTime.of(2026, 5, 30, 9, 30, 0);
+
+      Claim claim = buildClaim(claimId, "claim", null, false, null, (short) 0);
+      VerificationResult result = buildResult(claim, (short) 75, null, verifiedAt);
+      ClaimItemSource source = new ClaimItemSource(claim, result, "MOSTLY_FACT", null);
+
+      ArticleVerificationResponse response =
+          ArticleVerificationConverter.toResponse(article, session, "MOSTLY_FACT", List.of(source));
+
+      assertThat(response.getClaims().get(0).getVerifiedAt()).isEqualTo(verifiedAt);
+    }
+
+    @Test
+    @DisplayName("isQuotedClaim=false인 경우도 올바르게 매핑된다")
+    void isQuotedClaim_false_매핑() {
+      AnalysisSession session = buildSession((short) 75);
+      Article article = buildArticle(session);
+      UUID claimId = UUID.randomUUID();
+
+      Claim claim = buildClaim(claimId, "인용 아닌 claim", null, false, null, (short) 0);
+      VerificationResult result = buildResult(claim, (short) 75, null, LocalDateTime.now());
+      ClaimItemSource source = new ClaimItemSource(claim, result, "MOSTLY_FACT", null);
+
+      ArticleVerificationResponse response =
+          ArticleVerificationConverter.toResponse(article, session, "MOSTLY_FACT", List.of(source));
+
+      assertThat(response.getClaims().get(0).isQuotedClaim()).isFalse();
+    }
+  }
+
+  // -----------------------------------------------------------------------------------------
+  // 2. evidence=[] 계약 (C-5)
+  // -----------------------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("evidence 빈 배열 계약 (C-5)")
+  class EvidenceContract {
+
+    @Test
+    @DisplayName("66a: VerificationResult 있는 claim의 evidence는 빈 배열")
+    void evidence_빈_배열() {
+      AnalysisSession session = buildSession((short) 75);
+      Article article = buildArticle(session);
+      UUID claimId = UUID.randomUUID();
+
+      Claim claim = buildClaim(claimId, "claim", null, false, null, (short) 0);
+      VerificationResult result = buildResult(claim, (short) 75, null, LocalDateTime.now());
+      ClaimItemSource source = new ClaimItemSource(claim, result, "MOSTLY_FACT", null);
+
+      ArticleVerificationResponse response =
+          ArticleVerificationConverter.toResponse(article, session, "MOSTLY_FACT", List.of(source));
+
+      assertThat(response.getClaims().get(0).getEvidence()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("66a: VerificationResult null(미검증) claim의 evidence도 빈 배열")
+    void evidence_미검증_claim도_빈_배열() {
+      AnalysisSession session = buildSession(null);
+      Article article = buildArticle(session);
+      UUID claimId = UUID.randomUUID();
+
+      Claim claim = buildClaim(claimId, "미검증 claim", null, false, null, (short) 0);
+      // result=null (미검증)
+      ClaimItemSource source = new ClaimItemSource(claim, null, null, null);
+
+      ArticleVerificationResponse response =
+          ArticleVerificationConverter.toResponse(article, session, null, List.of(source));
+
+      assertThat(response.getClaims().get(0).getEvidence()).isEmpty();
+    }
+  }
+
+  // -----------------------------------------------------------------------------------------
+  // 3. sourceTransparency=null 계약 (66a)
+  // -----------------------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("sourceTransparency null 계약 (66a)")
+  class SourceTransparencyContract {
+
+    @Test
+    @DisplayName("66a: sourceTransparency는 항상 null (66b에서 채움)")
+    void sourceTransparency_null() {
+      AnalysisSession session = buildSession((short) 75);
+      Article article = buildArticle(session);
+
+      ArticleVerificationResponse response =
+          ArticleVerificationConverter.toResponse(article, session, "MOSTLY_FACT", List.of());
+
+      assertThat(response.getSourceTransparency()).isNull();
+    }
+  }
+
+  // -----------------------------------------------------------------------------------------
+  // 4. 기사 단위 필드 매핑
+  // -----------------------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("기사 단위 필드 매핑 (articleId/url/title/status/analysisCompletedAt/totalScore)")
+  class ArticleFieldMapping {
+
+    @Test
+    @DisplayName("articleId, url, title이 Article에서 올바르게 매핑된다")
+    void article_기본_필드_매핑() {
+      AnalysisSession session = buildSession((short) 75);
+      Article article = buildArticle(session);
+
+      ArticleVerificationResponse response =
+          ArticleVerificationConverter.toResponse(article, session, "MOSTLY_FACT", List.of());
+
+      assertThat(response.getUrl()).isEqualTo("https://news.example.com/article/1");
+      assertThat(response.getTitle()).isEqualTo("기사 제목");
+      assertThat(response.getArticleId()).isEqualTo(article.getId());
+    }
+
+    @Test
+    @DisplayName("status가 SessionStatus.name()으로 매핑된다")
+    void session_status_매핑() {
+      AnalysisSession session = buildSession((short) 75);
+      Article article = buildArticle(session);
+
+      ArticleVerificationResponse response =
+          ArticleVerificationConverter.toResponse(article, session, "MOSTLY_FACT", List.of());
+
+      assertThat(response.getStatus()).isEqualTo("COMPLETED");
+    }
+
+    @Test
+    @DisplayName("analysisCompletedAt이 session.completedAt으로 매핑된다")
+    void analysisCompletedAt_매핑() {
+      LocalDateTime completedAt = LocalDateTime.of(2026, 5, 30, 12, 0, 0);
+      AnalysisSession session =
+          AnalysisSession.builder()
+              .id(UUID.randomUUID())
+              .status(SessionStatus.COMPLETED)
+              .totalScore((short) 75)
+              .completedAt(completedAt)
+              .member(null)
+              .build();
+      Article article = buildArticle(session);
+
+      ArticleVerificationResponse response =
+          ArticleVerificationConverter.toResponse(article, session, "MOSTLY_FACT", List.of());
+
+      assertThat(response.getAnalysisCompletedAt()).isEqualTo(completedAt);
+    }
+
+    @Test
+    @DisplayName("totalScore null이면 DTO totalScore도 null")
+    void totalScore_null_매핑() {
+      AnalysisSession session = buildSession(null);
+      Article article = buildArticle(session);
+
+      ArticleVerificationResponse response =
+          ArticleVerificationConverter.toResponse(article, session, null, List.of());
+
+      assertThat(response.getTotalScore()).isNull();
+      assertThat(response.getArticleLabel()).isNull();
+    }
+
+    @Test
+    @DisplayName("claims가 여러 건이면 순서대로 매핑된다")
+    void claims_여러건_순서_매핑() {
+      AnalysisSession session = buildSession((short) 75);
+      Article article = buildArticle(session);
+
+      UUID id0 = UUID.randomUUID();
+      UUID id1 = UUID.randomUUID();
+      Claim claim0 = buildClaim(id0, "첫번째 claim", null, false, null, (short) 0);
+      Claim claim1 = buildClaim(id1, "두번째 claim", null, false, null, (short) 1);
+
+      VerificationResult result0 = buildResult(claim0, (short) 80, null, LocalDateTime.now());
+      VerificationResult result1 = buildResult(claim1, (short) 65, null, LocalDateTime.now());
+
+      List<ClaimItemSource> sources =
+          List.of(
+              new ClaimItemSource(claim0, result0, "FACT", null),
+              new ClaimItemSource(claim1, result1, "MOSTLY_FACT", null));
+
+      ArticleVerificationResponse response =
+          ArticleVerificationConverter.toResponse(article, session, "MOSTLY_FACT", sources);
+
+      assertThat(response.getClaims()).hasSize(2);
+      assertThat(response.getClaims().get(0).getClaimText()).isEqualTo("첫번째 claim");
+      assertThat(response.getClaims().get(1).getClaimText()).isEqualTo("두번째 claim");
+      assertThat(response.getClaims().get(0).getTruthLabel()).isEqualTo("FACT");
+      assertThat(response.getClaims().get(1).getTruthLabel()).isEqualTo("MOSTLY_FACT");
+    }
+  }
+
+  // -----------------------------------------------------------------------------------------
+  // 5. result null (미검증 claim)
+  // -----------------------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("result null (미검증 claim) 매핑")
+  class NullResultMapping {
+
+    @Test
+    @DisplayName("result null이면 tier/score/verdict/reason/disclaimer/verifiedAt 모두 null")
+    void result_null이면_관련_필드_null() {
+      AnalysisSession session = buildSession(null);
+      Article article = buildArticle(session);
+      UUID claimId = UUID.randomUUID();
+
+      Claim claim = buildClaim(claimId, "미검증 claim", "발언자", true, "맥락", (short) 0);
+      ClaimItemSource source = new ClaimItemSource(claim, null, null, null);
+
+      ArticleVerificationResponse response =
+          ArticleVerificationConverter.toResponse(article, session, null, List.of(source));
+
+      ClaimVerificationItem item = response.getClaims().get(0);
+      assertThat(item.getClaimText()).isEqualTo("미검증 claim");
+      assertThat(item.getSpeakerName()).isEqualTo("발언자");
+      assertThat(item.isQuotedClaim()).isTrue();
+      assertThat(item.getTier()).isNull();
+      assertThat(item.getScore()).isNull();
+      assertThat(item.getVerdict()).isNull();
+      assertThat(item.getReason()).isNull();
+      assertThat(item.getDisclaimer()).isNull();
+      assertThat(item.getVerifiedAt()).isNull();
+      assertThat(item.getTruthLabel()).isNull();
+      assertThat(item.getClaimScoreStatus()).isNull();
+      assertThat(item.getEvidence()).isEmpty();
+    }
+  }
+}

--- a/core/src/test/java/com/truthscope/web/converter/ArticleVerificationConverterTest.java
+++ b/core/src/test/java/com/truthscope/web/converter/ArticleVerificationConverterTest.java
@@ -24,7 +24,8 @@ import org.junit.jupiter.api.Test;
  * <p>PLAN 테스트 전략 Unit 반영: claim 매핑(text/speaker/isQuotedClaim/verdict/disclaimer/verifiedAt),
  * evidence=[], sourceTransparency=null.
  *
- * <p>Converter는 Spring bean이 아닌 static 순수 변환 유틸리티이므로 Mockito 없이 직접 호출한다.
+ * <p>Converter는 Spring bean이 아닌 static 순수 변환 유틸리티이므로 Mockito 없이 직접 호출한다. buildResult는 tier/verdict를
+ * 파라미터로 받아 테스트별 의도(Tier 1/2, verdict 종류)를 명시한다 (CodeRabbit 리뷰 반영).
  */
 @DisplayName("ArticleVerificationConverter 단위 테스트")
 class ArticleVerificationConverterTest {
@@ -70,13 +71,19 @@ class ArticleVerificationConverterTest {
         .build();
   }
 
+  /** tier/verdict를 명시 파라미터로 받는다 — Tier 1/2 + verdict 종류별 의도를 테스트에서 직접 표현 (CodeRabbit 리뷰 반영). */
   private VerificationResult buildResult(
-      Claim claim, Short score, String disclaimer, LocalDateTime verifiedAt) {
+      Claim claim,
+      Short tier,
+      Verdict verdict,
+      Short score,
+      String disclaimer,
+      LocalDateTime verifiedAt) {
     return VerificationResult.builder()
         .id(UUID.randomUUID())
         .claim(claim)
-        .tier((short) 2)
-        .verdict(Verdict.SUPPORTED)
+        .tier(tier)
+        .verdict(verdict)
         .score(score)
         .reason("검증 근거")
         .disclaimer(disclaimer)
@@ -101,7 +108,8 @@ class ArticleVerificationConverterTest {
       LocalDateTime verifiedAt = LocalDateTime.of(2026, 5, 30, 10, 0, 0);
 
       Claim claim = buildClaim(claimId, "정부 발표 claim 텍스트", "홍길동", true, "원문 맥락", (short) 0);
-      VerificationResult result = buildResult(claim, (short) 75, null, verifiedAt);
+      VerificationResult result =
+          buildResult(claim, (short) 2, Verdict.SUPPORTED, (short) 75, null, verifiedAt);
       ClaimItemSource source = new ClaimItemSource(claim, result, "MOSTLY_FACT", null);
 
       ArticleVerificationResponse response =
@@ -123,7 +131,8 @@ class ArticleVerificationConverterTest {
       UUID claimId = UUID.randomUUID();
 
       Claim claim = buildClaim(claimId, "claim", null, false, null, (short) 0);
-      VerificationResult result = buildResult(claim, (short) 75, null, LocalDateTime.now());
+      VerificationResult result =
+          buildResult(claim, (short) 2, Verdict.SUPPORTED, (short) 75, null, LocalDateTime.now());
       ClaimItemSource source = new ClaimItemSource(claim, result, "MOSTLY_FACT", null);
 
       ArticleVerificationResponse response =
@@ -142,7 +151,8 @@ class ArticleVerificationConverterTest {
 
       Claim claim = buildClaim(claimId, "AI 분석 claim", null, false, null, (short) 0);
       VerificationResult result =
-          buildResult(claim, (short) 70, disclaimerText, LocalDateTime.now());
+          buildResult(
+              claim, (short) 2, Verdict.SUPPORTED, (short) 70, disclaimerText, LocalDateTime.now());
       ClaimItemSource source = new ClaimItemSource(claim, result, "MOSTLY_FACT", null);
 
       ArticleVerificationResponse response =
@@ -159,13 +169,16 @@ class ArticleVerificationConverterTest {
       UUID claimId = UUID.randomUUID();
 
       Claim claim = buildClaim(claimId, "Tier 1 claim", null, false, null, (short) 0);
-      VerificationResult result = buildResult(claim, (short) 80, null, LocalDateTime.now());
+      // CodeRabbit 반영: 실제 Tier 1(tier=1) result로 검증 — 이름과 fixture 일치
+      VerificationResult result =
+          buildResult(claim, (short) 1, Verdict.SUPPORTED, (short) 80, null, LocalDateTime.now());
       ClaimItemSource source = new ClaimItemSource(claim, result, "FACT", null);
 
       ArticleVerificationResponse response =
           ArticleVerificationConverter.toResponse(article, session, "FACT", List.of(source));
 
       assertThat(response.getClaims().get(0).getDisclaimer()).isNull();
+      assertThat(response.getClaims().get(0).getTier()).isEqualTo((short) 1);
     }
 
     @Test
@@ -177,7 +190,8 @@ class ArticleVerificationConverterTest {
       LocalDateTime verifiedAt = LocalDateTime.of(2026, 5, 30, 9, 30, 0);
 
       Claim claim = buildClaim(claimId, "claim", null, false, null, (short) 0);
-      VerificationResult result = buildResult(claim, (short) 75, null, verifiedAt);
+      VerificationResult result =
+          buildResult(claim, (short) 2, Verdict.SUPPORTED, (short) 75, null, verifiedAt);
       ClaimItemSource source = new ClaimItemSource(claim, result, "MOSTLY_FACT", null);
 
       ArticleVerificationResponse response =
@@ -194,7 +208,8 @@ class ArticleVerificationConverterTest {
       UUID claimId = UUID.randomUUID();
 
       Claim claim = buildClaim(claimId, "인용 아닌 claim", null, false, null, (short) 0);
-      VerificationResult result = buildResult(claim, (short) 75, null, LocalDateTime.now());
+      VerificationResult result =
+          buildResult(claim, (short) 2, Verdict.SUPPORTED, (short) 75, null, LocalDateTime.now());
       ClaimItemSource source = new ClaimItemSource(claim, result, "MOSTLY_FACT", null);
 
       ArticleVerificationResponse response =
@@ -220,7 +235,8 @@ class ArticleVerificationConverterTest {
       UUID claimId = UUID.randomUUID();
 
       Claim claim = buildClaim(claimId, "claim", null, false, null, (short) 0);
-      VerificationResult result = buildResult(claim, (short) 75, null, LocalDateTime.now());
+      VerificationResult result =
+          buildResult(claim, (short) 2, Verdict.SUPPORTED, (short) 75, null, LocalDateTime.now());
       ClaimItemSource source = new ClaimItemSource(claim, result, "MOSTLY_FACT", null);
 
       ArticleVerificationResponse response =
@@ -346,8 +362,10 @@ class ArticleVerificationConverterTest {
       Claim claim0 = buildClaim(id0, "첫번째 claim", null, false, null, (short) 0);
       Claim claim1 = buildClaim(id1, "두번째 claim", null, false, null, (short) 1);
 
-      VerificationResult result0 = buildResult(claim0, (short) 80, null, LocalDateTime.now());
-      VerificationResult result1 = buildResult(claim1, (short) 65, null, LocalDateTime.now());
+      VerificationResult result0 =
+          buildResult(claim0, (short) 1, Verdict.SUPPORTED, (short) 80, null, LocalDateTime.now());
+      VerificationResult result1 =
+          buildResult(claim1, (short) 2, Verdict.SUPPORTED, (short) 65, null, LocalDateTime.now());
 
       List<ClaimItemSource> sources =
           List.of(


### PR DESCRIPTION
## 변경 사항

`GET /api/v1/articles/{articleId}/verification` 검증 결과 조회 API를 추가한다. 분석 파이프라인이 이미 저장한 결과(종합 점수·coverage·claim별 verdict/score/검증시각)를 결과 카드용 응답으로 노출한다.

- TruthLabel(기사 라벨)과 source transparency는 저장값에서 도출 — 마이그레이션·엔티티 변경 0 (공식 v1.5 "TruthLabel은 도출값" 원칙 정합)
- VerificationResult는 현행 `@OneToOne` 유지 (1:N 재검증 supersede 체인은 별도 phase)
- evidence·sourceTransparency는 후속 phase(66b, HybridCascade 실 evidence 수집)로 이연 — 빈 배열·null 계약
- claim 단위 `verifiedAt`과 기사 단위 `analysisCompletedAt` 분리, jackson ISO-8601 직렬화(`@JsonProperty("isQuotedClaim")` 포함)

<!-- SAFE_OP_START -->
Assumptions: 분석 파이프라인이 verification_results/analysis_sessions에 결과를 이미 저장함. VerificationResult-Claim은 현행 OneToOne 유지.
Scope: app(controller/service/repository/application.yml/test), core(dto/converter/build.gradle/test)
Out-of-scope: DB 마이그레이션, 엔티티 필드 추가, evidence 실수집(HybridCascade), RLS 인증 배선, FE 매핑(Phase 67)
<!-- SAFE_OP_END -->

## Done

- [✅] GET /api/v1/articles/{articleId}/verification 200 + ArticleVerificationResponse(점수·도출 라벨·claim별 verdict/verifiedAt·evidence=[]) 반환
- [✅] articleId 미존재 또는 분석 세션 null이면 404
- [✅] 마이그레이션 0건·엔티티 변경 0건 (db/migration·entity 무변경 확인)
- [✅] 수용 테스트: 단위(ArticleVerificationServiceTest 15, ArticleVerificationConverterTest) + 통합(ArticleVerificationControllerIntegrationTest, MockMvc + Testcontainers PostgreSQL)
- [✅] 로컬 `./gradlew build` BUILD SUCCESSFUL (spotless·checkstyle·spotbugs·전체 테스트·assemble), 기존 344+ 테스트 회귀 0
- [✅] 회귀 시뮬 A 라이브 실측 (무력화→FAIL→복구→PASS, 비-tautological 실증)

## 검증

- 로컬 `./gradlew spotlessApply build` → BUILD SUCCESSFUL
- 66b-게이트 테스트(evidence_count≥3, Tier 2 disclaimer 등)는 HybridCascade stub 상태라 본 phase verify 제외(66b 이관)

## 후속

- Phase 66b: HybridCascade 실 evidence 수집(Google FC/Gemini) + verify_sources 저장 + 응답 evidence 채움
- Phase 67(FE): 조회 호출 + mapper + 결과 카드 실 매핑 (claimText→claim, score→confidence, claimScoreStatus→status rename chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 기사 검증 결과 조회 API - 기사의 검증 점수, 신뢰도 레이블(대부분 사실, 대부분 거짓 등), 검증 완료 시각, 그리고 각 청구항별 검증 상태, 판정, 점수, 검증 완료 여부 등의 상세 정보를 조회할 수 있게 되었습니다.

## 개선사항
* JSON 응답의 검증 타임스탬프 표시 형식이 숫자 배열에서 ISO-8601 문자열 형식(예: 2024-01-15T10:30:45Z)으로 변경되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/truthscope-smu/truthscope-web-backend/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->