### PR TITLE
✨feat(security): FE 폴링용 CORS 허용 (Vercel origin)

### DIFF
--- a/app/src/main/java/com/truthscope/web/config/SecurityConfig.java
+++ b/app/src/main/java/com/truthscope/web/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
     CorsConfiguration config = new CorsConfiguration();
     config.setAllowedOrigins(
         List.of("https://truthscope-web-frontend.vercel.app", "http://localhost:3000"));
-    config.setAllowedMethods(List.of("GET", "POST", "PATCH", "DELETE", "OPTIONS"));
+    config.setAllowedMethods(List.of("GET", "OPTIONS"));
     config.setAllowedHeaders(List.of("*"));
     config.setMaxAge(3600L);
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/app/src/main/java/com/truthscope/web/config/SecurityConfig.java
+++ b/app/src/main/java/com/truthscope/web/config/SecurityConfig.java
@@ -1,22 +1,45 @@
 package com.truthscope.web.config;
 
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 /** Spring Security 기본 설정 */
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
-  /** 모든 엔드포인트 허용, CSRF 비활성화 */
+  /** CORS 허용, 모든 엔드포인트 허용, CSRF 비활성화 */
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-    http.csrf(AbstractHttpConfigurer::disable)
+    http.cors(cors -> cors.configurationSource(corsConfigurationSource()))
+        .csrf(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
     return http.build();
+  }
+
+  /**
+   * 브라우저에서 BE를 직접 호출하는 FE(결과 카드 폴링 등)를 위한 CORS 허용.
+   *
+   * <p>canonical Vercel 도메인과 로컬 개발 origin만 허용한다. 쿠키 미전송(allowCredentials 기본 false).
+   */
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration config = new CorsConfiguration();
+    config.setAllowedOrigins(
+        List.of("https://truthscope-web-frontend.vercel.app", "http://localhost:3000"));
+    config.setAllowedMethods(List.of("GET", "POST", "PATCH", "DELETE", "OPTIONS"));
+    config.setAllowedHeaders(List.of("*"));
+    config.setMaxAge(3600L);
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", config);
+    return source;
   }
 }


### PR DESCRIPTION
## 개요
브라우저에서 BE를 직접 호출하는 FE 결과 카드 폴링(poll-island)을 위해 CORS를 허용한다. canonical Vercel 도메인(`https://truthscope-web-frontend.vercel.app`)과 로컬 개발 origin(`http://localhost:3000`)만 허용. POST 분석은 Edge 프록시(same-origin) 경유라 CORS 무관, GET verification 클라이언트 폴링만 CORS 필요.

## Done
- [✅] 요구사항: 허용 origin에서 GET/POST/OPTIONS 등 CORS 응답 헤더 부여, 그 외 origin 차단
- [✅] 산출물: SecurityConfig.cors() + CorsConfigurationSource bean
- [✅] 수용 테스트: ./gradlew build GREEN (기존 컨텍스트 로딩 테스트가 SecurityConfig 포함 검증)

<!-- SAFE_OP_START -->
Assumptions: FE 폴링은 쿠키 미전송 → allowCredentials 기본 false. preview URL은 401 보호라 canonical만 허용
Scope: app/.../config/SecurityConfig.java
Out-of-scope: 비동기 전환 코드, FE, 환경변수
<!-- SAFE_OP_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CORS(크로스 오리진 리소스 공유) 설정을 명시적으로 활성화하여 프로덕션 및 로컬 개발 환경에서의 크로스 오리진 API 요청을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->