### PR TITLE
🔧chore(config): 배포 env 주입 prod 프로파일 + data-go-kr-key ENV 참조

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,19 +21,27 @@
 # ===========================
 # 배포 환경 (환경변수로 주입)
 # ===========================
+# application-prod.yml은 아래 변수를 폴백 없이 요구한다(--spring.profiles.active=prod).
+# 로컬 dev는 application-local.yml 평문을 그대로 쓰므로 .env가 필수는 아니다.
+
+# --- 필수 (코드가 실제 @Value로 읽음 — prod 부팅에 반드시 필요) ---
 # SUPABASE_HOST=your_supabase_host
 # SUPABASE_PORT=6543
 # SUPABASE_DB=postgres
 # SUPABASE_USER=postgres.your_ref
 # SUPABASE_PASSWORD=your_password
-# GEMINI_API_KEY=your_gemini_api_key
-# GOOGLE_FACTCHECK_API_KEY=your_factcheck_api_key
-# DEEPL_API_KEY=your_deepl_api_key
-# DATA_GO_KR_KEY=your_data_go_kr_serviceKey         # S3a 정책뉴스 + S3a' 보도자료 (한 키)
-# BIGKINDS_API_KEY=your_bigkinds_api_key            # [MVP 보류 — 2026-04 유료화 전환] 무상 경로: 뉴스빅데이터 해커톤 / 학술 공모 / 스타트업 지원 사업 선정 시 활성화 (context/references/bigkinds-support-programs.md 참조)
-# KOSIS_API_KEY=your_kosis_apiKey                   # S? KOSIS 통계 (Base64, = 패딩 포함 그대로)
-# GDELT_PROJECT_ID=your_gcp_project_id              # GDELT BigQuery (S7 Tier 1.5)
-# GOOGLE_APPLICATION_CREDENTIALS=keys/gdelt-sa.json # GDELT BigQuery service account JSON path
-# NAVER_CLIENT_ID=your_naver_client_id              # 네이버 뉴스 검색 API (developers.naver.com 즉시 발급, 25k건/일/앱)
-# NAVER_CLIENT_SECRET=your_naver_client_secret      # 네이버 뉴스 검색 API client secret
+# GEMINI_API_KEY=your_gemini_api_key                # Claim 추출 + Tier2 교차검증 (GeminiClient/FidelityClassifier)
+# DATA_GO_KR_KEY=your_data_go_kr_serviceKey         # S3a 정책뉴스 + S3a' 보도자료 공통 키 (DataGoKrAdapter)
+# ADMIN_PASSWORD=your_admin_password                # spring.security.user (prod 기본값 폴백 제거)
 # SERVER_PORT=8080
+
+# --- 선택 (현재 코드 미바인딩 — 향후 데이터소스 확장 시 활성화) ---
+# GOOGLE_FACTCHECK_API_KEY=your_factcheck_api_key   # Tier1은 현재 로컬 캐시만 사용 — 외부 키 미바인딩
+# DEEPL_API_KEY=your_deepl_api_key                  # 번역 미구현 (코드 0건)
+# HF_TOKEN=your_huggingface_read_token              # S4 HuggingFace Datasets (local.yml에만, 코드 미사용)
+# KOSIS_API_KEY=your_kosis_apiKey                   # KOSIS 통계 (Base64, = 패딩 포함) — 코드 미바인딩
+# GDELT_PROJECT_ID=your_gcp_project_id              # GDELT BigQuery (S7 Tier 1.5) — 코드 미바인딩
+# GOOGLE_APPLICATION_CREDENTIALS=keys/gdelt-sa.json # GDELT service account JSON path
+# NAVER_CLIENT_ID=your_naver_client_id              # 네이버 뉴스 검색 (66b-2 보조소스)
+# NAVER_CLIENT_SECRET=your_naver_client_secret
+# BIGKINDS_API_KEY=your_bigkinds_api_key            # [MVP 보류 — 2026-04 유료화] context/references/bigkinds-support-programs.md

