### PR TITLE
🔧chore(deploy): Heroku 배포 파일 추가

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: java -Dserver.port=$PORT $JAVA_OPTS -jar app/build/libs/app-0.0.1-SNAPSHOT.jar --spring.profiles.active=prod

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -Dserver.port=$PORT $JAVA_OPTS -jar app/build/libs/app-0.0.1-SNAPSHOT.jar --spring.profiles.active=prod
+web: java -Dserver.port=$PORT $JAVA_OPTS -jar app/build/libs/app.jar --spring.profiles.active=prod

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,3 +38,8 @@ dependencies {
 
 // throwaway 연구 코드(spike)는 워크스페이스 레벨 `truthscope-web/spike/` 독립 Java 프로젝트로 분리됨 (2026-05-04).
 // 이전 `app/src/spike/` sourceSet 제거 — BE 빌드 파이프라인과 단절. 상세는 spike/README.md 및 BE CLAUDE.md.
+
+// 배포 JAR 이름을 버전 비포함 고정명으로 강제 (Procfile이 버전 변경에 깨지지 않도록 — PR #100 CodeRabbit Major 반영).
+bootJar {
+	archiveFileName = 'app.jar'
+}

--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=17


### PR DESCRIPTION
Heroku 배포 파일(Procfile, system.properties)을 dev에 올린다. 비동기 전환 phase 재배포의 전제.

CodeRabbit Major(Procfile의 versioned JAR명 하드코딩 fragility) 반영: bootJar archiveFileName을 app.jar로 고정하고 Procfile이 이를 참조한다. 버전 변경에 깨지지 않음.

## Done
- [✅] 산출물: Procfile, system.properties, app/build.gradle(bootJar 고정명)
- [✅] 검증: ./gradlew :app:bootJar → app/build/libs/app.jar 생성 확인, 소스/테스트 무변경
- [✅] 실배포: Heroku v5에서 비동기 분석 종단 동작 확인(EXTRACTING→ANALYZING→COMPLETED)

<!-- SAFE_OP_START -->
Assumptions: 없음
Scope: Procfile, system.properties, app/build.gradle(bootJar archiveFileName)
Out-of-scope: 소스 코드, 테스트, 설정 yml
<!-- SAFE_OP_END -->