### PR TITLE
✨feat(analysis): 분석 파이프라인 비동기 전환 (Heroku H12 해소)

### DIFF
--- a/app/src/main/java/com/truthscope/web/config/AsyncConfig.java
+++ b/app/src/main/java/com/truthscope/web/config/AsyncConfig.java
@@ -1,0 +1,34 @@
+package com.truthscope.web.config;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+  /**
+   * 분석 비동기 실행 executor. 테스트에서 truthscope.async.enabled=false로 끄고 SyncTaskExecutor를 주입해 @Async를 인라인
+   * 실행한다(빈 이름 충돌 없이 결정적 override).
+   */
+  @Bean("analysisExecutor")
+  @ConditionalOnProperty(
+      name = "truthscope.async.enabled",
+      havingValue = "true",
+      matchIfMissing = true)
+  public Executor analysisExecutor() {
+    ThreadPoolTaskExecutor ex = new ThreadPoolTaskExecutor();
+    ex.setCorePoolSize(2);
+    ex.setMaxPoolSize(4);
+    ex.setQueueCapacity(25);
+    ex.setThreadNamePrefix("analysis-");
+    ex.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
+    ex.initialize();
+    return ex;
+  }
+}

--- a/app/src/main/java/com/truthscope/web/service/AnalysisService.java
+++ b/app/src/main/java/com/truthscope/web/service/AnalysisService.java
@@ -3,66 +3,47 @@ package com.truthscope.web.service;
 import com.truthscope.web.dto.request.AnalysisRequest;
 import com.truthscope.web.dto.response.AnalysisResponse;
 import com.truthscope.web.dto.response.ExtractedArticle;
-import com.truthscope.web.entity.enums.SessionStatus;
-import com.truthscope.web.scoring.ArticleFactScore;
-import com.truthscope.web.scoring.ArticleFactScoreAggregator;
-import com.truthscope.web.scoring.ArticleScorePolicy;
-import com.truthscope.web.scoring.ClaimAnalysisPort;
-import com.truthscope.web.scoring.ClaimCascadeResult;
-import com.truthscope.web.scoring.ClaimDraft;
-import com.truthscope.web.scoring.ClaimVerificationSignal;
-import com.truthscope.web.scoring.CoverageAggregator;
-import com.truthscope.web.scoring.CoverageSummary;
-import com.truthscope.web.scoring.ScoreBandPolicy;
-import com.truthscope.web.scoring.SourceTransparencyAggregator;
-import com.truthscope.web.scoring.SourceTransparencySummary;
-import com.truthscope.web.scoring.TruthLabel;
-import com.truthscope.web.scoring.TruthLabelDeriver;
-import com.truthscope.web.service.verification.VerificationCascadeService;
 import jakarta.annotation.Nullable;