--- a/app/src/main/resources/application-prod.yml
+++ b/app/src/main/resources/application-prod.yml
@@ -1,0 +1,25 @@
+# 배포(prod) 프로파일 — 모든 시크릿을 환경변수로 강제(폴백 없음).
+# 활성화: --spring.profiles.active=prod (또는 SPRING_PROFILES_ACTIVE=prod)
+# env 미주입 시 부팅 실패시켜 "빈 키로 조용히 가동"을 차단한다(참조 LikeLion14th-BE-fork 패턴).
+# 배포 env 주입: GitHub Actions Secrets 또는 호스트 환경변수.
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  datasource:
+    url: jdbc:postgresql://${SUPABASE_HOST}:${SUPABASE_PORT}/${SUPABASE_DB}
+    username: ${SUPABASE_USER}
+    password: ${SUPABASE_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
+  security:
+    user:
+      name: admin
+      password: ${ADMIN_PASSWORD}
+
+truthscope:
+  gemini:
+    api-key: ${GEMINI_API_KEY}
+  datasource:
+    data-go-kr-key: ${DATA_GO_KR_KEY}

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -71,6 +71,10 @@ truthscope:
     # production에서 환경변수 override 필요 시 GEMINI_BASE_URL 또는 truthscope.gemini.base-url 직접 set.
     prompt-version: "v1.0.0"
     schema-version: "v1.0.0"
+  datasource:
+    # data.go.kr 정책뉴스 + 보도자료 공통 서비스 키. 로컬은 application-local.yml에 평문,
+    # 배포는 DATA_GO_KR_KEY 환경변수로 주입(application-prod.yml은 폴백 없음).
+    data-go-kr-key: ${DATA_GO_KR_KEY:}
   cascade:
     source-count-threshold: 1
     tier1-hit-required: true


### PR DESCRIPTION
## 요약

배포(prod) 환경에서 시크릿을 환경변수로 주입하는 경로를 정비한다. 시크릿의 git 분리(`.gitignore` + `application-local.yml` 미추적)는 이미 돼 있었으나, 코드가 실제 사용하는 `data-go-kr-key`가 `application.yml`의 `${ENV}` 체인에 없어 배포 시 주입 경로가 없었고, prod 전용 프로파일이 없어 "빈 키로 조용히 가동"을 막지 못했다. 참조 레포(LikeLion14th-BE-fork) 패턴 적용.

## 주요 변경

- **`application-prod.yml` 신규**: `on-profile: prod` 게이트. 모든 시크릿을 폴백 없는 `${ENV}`로 요구(SUPABASE 5 + ADMIN_PASSWORD + GEMINI_API_KEY + DATA_GO_KR_KEY) → env 미주입 시 부팅 실패로 빈 키 가동 차단.
- **`application.yml`**: `truthscope.datasource.data-go-kr-key: ${DATA_GO_KR_KEY:}` 추가(로컬 폴백 빈값 유지). gemini/supabase는 기존부터 `${ENV}`.
- **`.env.example`**: 필수(코드 @Value 바인딩 — SUPABASE/GEMINI/DATA_GO_KR/ADMIN_PASSWORD)와 선택(미바인딩 — HF/KOSIS/GDELT/FactCheck/DeepL/Naver) 분리.

## 범위 근거 (실측)

- 코드가 실제 `@Value`로 읽는 시크릿: `truthscope.gemini.api-key`(GeminiClient/FidelityClassifier), `truthscope.datasource.data-go-kr-key`(DataGoKrAdapter), `spring.datasource.*`(Supabase), ADMIN_PASSWORD.
- hf-token/kosis/gdelt/deepl/naver는 현재 코드 미바인딩 → `${ENV}` 통일 범위에서 제외(YAGNI), `.env.example` 주석에만.
- 로컬 dev는 `application-local.yml`(git 미추적) 평문 그대로 사용 — 동작 흐름 불변.

## 검증

- `./gradlew compileJava` 통과
- 3개 YAML 문법 유효성 통과(yaml.safe_load_all)
- `application-prod.yml`은 `on-profile: prod` 게이트라 default/local 부팅에 영향 없음
- 빌드 산출물의 평문 `application-local.yml` 사본 제거(디스크 위생)
- 시크릿 평문 커밋 0건(`application-local.yml`은 커밋에 미포함)

## Done

- [ ] 요구사항: 배포 시 시크릿을 env로 주입하는 경로 확보 + prod에서 env 미주입 시 부팅 실패 강제. 입력=환경변수, 출력=prod 프로파일 바인딩, 에러=env 누락 시 부팅 실패
- [ ] 산출물: application-prod.yml 신규, application.yml data-go-kr-key ${ENV}, .env.example 재정리
- [ ] 수용 테스트: compileJava + YAML 파싱 검증(YAML/config 변경이라 unit test 비대상)

## 후속

- GitHub Actions Secrets 등록 + 배포 워크플로우는 배포 도달처(EC2 vs PaaS) 확정 후 별 트랙
- 키 재발급(보안): 일부 키가 개발 중 노출 — 데모 후 교체 예정

<!-- SAFE_OP_START -->
Assumptions: 참조 LikeLion14th-BE-fork의 .env 분리 + ${ENV} + prod 프로파일 패턴 채택(SOPS/git-crypt 암호화 아님). 로컬 dev는 application-local.yml 유지(옵션 A).
Scope: app/src/main/resources/application.yml, app/src/main/resources/application-prod.yml(신규), .env.example
Out-of-scope: GitHub Actions Secrets 등록, 배포 워크플로우, 키 재발급, application-local.yml(실 시크릿, git 미추적)
<!-- SAFE_OP_END -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
