### PR TITLE
🐛fix(gemini): Gemini 요청 JSON 직렬화 + responseMimeType 교정

### DIFF
--- a/app/src/main/java/com/truthscope/web/gemini/GeminiClient.java
+++ b/app/src/main/java/com/truthscope/web/gemini/GeminiClient.java
@@ -9,6 +9,7 @@ import jakarta.annotation.Nullable;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
@@ -67,6 +68,10 @@ public class GeminiClient {
             .post()
             .uri("/v1beta/models/{model}:generateContent", PRIMARY_MODEL)
             .header("x-goog-api-key", effectiveKey)
+            // jackson-dataformat-xml(data.go.kr용)이 classpath에 있어 contentType 미지정 시 요청이 XML로
+            // 직렬화됨 → Gemini 400. JSON 강제 (response는 application/json 으로 정상 수신).
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
             .body(req)
             .retrieve()
             .body(GeminiGenerateContentResponse.class);
@@ -122,6 +127,8 @@ public class GeminiClient {
               .post()
               .uri("/v1beta/models/{model}:generateContent", FALLBACK_MODEL)
               .header("x-goog-api-key", effectiveKey)
+              .contentType(MediaType.APPLICATION_JSON)
+              .accept(MediaType.APPLICATION_JSON)
               .body(req)
               .retrieve()
               .body(GeminiGenerateContentResponse.class);

--- a/app/src/main/java/com/truthscope/web/gemini/GeminiRequest.java
+++ b/app/src/main/java/com/truthscope/web/gemini/GeminiRequest.java
@@ -1,16 +1,16 @@
 package com.truthscope.web.gemini;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
 
 /**
  * Gemini API {@code generateContent} 요청 DTO.
  *
- * <p>Gemini REST API 스펙 정합 — contents + generationConfig 구성. {@link ResponseFormat#mimeType} 은
- * {@code "application/json"} 고정, {@link ResponseFormat#schema} 에 JSON schema 문자열을 전달.
+ * <p>Gemini REST API 스펙 정합 — contents + generationConfig 구성. {@link
+ * GenerationConfig#responseMimeType} 은 {@code "application/json"} 고정 (structured output).
+ * responseSchema enforcement 는 v2 트랙.
  *
  * @param contents 요청 메시지 목록
- * @param generationConfig 생성 설정 (responseFormat + temperature)
+ * @param generationConfig 생성 설정 (responseMimeType + temperature)
  */
 public record GeminiRequest(List<Content> contents, GenerationConfig generationConfig) {
 
@@ -21,18 +21,13 @@ public record GeminiRequest(List<Content> contents, GenerationConfig generationC
   public record Part(String text) {}
 
   /**
-   * 생성 설정.
+   * 생성 설정 — Gemini {@code generationConfig} 스펙 정합.
    *
-   * @param responseFormat structured output 포맷 설정
+   * <p>OpenAI 식 {@code responseFormat} 중첩이 아니라 Gemini 스펙의 {@code responseMimeType} 평면 필드를 사용한다
+   * (Gemini 는 {@code response_format} 를 모르는 필드로 400 INVALID_ARGUMENT 반환).
+   *
+   * @param responseMimeType 응답 MIME 타입 — {@code "application/json"} 고정 (structured output)
    * @param temperature 생성 온도 (0.0 ~ 2.0)
    */
-  public record GenerationConfig(ResponseFormat responseFormat, double temperature) {}
-
-  /**
-   * structured output 포맷.
-   *
-   * @param mimeType MIME 타입 — {@code "application/json"} 고정
-   * @param schema JSON schema 객체 (null = schema 미지정, v2 트랙에서 JsonNode 로 채움)
-   */
-  public record ResponseFormat(String mimeType, JsonNode schema) {}
+  public record GenerationConfig(String responseMimeType, double temperature) {}
 }

--- a/app/src/main/java/com/truthscope/web/service/claim/ClaimAnalysisService.java
+++ b/app/src/main/java/com/truthscope/web/service/claim/ClaimAnalysisService.java
@@ -131,9 +131,7 @@ public class ClaimAnalysisService implements ClaimAnalysisPort {
   private GeminiRequest buildRequest(String prompt) {
     return new GeminiRequest(
         List.of(new GeminiRequest.Content(List.of(new GeminiRequest.Part(prompt)))),
-        new GeminiRequest.GenerationConfig(
-            new GeminiRequest.ResponseFormat(
-                "application/json", null), // schema 박제는 v2 트랙 (responseSchema enforcement)
-            0.0)); // deterministic for fact extraction
+        // schema 박제는 v2 트랙 (responseSchema enforcement). temperature 0.0 = deterministic.
+        new GeminiRequest.GenerationConfig("application/json", 0.0));
   }
 }

--- a/app/src/main/java/com/truthscope/web/service/fidelity/FidelityClassifierService.java
+++ b/app/src/main/java/com/truthscope/web/service/fidelity/FidelityClassifierService.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
@@ -152,6 +153,10 @@ public class FidelityClassifierService implements FidelityClassifierPort {
             .post()
             .uri("/v1beta/models/{model}:generateContent", PRIMARY_MODEL)
             .header("x-goog-api-key", effectiveKey)
+            // jackson-dataformat-xml(data.go.kr용)이 classpath에 있어 contentType 미지정 시 요청이 XML로
+            // 직렬화됨 → Gemini 400. JSON 강제 (GeminiClient와 동일 처리).
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
             .body(request)
             .retrieve()
             .body(GeminiGenerateContentResponse.class);

--- a/app/src/main/java/com/truthscope/web/service/fidelity/FidelityClassifierService.java
+++ b/app/src/main/java/com/truthscope/web/service/fidelity/FidelityClassifierService.java
@@ -260,7 +260,6 @@ public class FidelityClassifierService implements FidelityClassifierPort {
   private GeminiRequest buildRequest(String prompt) {
     return new GeminiRequest(
         List.of(new GeminiRequest.Content(List.of(new GeminiRequest.Part(prompt)))),
-        new GeminiRequest.GenerationConfig(
-            new GeminiRequest.ResponseFormat("application/json", null), 0.0));
+        new GeminiRequest.GenerationConfig("application/json", 0.0));
   }
 }

--- a/app/src/test/java/com/truthscope/web/gemini/GeminiClientTest.java
+++ b/app/src/test/java/com/truthscope/web/gemini/GeminiClientTest.java
@@ -55,8 +55,7 @@ class GeminiClientTest {
   private static final GeminiRequest DUMMY_REQUEST =
       new GeminiRequest(
           List.of(new GeminiRequest.Content(List.of(new GeminiRequest.Part("테스트 기사")))),
-          new GeminiRequest.GenerationConfig(
-              new GeminiRequest.ResponseFormat("application/json", null), 0.0));
+          new GeminiRequest.GenerationConfig("application/json", 0.0));
 
   @BeforeEach
   void setUp() {
@@ -105,6 +104,8 @@ class GeminiClientTest {
     when(restClient.post()).thenReturn(requestBodyUriSpec);
     doReturn(requestBodySpec).when(requestBodyUriSpec).uri(anyString(), any(Object[].class));
     doReturn(requestBodySpec).when(requestBodySpec).header(anyString(), any(String[].class));
+    doReturn(requestBodySpec).when(requestBodySpec).contentType(any());
+    doReturn(requestBodySpec).when(requestBodySpec).accept(any());
     doReturn(requestBodySpec).when(requestBodySpec).body(any(Object.class));
     doReturn(responseSpec).when(requestBodySpec).retrieve();
     doReturn(response).when(responseSpec).body(GeminiGenerateContentResponse.class);
@@ -176,6 +177,8 @@ class GeminiClientTest {
     when(restClient.post()).thenReturn(requestBodyUriSpec);
     doReturn(requestBodySpec).when(requestBodyUriSpec).uri(anyString(), any(Object[].class));
     doReturn(requestBodySpec).when(requestBodySpec).header(anyString(), any(String[].class));
+    doReturn(requestBodySpec).when(requestBodySpec).contentType(any());
+    doReturn(requestBodySpec).when(requestBodySpec).accept(any());
     doReturn(requestBodySpec).when(requestBodySpec).body(any(Object.class));
     doReturn(responseSpec).when(requestBodySpec).retrieve();
     doReturn(fallbackWrapper).when(responseSpec).body(GeminiGenerateContentResponse.class);
@@ -270,6 +273,8 @@ class GeminiClientTest {
     when(restClient.post()).thenReturn(requestBodyUriSpec);
     doReturn(requestBodySpec).when(requestBodyUriSpec).uri(anyString(), any(Object[].class));
     doReturn(requestBodySpec).when(requestBodySpec).header(anyString(), any(String[].class));
+    doReturn(requestBodySpec).when(requestBodySpec).contentType(any());
+    doReturn(requestBodySpec).when(requestBodySpec).accept(any());
     doReturn(requestBodySpec).when(requestBodySpec).body(any(Object.class));
     doReturn(responseSpec).when(requestBodySpec).retrieve();
     doReturn(fallbackWrapper).when(responseSpec).body(GeminiGenerateContentResponse.class);

--- a/app/src/test/java/com/truthscope/web/gemini/GeminiClientTest.java
+++ b/app/src/test/java/com/truthscope/web/gemini/GeminiClientTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -25,6 +26,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.http.MediaType;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
@@ -124,6 +126,9 @@ class GeminiClientTest {
     assertThat(response.claims().get(0).claimText()).isEqualTo("정부는 GDP 성장률 3%를 발표했다.");
     assertThat(response.claims().get(0).claimStatusCandidate())
         .isEqualTo(ClaimStatusCandidate.SCORABLE);
+    // 회귀 가드: Gemini 요청은 application/json 으로 협상해야 한다 (XML 직렬화 회귀 방지)
+    verify(requestBodySpec).contentType(MediaType.APPLICATION_JSON);
+    verify(requestBodySpec).accept(MediaType.APPLICATION_JSON);
   }
 
   @Test


### PR DESCRIPTION
## 배경

실 Gemini end-to-end 검증 중 claim 추출이 항상 0건으로 나오는 문제를 발견했다. 원인은 두 가지였고, `@CircuitBreaker` fallback이 예외를 삼켜 로그에 드러나지 않았다.

1. **요청이 XML로 직렬화** — `jackson-dataformat-xml`(data.go.kr XML 파싱용)이 classpath에 있어, `GeminiClient`가 Content-Type을 명시하지 않으면 RestClient가 XML 컨버터를 선택한다. Gemini는 JSON만 받으므로 400 INVALID_ARGUMENT로 거부됐다. (1차 차단자)
2. **`responseFormat`(OpenAI식)** — `generationConfig.responseFormat`은 Gemini 스펙에 없는 필드라 400을 유발한다. Gemini는 `responseMimeType`을 쓴다.

유닛 테스트는 RestClient를 mock하고, WireMock 통합 테스트는 요청 본문을 검증하지 않아 두 버그 모두 실 호출에서만 드러났다.

## 변경 내용

- `GeminiClient`: 1차/2차 모델 호출에 `contentType`/`accept`를 `application/json`으로 명시.
- `GeminiRequest.GenerationConfig`: 중첩 `responseFormat { mimeType, schema }`를 평면 `responseMimeType`으로 교정 (responseSchema enforcement는 v2 트랙 그대로 유지).
- `ClaimAnalysisService`, `FidelityClassifierService`: 호출부 정합.
- `GeminiClientTest`: mock 체인에 `contentType`/`accept` stub 추가.

## Done

- [✅] 요구사항: 실 Gemini 요청이 JSON으로 전송되어 claim 추출이 동작한다. (입력: 뉴스 URL, 출력: claims 배열, 에러: Gemini 4xx 시 insufficient로 graceful degrade)
- [✅] 산출물: `GeminiClient.java`, `GeminiRequest.java`, `ClaimAnalysisService.java`, `FidelityClassifierService.java`, `GeminiClientTest.java`
- [✅] 수용 테스트: 단위 테스트 348개 GREEN(spotless/checkstyle/spotbugs/test/build 전부 통과) + 로컬 Docker Postgres 16 + 실 Gemini end-to-end로 유가 지원금 기사에서 claim 6건 추출·영속 확인

## 검증 근거

- 직접 프로브: 수정 전 요청형(`responseFormat`)은 Gemini 400, 수정형(`responseMimeType`)은 200.
- 캡처 서버로 BE 요청 본문 확인: 수정 전 본문이 `<GeminiRequest>...` XML이었음을 실측.
- 수정 후 실 Gemini로 분석 시 claim 6건 추출(api_usage_logs `GEMINI/SERVER_POOL` 1건), Tier 분류(TIME_SENSITIVE/INSUFFICIENT) 정상.

<!-- SAFE_OP_START -->
Assumptions: 없음 (Gemini generateContent 공식 스펙 정합)
Scope: app/src/main/java/com/truthscope/web/gemini/, app/src/main/java/com/truthscope/web/service/claim/, app/src/main/java/com/truthscope/web/service/fidelity/, app/src/test/java/com/truthscope/web/gemini/
Out-of-scope: responseSchema enforcement(v2 트랙), 운영 Supabase 마이그레이션, 노출 키 재발급
<!-- SAFE_OP_END -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * Gemini API 응답 처리의 안정성 개선

* **개선사항**
  * API 구성 업데이트로 인한 내부 처리 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->