-import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-/** 뉴스 기사 분석 오케스트레이션 서비스 (Wave 2 cascade + Phase 55 4함수 통합) */
+/** 뉴스 기사 분석 오케스트레이션 서비스 (동기 추출+영속화, 비동기 claims 이후 AsyncAnalysisService 위임) */
 @Service
 @RequiredArgsConstructor
 public class AnalysisService {
 
   private final AnalysisTransactionService transactionService;
   private final ContentExtractService contentExtractService;
-  // Wave 1: ClaimAnalysisPort — production = ClaimAnalysisService, stub = ClaimAnalysisStubService
-  private final ClaimAnalysisPort claimAnalysisPort;
-  // Wave 2: 3-Tier Cascade orchestrator
-  private final VerificationCascadeService verificationCascadeService;
-  // Phase 55 policy beans (4 집계 함수는 static — policy만 DI)
-  private final ArticleScorePolicy scorePolicy;
-  private final ScoreBandPolicy bandPolicy;
+  private final AsyncAnalysisService asyncProcessor;
 
   /**
-   * 뉴스 기사 URL을 받아 전체 분석 파이프라인을 실행한다.
+   * 뉴스 기사 URL을 받아 기사 추출과 영속화를 동기로 수행한 뒤 claims 이후를 비동기로 위임한다.
    *
    * <p>단계:
    *
    * <ol>
    *   <li>세션 생성 (트랜잭션)
-   *   <li>기사 본문 추출 (트랜잭션 밖 — 외부 HTTP Jsoup)
-   *   <li>Article 저장 + 상태 EXTRACTING 전이 (트랜잭션)
-   *   <li>Claim 추출 — ClaimAnalysisPort (Gemini 또는 stub)
-   *   <li>Claim DB 영속화 (트랜잭션)
-   *   <li>Wave 2 Cascade 검증 — VerificationCascadeService (외부 HTTP, 트랜잭션 밖)
-   *   <li>Phase 55 집계 4함수 STATIC 직접 호출 (순수 함수, 트랜잭션 불필요)
-   *   <li>Cascade 결과 영속화 + 세션 COMPLETED 전이 (트랜잭션)
+   *   <li>기사 본문 추출 (트랜잭션 밖, 외부 HTTP Jsoup)
+   *   <li>Article 저장 + 상태 EXTRACTING 전이 (트랜잭션, 즉시 커밋)
+   *   <li>EXTRACTING 스냅샷 DTO 반환 + 비동기 프로세서에 claims 이후 위임
    * </ol>
    *
-   * <p>어느 단계에서든 RuntimeException 발생 시 세션을 FAILED로 전이한다. markFailed 자체 실패 시 원본 예외에 suppressed로 추가.
+   * <p>동기 구간에서 RuntimeException 발생 시 세션을 FAILED로 전이한다. markFailed 자체 실패 시 원본 예외에 suppressed로 추가.
    */
   public AnalysisResponse analyze(AnalysisRequest request, @Nullable String userApiKey) {
     UUID sessionId = transactionService.createPendingSession();
     try {
-      return runPipeline(request, sessionId, userApiKey);
+      ExtractedArticle extracted = contentExtractService.extract(request.url());
+      // persistArticleAndUpdateStatus는 독립 @Transactional이므로 메서드 반환 시 즉시 커밋.
+      // 반환 AnalysisResponse는 AnalysisConverter.toResponse(session, article)로 빌드된 EXTRACTING 스냅샷
+      // DTO.
+      AnalysisResponse response =
+          transactionService.persistArticleAndUpdateStatus(sessionId, request.url(), extracted);
+      // 커밋 후 제출이므로 비동기 스레드가 미커밋 session/article을 못 보는 race가 없다.
+      asyncProcessor.process(sessionId, response.getArticleId(), extracted.getBody(), userApiKey);
+      return response; // EXTRACTING 스냅샷 (process가 인라인 실행돼 DB가 COMPLETED여도 이 DTO 문자열은 EXTRACTING
+      // 고정).
     } catch (RuntimeException ex) {
       try {
         transactionService.markFailed(sessionId);
@@ -73,42 +54,10 @@ public class AnalysisService {
     }
   }
 
-  /** Backward compat — userApiKey null 위임. */
+  /**
+   * Backward compat, userApiKey null 위임. (VerificationCascadeIntegrationTest:174,250가 호출, 제거 금지)
+   */
   public AnalysisResponse analyze(AnalysisRequest request) {
     return analyze(request, null);
-  }
-
-  private AnalysisResponse runPipeline(
-      AnalysisRequest request, UUID sessionId, @Nullable String userApiKey) {
-    ExtractedArticle extracted = contentExtractService.extract(request.url());
-    UUID articleId =
-        transactionService
-            .persistArticleAndUpdateStatus(sessionId, request.url(), extracted)
-            .getArticleId();
-
-    List<ClaimDraft> drafts = claimAnalysisPort.analyze(extracted.getBody(), userApiKey);
-    List<com.truthscope.web.entity.Claim> savedClaims =
-        transactionService.persistClaims(articleId, drafts);
-    List<ClaimCascadeResult> results = verificationCascadeService.cascade(drafts);
-    List<ClaimVerificationSignal> signals =
-        results.stream().map(ClaimCascadeResult::signal).toList();
-
-    // CX2-1 Critical lock: Phase 55 집계 4함수 STATIC 직접 호출
-    Optional<ArticleFactScore> totalScore =
-        ArticleFactScoreAggregator.aggregateArticleFactScore(signals, scorePolicy);
-    Optional<TruthLabel> articleLabel =
-        totalScore.map(s -> TruthLabelDeriver.deriveTruthLabel(s.value(), bandPolicy));
-    SourceTransparencySummary transparencySummary =
-        SourceTransparencyAggregator.aggregateSourceTransparency(signals);
-    CoverageSummary coverage = CoverageAggregator.aggregateCoverage(signals);
-
-    transactionService.persistCascadeResults(
-        sessionId, savedClaims, totalScore, articleLabel, transparencySummary, coverage, results);
-
-    return AnalysisResponse.builder()
-        .sessionId(sessionId)
-        .articleId(articleId)
-        .status(SessionStatus.COMPLETED.name())
-        .build();
   }
 }

--- a/app/src/main/java/com/truthscope/web/service/AnalysisTransactionService.java
+++ b/app/src/main/java/com/truthscope/web/service/AnalysisTransactionService.java
@@ -197,6 +197,14 @@ public class AnalysisTransactionService {
     //       µ2.5 통합 테스트 단계에서 HybridCascadeService + Gemini 연동 후 구현.
   }
 
+  /** 세션 상태를 ANALYZING으로 전이 (비동기 분석 시작 시점). */
+  @Transactional
+  public void markAnalyzing(UUID sessionId) {
+    sessionRepository
+        .findById(sessionId)
+        .ifPresent(session -> session.updateStatus(SessionStatus.ANALYZING));
+  }
+
   /** 세션 상태를 FAILED로 전이 */
   @Transactional
   public void markFailed(UUID sessionId) {

--- a/app/src/main/java/com/truthscope/web/service/AsyncAnalysisService.java
+++ b/app/src/main/java/com/truthscope/web/service/AsyncAnalysisService.java
@@ -1,0 +1,74 @@
+package com.truthscope.web.service;
+
+import com.truthscope.web.entity.Claim;
+import com.truthscope.web.scoring.ArticleFactScore;
+import com.truthscope.web.scoring.ArticleFactScoreAggregator;
+import com.truthscope.web.scoring.ArticleScorePolicy;
+import com.truthscope.web.scoring.ClaimAnalysisPort;
+import com.truthscope.web.scoring.ClaimCascadeResult;
+import com.truthscope.web.scoring.ClaimDraft;
+import com.truthscope.web.scoring.ClaimVerificationSignal;
+import com.truthscope.web.scoring.CoverageAggregator;
+import com.truthscope.web.scoring.CoverageSummary;
+import com.truthscope.web.scoring.ScoreBandPolicy;
+import com.truthscope.web.scoring.SourceTransparencyAggregator;
+import com.truthscope.web.scoring.SourceTransparencySummary;
+import com.truthscope.web.scoring.TruthLabel;
+import com.truthscope.web.scoring.TruthLabelDeriver;
+import com.truthscope.web.service.verification.VerificationCascadeService;
+import jakarta.annotation.Nullable;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+/** 분석 파이프라인 후반부(claims 이후)를 비동기로 실행하는 서비스. self-invocation 우회를 위해 별도 빈으로 분리. */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AsyncAnalysisService {
+
+  private final AnalysisTransactionService transactionService;
+  private final ClaimAnalysisPort claimAnalysisPort;
+  private final VerificationCascadeService verificationCascadeService;
+  private final ArticleScorePolicy scorePolicy;
+  private final ScoreBandPolicy bandPolicy;
+
+  /**
+   * 비동기 분석 후반부: markAnalyzing, claims, cascade, 집계, persist(COMPLETED).
+   *
+   * <p>@Async void라 예외 전파 불가 - 내부 try/catch에서 markFailed. markFailed 자체 실패도 중첩 try/catch로 로깅.
+   */
+  @Async("analysisExecutor")
+  public void process(UUID sessionId, UUID articleId, String body, @Nullable String userApiKey) {
+    try {
+      transactionService.markAnalyzing(sessionId);
+      List<ClaimDraft> drafts = claimAnalysisPort.analyze(body, userApiKey);
+      List<Claim> savedClaims = transactionService.persistClaims(articleId, drafts);
+      List<ClaimCascadeResult> results = verificationCascadeService.cascade(drafts);
+      // signals는 집계 4함수에만 사용. persistCascadeResults는 cascadeResults에서 signals를 자체 재도출.
+      List<ClaimVerificationSignal> signals =
+          results.stream().map(ClaimCascadeResult::signal).toList();
+      Optional<ArticleFactScore> totalScore =
+          ArticleFactScoreAggregator.aggregateArticleFactScore(signals, scorePolicy);
+      Optional<TruthLabel> articleLabel =
+          totalScore.map(s -> TruthLabelDeriver.deriveTruthLabel(s.value(), bandPolicy));
+      SourceTransparencySummary transparency =
+          SourceTransparencyAggregator.aggregateSourceTransparency(signals);
+      CoverageSummary coverage = CoverageAggregator.aggregateCoverage(signals);
+      transactionService.persistCascadeResults(
+          sessionId, savedClaims, totalScore, articleLabel, transparency, coverage, results);
+    } catch (RuntimeException ex) {
+      log.error("[AsyncAnalysisService] sessionId={} 비동기 분석 실패", sessionId, ex);
+      try {
+        transactionService.markFailed(sessionId);
+      } catch (RuntimeException markEx) {
+        log.error(
+            "[AsyncAnalysisService] sessionId={} markFailed 실패, 세션 상태 미수렴", sessionId, markEx);
+      }
+    }
+  }
+}

--- a/app/src/test/java/com/truthscope/web/drift/VerificationCascadeIntegrationTest.java
+++ b/app/src/test/java/com/truthscope/web/drift/VerificationCascadeIntegrationTest.java
@@ -31,6 +31,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -77,8 +78,11 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       "truthscope.gemini.api-key=test-key",
       "spring.jpa.hibernate.ddl-auto=validate",
       "spring.flyway.enabled=true",
-      "spring.flyway.locations=classpath:db/migration"
+      "spring.flyway.locations=classpath:db/migration",
+      "spring.main.allow-bean-definition-overriding=true",
+      "truthscope.async.enabled=false"
     })
+@Import(com.truthscope.web.support.SyncAnalysisExecutorConfig.class)
 @DisplayName("Wave 2 Verification Cascade 통합 테스트 (µ2.5 T2-11)")
 class VerificationCascadeIntegrationTest {
 
@@ -175,7 +179,7 @@ class VerificationCascadeIntegrationTest {
 
     // Then: AnalysisSession COMPLETED 검증
     assertThat(response).isNotNull();
-    assertThat(response.getStatus()).isEqualTo(SessionStatus.COMPLETED.name());
+    assertThat(response.getStatus()).isEqualTo(SessionStatus.EXTRACTING.name());
 
     AnalysisSession session = sessionRepo.findById(response.getSessionId()).orElseThrow();
     assertThat(session.getStatus()).isEqualTo(SessionStatus.COMPLETED);
@@ -252,7 +256,7 @@ class VerificationCascadeIntegrationTest {
 
     // Then: session COMPLETED (Tier 3 도 정상 완료)
     assertThat(response).isNotNull();
-    assertThat(response.getStatus()).isEqualTo(SessionStatus.COMPLETED.name());
+    assertThat(response.getStatus()).isEqualTo(SessionStatus.EXTRACTING.name());
 
     AnalysisSession session = sessionRepo.findById(response.getSessionId()).orElseThrow();
     assertThat(session.getStatus()).isEqualTo(SessionStatus.COMPLETED);

--- a/app/src/test/java/com/truthscope/web/integration/VerificationPipelineIntegrationTest.java
+++ b/app/src/test/java/com/truthscope/web/integration/VerificationPipelineIntegrationTest.java
@@ -58,6 +58,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -115,8 +116,11 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       "truthscope.gemini.api-key=test-key",
       "spring.jpa.hibernate.ddl-auto=validate",
       "spring.flyway.enabled=true",
-      "spring.flyway.locations=classpath:db/migration"
+      "spring.flyway.locations=classpath:db/migration",
+      "spring.main.allow-bean-definition-overriding=true",
+      "truthscope.async.enabled=false"
     })
+@Import(com.truthscope.web.support.SyncAnalysisExecutorConfig.class)
 @DisplayName("BE #66 통합 테스트 2축 — 기능 적합성 + 신뢰성 (ISO/IEC 25010 정합)")
 class VerificationPipelineIntegrationTest {
 
@@ -247,7 +251,7 @@ class VerificationPipelineIntegrationTest {
               .andExpect(status().isCreated())
               .andExpect(jsonPath("$.sessionId").exists())
               .andExpect(jsonPath("$.articleId").exists())
-              .andExpect(jsonPath("$.status").value("COMPLETED"))
+              .andExpect(jsonPath("$.status").value("EXTRACTING"))
               .andReturn();
 
       // Then: DB state 검증
@@ -343,7 +347,7 @@ class VerificationPipelineIntegrationTest {
                       .contentType(MediaType.APPLICATION_JSON)
                       .content(requestJson("https://example.com/news/tier2")))
               .andExpect(status().isCreated())
-              .andExpect(jsonPath("$.status").value("COMPLETED"))
+              .andExpect(jsonPath("$.status").value("EXTRACTING"))
               .andReturn();
 
       // Then: DB tier2Count >= 1 + tier1Count = 0 + totalScore + Tier 2 disclaimer
@@ -417,7 +421,7 @@ class VerificationPipelineIntegrationTest {
                   .contentType(MediaType.APPLICATION_JSON)
                   .content(requestJson("https://example.com/news/transparency")))
           .andExpect(status().isCreated())
-          .andExpect(jsonPath("$.status").value("COMPLETED"))
+          .andExpect(jsonPath("$.status").value("EXTRACTING"))
           .andReturn();
 
       // Aggregator 직접 호출: production이 받았을 ClaimVerificationSignal 1건 fixture 생성 후 cross-check
@@ -572,7 +576,7 @@ class VerificationPipelineIntegrationTest {
                       .contentType(MediaType.APPLICATION_JSON)
                       .content(requestJson("https://example.com/news/mixed")))
               .andExpect(status().isCreated())
-              .andExpect(jsonPath("$.status").value("COMPLETED"))
+              .andExpect(jsonPath("$.status").value("EXTRACTING"))
               .andReturn();
 
       // Then: tier1=1 + tier3=1 + tier2=0 + totalScore present + VR 2건
@@ -647,7 +651,7 @@ class VerificationPipelineIntegrationTest {
                       .contentType(MediaType.APPLICATION_JSON)
                       .content(requestJson("https://unknown.com/news/tier3")))
               .andExpect(status().isCreated())
-              .andExpect(jsonPath("$.status").value("COMPLETED"))
+              .andExpect(jsonPath("$.status").value("EXTRACTING"))
               .andReturn();
 
       // Then: tier3Count >= 1 + tier=3 + tier3Reason=INSUFFICIENT + score=null
@@ -699,7 +703,7 @@ class VerificationPipelineIntegrationTest {
                       .contentType(MediaType.APPLICATION_JSON)
                       .content(requestJson("https://example.com/news/empty")))
               .andExpect(status().isCreated())
-              .andExpect(jsonPath("$.status").value("COMPLETED"))
+              .andExpect(jsonPath("$.status").value("EXTRACTING"))
               .andReturn();
 
       // Then: totalScore=null + 모든 tier count=0 + VR 0건

--- a/app/src/test/java/com/truthscope/web/service/AsyncAnalysisServiceTest.java
+++ b/app/src/test/java/com/truthscope/web/service/AsyncAnalysisServiceTest.java
@@ -1,0 +1,89 @@
+package com.truthscope.web.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.truthscope.web.scoring.ArticleScorePolicy;
+import com.truthscope.web.scoring.ClaimAnalysisPort;
+import com.truthscope.web.scoring.ScoreBandPolicy;
+import com.truthscope.web.service.verification.VerificationCascadeService;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+@DisplayName("AsyncAnalysisService unit")
+class AsyncAnalysisServiceTest {
+
+  private AnalysisTransactionService transactionService;
+  private ClaimAnalysisPort claimAnalysisPort;
+  private VerificationCascadeService verificationCascadeService;
+  private ArticleScorePolicy scorePolicy;
+  private ScoreBandPolicy bandPolicy;
+
+  private AsyncAnalysisService asyncAnalysisService;
+
+  @BeforeEach
+  void setUp() {
+    transactionService = mock(AnalysisTransactionService.class);
+    claimAnalysisPort = mock(ClaimAnalysisPort.class);
+    verificationCascadeService = mock(VerificationCascadeService.class);
+    scorePolicy = mock(ArticleScorePolicy.class);
+    bandPolicy = mock(ScoreBandPolicy.class);
+
+    asyncAnalysisService =
+        new AsyncAnalysisService(
+            transactionService,
+            claimAnalysisPort,
+            verificationCascadeService,
+            scorePolicy,
+            bandPolicy);
+  }
+
+  @Test
+  @DisplayName(
+      "happy path: markAnalyzing, analyze, persistClaims, cascade, persistCascadeResults 순서대로 호출")
+  void happyPath() {
+    UUID sessionId = UUID.randomUUID();
+    UUID articleId = UUID.randomUUID();
+    String body = "기사 본문";
+
+    // 빈 cascade 경로: SCORABLE signal 0건이라 집계 4함수가 policy를 건드리지 않고 안전하게 종료(persist까지 도달).
+    when(claimAnalysisPort.analyze(body, null)).thenReturn(List.of());
+    when(transactionService.persistClaims(eq(articleId), any())).thenReturn(List.of());
+    when(verificationCascadeService.cascade(any())).thenReturn(List.of());
+
+    asyncAnalysisService.process(sessionId, articleId, body, null);
+
+    InOrder order = inOrder(transactionService, claimAnalysisPort, verificationCascadeService);
+    order.verify(transactionService).markAnalyzing(sessionId);
+    order.verify(claimAnalysisPort).analyze(body, null);
+    order.verify(transactionService).persistClaims(eq(articleId), any());
+    order.verify(verificationCascadeService).cascade(any());
+    order
+        .verify(transactionService)
+        .persistCascadeResults(eq(sessionId), any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("회귀 sim E: claimAnalysisPort.analyze 예외 시 markFailed(sessionId) 1회 호출")
+  void analyzeThrowCallsMarkFailed() {
+    UUID sessionId = UUID.randomUUID();
+    UUID articleId = UUID.randomUUID();
+    String body = "기사 본문";
+
+    doThrow(new RuntimeException("Gemini 호출 실패")).when(claimAnalysisPort).analyze(body, null);
+
+    asyncAnalysisService.process(sessionId, articleId, body, null);
+
+    verify(transactionService, times(1)).markFailed(sessionId);
+  }
+}

--- a/app/src/test/java/com/truthscope/web/support/SyncAnalysisExecutorConfig.java
+++ b/app/src/test/java/com/truthscope/web/support/SyncAnalysisExecutorConfig.java
@@ -1,0 +1,16 @@
+package com.truthscope.web.support;
+
+import java.util.concurrent.Executor;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.task.SyncTaskExecutor;
+
+@TestConfiguration
+public class SyncAnalysisExecutorConfig {
+  @Bean("analysisExecutor")
+  @Primary
+  public Executor analysisExecutor() {
+    return new SyncTaskExecutor(); // 호출 스레드에서 즉시 실행, @Async 인라인화
+  }
+}


### PR DESCRIPTION
## 개요
동기 분석이 Heroku 30초 하드 타임아웃(H12)을 초과하던 문제를 해소한다. 추출+영속화까지 동기로 처리하고 즉시 EXTRACTING 응답(sessionId/articleId)을 반환한 뒤, claims 추출부터 cascade/집계/COMPLETED를 신규 `AsyncAnalysisService`(@Async)로 분리한다. FE는 articleId로 GET verification을 폴링한다(기존 poll-island 무변경).

진행 상태: EXTRACTING → ANALYZING → COMPLETED. 비동기 예외는 내부에서 markFailed로 FAILED 수렴(중첩 try/catch).

## 변경
- 신규 `AsyncConfig` — @EnableAsync + analysisExecutor(core2/max4/queue25, AbortPolicy). `@ConditionalOnProperty(truthscope.async.enabled, matchIfMissing=true)`로 테스트에서 비활성.
- 신규 `AsyncAnalysisService` — claims 이후 비동기 파이프라인. 별도 빈으로 self-invocation 회피.
- `AnalysisTransactionService.markAnalyzing` 추가.
- `AnalysisService` — runPipeline 분해, 동기 EXTRACTING 반환 + 비동기 위임. 단일 인수 오버로드 유지.
- 테스트 — 신규 `SyncAnalysisExecutorConfig`(SyncTaskExecutor)로 통합테스트에서 @Async 인라인 실행. 응답 단언 EXTRACTING으로 갱신(DB COMPLETED 단언은 인라인으로 유지). AsyncAnalysisService unit(happy + 예외).

## 검증
- `./gradlew build` BUILD SUCCESSFUL (spotless+checkstyle+spotbugs+test[Testcontainers]+assemble), 350+ tests 0 failed.
- 회귀 시뮬레이션 ABC + E (tautology 방지): A(completeCascade 무력화)=`but was: ANALYZING`, B(비동기 제출 무력화)=`but was: EXTRACTING`, C(status 강제)=`$.status expected:<EXTRACTING> but was:<COMPLETED>`, E(analyze 예외)=markFailed 호출.

## Done
- [✅] 요구사항: 분석 POST가 즉시 EXTRACTING 반환(30초 내), 폴링이 COMPLETED로 수렴, 비동기 실패 시 FAILED
- [✅] 산출물: AsyncConfig, AsyncAnalysisService, markAnalyzing, AnalysisService 분해, SyncAnalysisExecutorConfig, 통합테스트 2 갱신
- [✅] 수용 테스트: unit(AsyncAnalysisService) + integration(Pipeline/Cascade) + 회귀 시뮬레이션 ABC/E

<!-- SAFE_OP_START -->
Assumptions: Heroku web dyno에서 응답 후 @Async 작업 지속(best-effort, 큐/worker 도입 전까지 durability 미보장)
Scope: app 모듈 service/config + 통합테스트 2 + 신규 test config
Out-of-scope: DB 스키마, FE, 조회 API, Heroku 재배포(후속), 노출 키 재발급
<!-- SAFE_OP_END -->