### PR TITLE
✨feat: Phase 70 — Supabase JWT 인증 + member_id 바인딩 + 분석 이력 조회 API

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-database-postgresql'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'

--- a/app/src/main/java/com/truthscope/web/config/SecurityConfig.java
+++ b/app/src/main/java/com/truthscope/web/config/SecurityConfig.java
@@ -1,34 +1,83 @@
 package com.truthscope.web.config;
 
+import com.truthscope.web.security.SupabaseAuthenticationEntryPoint;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-/** Spring Security 기본 설정 */
+/** Spring Security 설정 — Supabase JWT(ES256 JWKS) 리소스 서버 + CORS */
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
-  /** CORS 허용, 모든 엔드포인트 허용, CSRF 비활성화 */
+  /**
+   * GET /api/v1/analysis-sessions 만 authenticated, 나머지는 permitAll(POST 익명 분석 보존). 무효 토큰 401 →
+   * SupabaseAuthenticationEntryPoint.
+   */
   @Bean
-  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+  public SecurityFilterChain securityFilterChain(
+      HttpSecurity http, SupabaseAuthenticationEntryPoint entryPoint) throws Exception {
     http.cors(cors -> cors.configurationSource(corsConfigurationSource()))
         .csrf(AbstractHttpConfigurer::disable)
-        .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers(HttpMethod.GET, "/api/v1/analysis-sessions")
+                    .authenticated()
+                    .anyRequest()
+                    .permitAll())
+        .oauth2ResourceServer(
+            oauth2 ->
+                oauth2
+                    .authenticationEntryPoint(entryPoint) // 무효 토큰 401 JSON
+                    .jwt(Customizer.withDefaults()))
+        .exceptionHandling(ex -> ex.authenticationEntryPoint(entryPoint)); // 토큰 부재 401 JSON
     return http.build();
   }
 
   /**
-   * 브라우저에서 BE를 직접 호출하는 FE(결과 카드 폴링 등)를 위한 CORS 허용.
-   *
-   * <p>canonical Vercel 도메인과 로컬 개발 origin만 허용한다. 쿠키 미전송(allowCredentials 기본 false).
+   * Supabase JWT 검증기. withJwkSetUri 기본은 RS256-only라 ES256 명시 필수. issuer + aud=authenticated 검증 포함.
+   */
+  @Bean
+  public JwtDecoder jwtDecoder(
+      @Value("${truthscope.supabase.jwk-set-uri}") String jwkSetUri,
+      @Value("${truthscope.supabase.issuer}") String issuer) {
+    NimbusJwtDecoder decoder =
+        NimbusJwtDecoder.withJwkSetUri(jwkSetUri)
+            .jwsAlgorithm(SignatureAlgorithm.ES256) // Supabase GoTrue = EC P-256
+            .build();
+    OAuth2TokenValidator<Jwt> withIssuer = JwtValidators.createDefaultWithIssuer(issuer);
+    OAuth2TokenValidator<Jwt> audience =
+        jwt ->
+            (jwt.getAudience() != null && jwt.getAudience().contains("authenticated"))
+                ? OAuth2TokenValidatorResult.success()
+                : OAuth2TokenValidatorResult.failure(
+                    new OAuth2Error("invalid_token", "aud 불일치", null));
+    decoder.setJwtValidator(new DelegatingOAuth2TokenValidator<>(withIssuer, audience));
+    return decoder;
+  }
+
+  /**
+   * CORS — canonical Vercel 도메인과 로컬 개발 origin만 허용. POST 분석은 Edge 프록시 서버사이드 중계이므로 GET/OPTIONS 유지로
+   * 충분(Precondition 5).
    */
   @Bean
   public CorsConfigurationSource corsConfigurationSource() {

--- a/app/src/main/java/com/truthscope/web/controller/NewsController.java
+++ b/app/src/main/java/com/truthscope/web/controller/NewsController.java
@@ -1,12 +1,20 @@
 package com.truthscope.web.controller;
 
+import com.truthscope.web.dto.AuthenticatedUser;
 import com.truthscope.web.dto.request.AnalysisRequest;
 import com.truthscope.web.dto.response.AnalysisResponse;
+import com.truthscope.web.dto.response.AnalysisSessionHistoryResponse;
+import com.truthscope.web.service.AnalysisHistoryService;
 import com.truthscope.web.service.AnalysisService;
 import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -20,22 +28,41 @@ import org.springframework.web.bind.annotation.RestController;
 public class NewsController {
 
   private final AnalysisService analysisService;
+  private final AnalysisHistoryService analysisHistoryService;
 
   /**
-   * 뉴스 기사 분석 요청.
+   * 뉴스 기사 분석 요청. 익명(토큰 없음) 및 인증(토큰 있음) 모두 허용(permitAll). 유효 Bearer 첨부 시 member_id 바인딩.
    *
    * <p>BE #74 amend: BYOK 사용자 키를 {@code X-User-Gemini-Key} 헤더로 1회성 수신 (ADR-004 §c). 헤더 부재 시 서버 기본 키
    * 사용.
    *
    * @param request 분석할 뉴스 기사 URL
    * @param userApiKey BYOK 사용자 Gemini API 키 (헤더 옵션, 없으면 서버 기본 키)
+   * @param jwt 인증 JWT (익명이면 null)
    * @return 생성된 세션 ID와 상태 (201 Created)
    */
   @PostMapping
   public ResponseEntity<AnalysisResponse> analyze(
       @Valid @RequestBody AnalysisRequest request,
-      @RequestHeader(name = "X-User-Gemini-Key", required = false) String userApiKey) {
-    AnalysisResponse response = analysisService.analyze(request, userApiKey);
+      @RequestHeader(name = "X-User-Gemini-Key", required = false) String userApiKey,
+      @AuthenticationPrincipal Jwt jwt) {
+    AuthenticatedUser user =
+        (jwt == null)
+            ? null
+            : new AuthenticatedUser(
+                UUID.fromString(jwt.getSubject()), jwt.getClaimAsString("email"));
+    AnalysisResponse response = analysisService.analyze(request, userApiKey, user);
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  /**
+   * 인증 사용자 분석 이력 조회. GET /api/v1/analysis-sessions — SecurityConfig에서 authenticated() 필수.
+   *
+   * @param jwt 인증 JWT (SecurityConfig에서 authenticated 보장으로 non-null)
+   * @return 이력 목록 (requested_at DESC)
+   */
+  @GetMapping
+  public List<AnalysisSessionHistoryResponse> getMySessions(@AuthenticationPrincipal Jwt jwt) {
+    return analysisHistoryService.findMySessions(UUID.fromString(jwt.getSubject()));
   }
 }

--- a/app/src/main/java/com/truthscope/web/controller/NewsController.java
+++ b/app/src/main/java/com/truthscope/web/controller/NewsController.java
@@ -4,6 +4,7 @@ import com.truthscope.web.dto.AuthenticatedUser;
 import com.truthscope.web.dto.request.AnalysisRequest;
 import com.truthscope.web.dto.response.AnalysisResponse;
 import com.truthscope.web.dto.response.AnalysisSessionHistoryResponse;
+import com.truthscope.web.exception.UnauthorizedException;
 import com.truthscope.web.service.AnalysisHistoryService;
 import com.truthscope.web.service.AnalysisService;
 import jakarta.validation.Valid;
@@ -46,11 +47,7 @@ public class NewsController {
       @Valid @RequestBody AnalysisRequest request,
       @RequestHeader(name = "X-User-Gemini-Key", required = false) String userApiKey,
       @AuthenticationPrincipal Jwt jwt) {
-    AuthenticatedUser user =
-        (jwt == null)
-            ? null
-            : new AuthenticatedUser(
-                UUID.fromString(jwt.getSubject()), jwt.getClaimAsString("email"));
+    AuthenticatedUser user = toUser(jwt);
     AnalysisResponse response = analysisService.analyze(request, userApiKey, user);
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
@@ -63,6 +60,33 @@ public class NewsController {
    */
   @GetMapping
   public List<AnalysisSessionHistoryResponse> getMySessions(@AuthenticationPrincipal Jwt jwt) {
-    return analysisHistoryService.findMySessions(UUID.fromString(jwt.getSubject()));
+    return analysisHistoryService.findMySessions(requireUserId(jwt));
+  }
+
+  /**
+   * JWT subject를 UUID로 파싱한다. sub가 UUID 형식이 아니면 UnauthorizedException(401)을 던진다.
+   *
+   * @param jwt 인증 JWT (null 불가)
+   * @return 파싱된 UUID
+   */
+  private static UUID requireUserId(Jwt jwt) {
+    try {
+      return UUID.fromString(jwt.getSubject());
+    } catch (IllegalArgumentException e) {
+      throw new UnauthorizedException("유효하지 않은 토큰 subject입니다");
+    }
+  }
+
+  /**
+   * JWT가 있으면 AuthenticatedUser를 생성하고, null이면 null을 반환한다.
+   *
+   * @param jwt 인증 JWT (익명이면 null)
+   * @return AuthenticatedUser 또는 null
+   */
+  private static AuthenticatedUser toUser(Jwt jwt) {
+    if (jwt == null) {
+      return null;
+    }
+    return new AuthenticatedUser(requireUserId(jwt), jwt.getClaimAsString("email"));
   }
 }

--- a/app/src/main/java/com/truthscope/web/repository/AnalysisSessionRepository.java
+++ b/app/src/main/java/com/truthscope/web/repository/AnalysisSessionRepository.java
@@ -1,14 +1,29 @@
 package com.truthscope.web.repository;
 
+import com.truthscope.web.dto.projection.AnalysisSessionHistoryRow;
 import com.truthscope.web.entity.AnalysisSession;
 import com.truthscope.web.entity.enums.SessionStatus;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AnalysisSessionRepository extends JpaRepository<AnalysisSession, UUID> {
 
   List<AnalysisSession> findByMemberId(UUID memberId);
 
   List<AnalysisSession> findByStatus(SessionStatus status);
+
+  /**
+   * 인증 사용자의 분석 이력을 요청일 내림차순으로 조회한다. article 없는 세션(PENDING)도 좌조인으로 포함되며 article 필드는 null.
+   *
+   * <p>Hibernate 6(Spring Boot 3.5) ad-hoc join 지원으로 엔티티 조인 사용.
+   */
+  @Query(
+      "select new com.truthscope.web.dto.projection.AnalysisSessionHistoryRow("
+          + "s.id, a.id, a.title, a.url, a.domain, s.status, s.totalScore, s.requestedAt, s.completedAt) "
+          + "from AnalysisSession s left join Article a on a.session = s "
+          + "where s.member.id = :memberId order by s.requestedAt desc")
+  List<AnalysisSessionHistoryRow> findHistoryByMemberId(@Param("memberId") UUID memberId);
 }

--- a/app/src/main/java/com/truthscope/web/security/SupabaseAuthenticationEntryPoint.java
+++ b/app/src/main/java/com/truthscope/web/security/SupabaseAuthenticationEntryPoint.java
@@ -1,0 +1,35 @@
+package com.truthscope.web.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.truthscope.web.dto.ApiErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+/** 인증 실패(토큰 부재/무효) 시 401 JSON 응답을 반환하는 EntryPoint. */
+@Component
+@RequiredArgsConstructor
+public class SupabaseAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void commence(HttpServletRequest req, HttpServletResponse res, AuthenticationException ex)
+      throws IOException {
+    res.setStatus(HttpStatus.UNAUTHORIZED.value());
+    res.setContentType("application/json;charset=UTF-8");
+    res.getWriter()
+        .write(
+            objectMapper.writeValueAsString(
+                ApiErrorResponse.builder()
+                    .status("fail")
+                    .statusCode(401)
+                    .message("인증이 필요합니다")
+                    .build()));
+  }
+}

--- a/app/src/main/java/com/truthscope/web/service/AnalysisHistoryService.java
+++ b/app/src/main/java/com/truthscope/web/service/AnalysisHistoryService.java
@@ -1,0 +1,30 @@
+package com.truthscope.web.service;
+
+import com.truthscope.web.converter.AnalysisSessionHistoryConverter;
+import com.truthscope.web.dto.response.AnalysisSessionHistoryResponse;
+import com.truthscope.web.repository.AnalysisSessionRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 인증 사용자 분석 이력 조회 서비스. */
+@Service
+@RequiredArgsConstructor
+public class AnalysisHistoryService {
+
+  private final AnalysisSessionRepository sessionRepository;
+
+  /**
+   * member의 분석 이력을 요청일 내림차순으로 반환한다.
+   *
+   * @param memberId Supabase Auth UUID (member PK)
+   */
+  @Transactional(readOnly = true)
+  public List<AnalysisSessionHistoryResponse> findMySessions(UUID memberId) {
+    return sessionRepository.findHistoryByMemberId(memberId).stream()
+        .map(AnalysisSessionHistoryConverter::toResponse)
+        .toList();
+  }
+}

--- a/app/src/main/java/com/truthscope/web/service/AnalysisService.java
+++ b/app/src/main/java/com/truthscope/web/service/AnalysisService.java
@@ -1,8 +1,10 @@
 package com.truthscope.web.service;
 
+import com.truthscope.web.dto.AuthenticatedUser;
 import com.truthscope.web.dto.request.AnalysisRequest;
 import com.truthscope.web.dto.response.AnalysisResponse;
 import com.truthscope.web.dto.response.ExtractedArticle;
+import com.truthscope.web.entity.Member;
 import jakarta.annotation.Nullable;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,7 @@ public class AnalysisService {
   private final AnalysisTransactionService transactionService;
   private final ContentExtractService contentExtractService;
   private final AsyncAnalysisService asyncProcessor;
+  private final MemberService memberService;
 
   /**
    * 뉴스 기사 URL을 받아 기사 추출과 영속화를 동기로 수행한 뒤 claims 이후를 비동기로 위임한다.
@@ -23,16 +26,22 @@ public class AnalysisService {
    * <p>단계:
    *
    * <ol>
-   *   <li>세션 생성 (트랜잭션)
+   *   <li>세션 생성 (트랜잭션, 인증 시 member 바인딩)
    *   <li>기사 본문 추출 (트랜잭션 밖, 외부 HTTP Jsoup)
    *   <li>Article 저장 + 상태 EXTRACTING 전이 (트랜잭션, 즉시 커밋)
    *   <li>EXTRACTING 스냅샷 DTO 반환 + 비동기 프로세서에 claims 이후 위임
    * </ol>
    *
    * <p>동기 구간에서 RuntimeException 발생 시 세션을 FAILED로 전이한다. markFailed 자체 실패 시 원본 예외에 suppressed로 추가.
+   *
+   * @param request 분석 요청 (URL)
+   * @param userApiKey BYOK 사용자 Gemini API 키 (null이면 서버 기본 키)
+   * @param user 인증 사용자 정보 (null이면 익명 — member_id NULL)
    */
-  public AnalysisResponse analyze(AnalysisRequest request, @Nullable String userApiKey) {
-    UUID sessionId = transactionService.createPendingSession();
+  public AnalysisResponse analyze(
+      AnalysisRequest request, @Nullable String userApiKey, @Nullable AuthenticatedUser user) {
+    Member member = (user == null) ? null : memberService.upsert(user.id(), user.email());
+    UUID sessionId = transactionService.createPendingSession(member);
     try {
       ExtractedArticle extracted = contentExtractService.extract(request.url());
       // persistArticleAndUpdateStatus는 독립 @Transactional이므로 메서드 반환 시 즉시 커밋.
@@ -55,9 +64,19 @@ public class AnalysisService {
   }
 
   /**
+   * Backward compat: userApiKey 위임 (BYOK 사용 + 익명).
+   *
+   * <p>BE #74 amend: BYOK 사용자 키를 {@code X-User-Gemini-Key} 헤더로 1회성 수신 (ADR-004 §c). 헤더 부재 시 서버 기본 키
+   * 사용.
+   */
+  public AnalysisResponse analyze(AnalysisRequest request, @Nullable String userApiKey) {
+    return analyze(request, userApiKey, null);
+  }
+
+  /**
    * Backward compat, userApiKey null 위임. (VerificationCascadeIntegrationTest:174,250가 호출, 제거 금지)
    */
   public AnalysisResponse analyze(AnalysisRequest request) {
-    return analyze(request, null);
+    return analyze(request, null, null);
   }
 }

--- a/app/src/main/java/com/truthscope/web/service/AnalysisTransactionService.java
+++ b/app/src/main/java/com/truthscope/web/service/AnalysisTransactionService.java
@@ -7,6 +7,7 @@ import com.truthscope.web.dto.response.ExtractedArticle;
 import com.truthscope.web.entity.AnalysisSession;
 import com.truthscope.web.entity.Article;
 import com.truthscope.web.entity.Claim;
+import com.truthscope.web.entity.Member;
 import com.truthscope.web.entity.VerificationResult;
 import com.truthscope.web.entity.VerifySource;
 import com.truthscope.web.entity.enums.ClaimImportance;
@@ -47,11 +48,16 @@ public class AnalysisTransactionService {
   private final VerificationResultRepository verificationResultRepository;
   private final VerifySourceRepository verifySourceRepository;
 
-  /** 세션 생성 후 ID 반환 */
+  /**
+   * 세션 생성 후 ID 반환.
+   *
+   * @param member 인증 사용자(null이면 익명 — member_id NULL)
+   */
   @Transactional
-  public UUID createPendingSession() {
+  public UUID createPendingSession(Member member) {
     AnalysisSession session =
         AnalysisSession.builder()
+            .member(member)
             .status(SessionStatus.PENDING)
             .requestedAt(LocalDateTime.now())
             .build();

--- a/app/src/main/java/com/truthscope/web/service/MemberService.java
+++ b/app/src/main/java/com/truthscope/web/service/MemberService.java
@@ -33,7 +33,7 @@ public class MemberService {
 
   private Member saveNew(UUID id, String email) {
     try {
-      return memberRepository.save(
+      return memberRepository.saveAndFlush(
           Member.builder()
               .id(id)
               .email(email)

--- a/app/src/main/java/com/truthscope/web/service/MemberService.java
+++ b/app/src/main/java/com/truthscope/web/service/MemberService.java
@@ -1,0 +1,53 @@
+package com.truthscope.web.service;
+
+import com.truthscope.web.entity.Member;
+import com.truthscope.web.entity.enums.MemberRole;
+import com.truthscope.web.repository.MemberRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 인증 사용자 member lazy upsert — 첫 인증 분석 시 호출, 이후엔 기존 row 반환. */
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+  private final MemberRepository memberRepository;
+
+  /**
+   * Supabase sub(id)로 member를 조회하거나 신규 생성한다.
+   *
+   * <p>동시 첫 분석 race(같은 sub로 두 요청)에서 PK/email unique 충돌 시 DataIntegrityViolationException catch 후
+   * 재조회로 멱등 보장.
+   *
+   * @param id Supabase Auth UUID (member PK)
+   * @param email Supabase JWT에서 추출한 이메일
+   * @return 기존 또는 신규 생성된 Member
+   */
+  @Transactional
+  public Member upsert(UUID id, String email) {
+    return memberRepository.findById(id).orElseGet(() -> saveNew(id, email));
+  }
+
+  private Member saveNew(UUID id, String email) {
+    try {
+      return memberRepository.save(
+          Member.builder()
+              .id(id)
+              .email(email)
+              .nickname(deriveNickname(email))
+              .role(MemberRole.USER)
+              .build());
+    } catch (DataIntegrityViolationException e) {
+      return memberRepository.findById(id).orElseThrow(() -> e); // 충돌인데 재조회도 없으면 진짜 에러
+    }
+  }
+
+  private static String deriveNickname(String email) {
+    if (email == null || email.isBlank()) return "user";
+    int at = email.indexOf('@');
+    return at > 0 ? email.substring(0, at) : email;
+  }
+}

--- a/app/src/main/resources/application-prod.yml
+++ b/app/src/main/resources/application-prod.yml
@@ -19,6 +19,9 @@ spring:
       password: ${ADMIN_PASSWORD}
 
 truthscope:
+  supabase:
+    jwk-set-uri: ${SUPABASE_JWK_SET_URI}
+    issuer: ${SUPABASE_ISSUER}
   gemini:
     api-key: ${GEMINI_API_KEY}
   datasource:

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -64,6 +64,9 @@ resilience4j:
           - org.springframework.web.client.HttpClientErrorException.Forbidden
 
 truthscope:
+  supabase:
+    jwk-set-uri: ${SUPABASE_JWK_SET_URI:https://cbomiwbngcajjmslflfc.supabase.co/auth/v1/.well-known/jwks.json}
+    issuer: ${SUPABASE_ISSUER:https://cbomiwbngcajjmslflfc.supabase.co/auth/v1}
   gemini:
     api-key: ${GEMINI_API_KEY:}
     # base-url default는 RestClientConfig의 @Value에서 정의 (BE #92 wiremock-spring-boot customizer가

--- a/app/src/test/java/com/truthscope/web/controller/ArticleControllerTest.java
+++ b/app/src/test/java/com/truthscope/web/controller/ArticleControllerTest.java
@@ -13,6 +13,7 @@ import com.truthscope.web.dto.response.ArticleResponse;
 import com.truthscope.web.exception.ConflictException;
 import com.truthscope.web.exception.GlobalExceptionHandler;
 import com.truthscope.web.exception.NotFoundException;
+import com.truthscope.web.security.SupabaseAuthenticationEntryPoint;
 import com.truthscope.web.service.ArticleService;
 import com.truthscope.web.service.ArticleVerificationService;
 import java.time.LocalDateTime;
@@ -23,13 +24,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 /** ArticleController 단위 테스트 (WebMvcTest + Service mock) */
 @WebMvcTest(controllers = ArticleController.class)
-@Import({GlobalExceptionHandler.class, SecurityConfig.class})
+@Import({
+  GlobalExceptionHandler.class,
+  SecurityConfig.class,
+  SupabaseAuthenticationEntryPoint.class
+})
 @ActiveProfiles("test")
 class ArticleControllerTest {
 
@@ -39,6 +45,9 @@ class ArticleControllerTest {
 
   // findVerification 엔드포인트 추가로 컨트롤러 의존 주입됨 — WebMvcTest 컨텍스트 로드용 mock
   @MockitoBean private ArticleVerificationService articleVerificationService;
+
+  // SecurityConfig에 oauth2ResourceServer + JwtDecoder bean이 필요 — WebMvcTest 컨텍스트 로드용 mock
+  @MockitoBean private JwtDecoder jwtDecoder;
 
   @Test
   @DisplayName("GET /api/v1/articles/{id} — 200 + ArticleResponse 반환")

--- a/app/src/test/java/com/truthscope/web/controller/NewsControllerTest.java
+++ b/app/src/test/java/com/truthscope/web/controller/NewsControllerTest.java
@@ -2,6 +2,8 @@ package com.truthscope.web.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -9,22 +11,33 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.truthscope.web.config.SecurityConfig;
 import com.truthscope.web.dto.request.AnalysisRequest;
 import com.truthscope.web.dto.response.AnalysisResponse;
+import com.truthscope.web.dto.response.AnalysisSessionHistoryResponse;
 import com.truthscope.web.exception.GlobalExceptionHandler;
+import com.truthscope.web.security.SupabaseAuthenticationEntryPoint;
+import com.truthscope.web.service.AnalysisHistoryService;
 import com.truthscope.web.service.AnalysisService;
+import java.util.List;
 import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.BadJwtException;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 /** NewsController 단위 테스트 */
 @WebMvcTest(controllers = NewsController.class)
-@Import({GlobalExceptionHandler.class, SecurityConfig.class})
+@Import({
+  GlobalExceptionHandler.class,
+  SecurityConfig.class,
+  SupabaseAuthenticationEntryPoint.class
+})
 @ActiveProfiles("test")
 class NewsControllerTest {
 
@@ -32,9 +45,19 @@ class NewsControllerTest {
 
   @MockitoBean private AnalysisService analysisService;
 
+  @MockitoBean private AnalysisHistoryService analysisHistoryService;
+
+  @MockitoBean private JwtDecoder jwtDecoder;
+
+  @BeforeEach
+  void setupJwtDecoder() {
+    // 무효 토큰 패턴 stub: "Bearer invalid.token.here" 헤더가 들어오면 JwtDecoder가 BadJwtException throw
+    given(jwtDecoder.decode("invalid.token.here")).willThrow(new BadJwtException("invalid token"));
+  }
+
   @Test
-  @DisplayName("POST /api/v1/analysis-sessions — 유효한 URL → 201 반환 (sessionId + articleId + status)")
-  void analyze_validUrl_returns201() throws Exception {
+  @DisplayName("POST /api/v1/analysis-sessions — 익명(토큰 없음) → 201 반환 (permitAll 보장)")
+  void analyze_anonymous_returns201() throws Exception {
     UUID sessionId = UUID.randomUUID();
     UUID articleId = UUID.randomUUID();
     AnalysisResponse response =
@@ -44,7 +67,7 @@ class NewsControllerTest {
             .status("EXTRACTING")
             .build();
 
-    given(analysisService.analyze(any(AnalysisRequest.class), any())).willReturn(response);
+    given(analysisService.analyze(any(AnalysisRequest.class), any(), any())).willReturn(response);
 
     mockMvc
         .perform(
@@ -53,8 +76,44 @@ class NewsControllerTest {
                 .content("{\"url\":\"https://news.naver.com/article/001\"}"))
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.sessionId").value(sessionId.toString()))
-        .andExpect(jsonPath("$.articleId").value(articleId.toString()))
         .andExpect(jsonPath("$.status").value("EXTRACTING"));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/analysis-sessions — 유효 JWT → 201 반환")
+  void analyze_withValidJwt_returns201() throws Exception {
+    UUID sessionId = UUID.randomUUID();
+    UUID memberId = UUID.randomUUID();
+    AnalysisResponse response =
+        AnalysisResponse.builder()
+            .sessionId(sessionId)
+            .articleId(UUID.randomUUID())
+            .status("EXTRACTING")
+            .build();
+
+    given(analysisService.analyze(any(AnalysisRequest.class), any(), any())).willReturn(response);
+
+    mockMvc
+        .perform(
+            post("/api/v1/analysis-sessions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"url\":\"https://news.naver.com/article/001\"}")
+                .with(jwt().jwt(j -> j.subject(memberId.toString()).claim("email", "u@test.com"))))
+        .andExpect(status().isCreated());
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/analysis-sessions — 무효 Bearer(잘못된 토큰) → 401 반환 (CX-1)")
+  void analyze_invalidBearer_returns401() throws Exception {
+    // @MockitoBean JwtDecoder가 있으면 SecurityConfig의 oauth2ResourceServer가 실제 JWKS fetch 없이
+    // 동작한다. 무효 Bearer 헤더는 SecurityConfig가 401로 거부한다.
+    mockMvc
+        .perform(
+            post("/api/v1/analysis-sessions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"url\":\"https://news.naver.com/article/001\"}")
+                .header("Authorization", "Bearer invalid.token.here"))
+        .andExpect(status().isUnauthorized());
   }
 
   @Test
@@ -75,5 +134,32 @@ class NewsControllerTest {
         .perform(
             post("/api/v1/analysis-sessions").contentType(MediaType.APPLICATION_JSON).content("{}"))
         .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/analysis-sessions — 토큰 없음 → 401 + ApiErrorResponse JSON (status:fail)")
+  void getMySessions_noToken_returns401WithApiErrorResponse() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/analysis-sessions"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.status").value("fail"))
+        .andExpect(jsonPath("$.statusCode").value(401));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/analysis-sessions — 유효 JWT → 200 + 목록 반환")
+  void getMySessions_withJwt_returns200() throws Exception {
+    UUID memberId = UUID.randomUUID();
+    UUID sessionId = UUID.randomUUID();
+    AnalysisSessionHistoryResponse item =
+        AnalysisSessionHistoryResponse.builder().sessionId(sessionId).status("COMPLETED").build();
+    given(analysisHistoryService.findMySessions(memberId)).willReturn(List.of(item));
+
+    mockMvc
+        .perform(
+            get("/api/v1/analysis-sessions")
+                .with(jwt().jwt(j -> j.subject(memberId.toString()).claim("email", "u@test.com"))))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].sessionId").value(sessionId.toString()));
   }
 }

--- a/app/src/test/java/com/truthscope/web/controller/NewsControllerTest.java
+++ b/app/src/test/java/com/truthscope/web/controller/NewsControllerTest.java
@@ -162,4 +162,12 @@ class NewsControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$[0].sessionId").value(sessionId.toString()));
   }
+
+  @Test
+  @DisplayName("GET /api/v1/analysis-sessions — 비-UUID subject JWT → 401 반환")
+  void getMySessions_nonUuidSubject_returns401() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/analysis-sessions").with(jwt().jwt(j -> j.subject("not-a-uuid"))))
+        .andExpect(status().isUnauthorized());
+  }
 }

--- a/app/src/test/java/com/truthscope/web/exception/GlobalExceptionHandlerTest.java
+++ b/app/src/test/java/com/truthscope/web/exception/GlobalExceptionHandlerTest.java
@@ -6,22 +6,32 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.truthscope.web.config.SecurityConfig;
+import com.truthscope.web.security.SupabaseAuthenticationEntryPoint;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 /** GlobalExceptionHandler 단위 테스트 */
 @WebMvcTest(controllers = ExceptionTestController.class)
-@Import({GlobalExceptionHandler.class, SecurityConfig.class})
+@Import({
+  GlobalExceptionHandler.class,
+  SecurityConfig.class,
+  SupabaseAuthenticationEntryPoint.class
+})
 @ActiveProfiles("test")
 class GlobalExceptionHandlerTest {
 
   @Autowired private MockMvc mockMvc;
+
+  // SecurityConfig에 oauth2ResourceServer + JwtDecoder bean이 필요 — WebMvcTest 컨텍스트 로드용 mock
+  @MockitoBean private JwtDecoder jwtDecoder;
 
   @Test
   @DisplayName("NotFoundException → 404, status=fail 반환")

--- a/app/src/test/java/com/truthscope/web/service/AnalysisHistoryServiceTest.java
+++ b/app/src/test/java/com/truthscope/web/service/AnalysisHistoryServiceTest.java
@@ -1,0 +1,120 @@
+package com.truthscope.web.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.truthscope.web.dto.response.AnalysisSessionHistoryResponse;
+import com.truthscope.web.entity.AnalysisSession;
+import com.truthscope.web.entity.Article;
+import com.truthscope.web.entity.Member;
+import com.truthscope.web.entity.enums.MemberRole;
+import com.truthscope.web.entity.enums.SessionStatus;
+import com.truthscope.web.repository.AnalysisSessionRepository;
+import com.truthscope.web.repository.ArticleRepository;
+import com.truthscope.web.repository.MemberRepository;
+import com.truthscope.web.support.AbstractIntegrationTest;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * findHistoryByMemberId JPQL 실행 검증 (H-1/CX-9).
+ *
+ * <p>Testcontainers PostgreSQL 필요 — Docker 없이 실행 시 자동 SKIP (@Testcontainers
+ * disabledWithoutDocker=true).
+ */
+class AnalysisHistoryServiceTest extends AbstractIntegrationTest {
+
+  @Autowired private AnalysisHistoryService analysisHistoryService;
+
+  @Autowired private MemberRepository memberRepository;
+
+  @Autowired private AnalysisSessionRepository sessionRepository;
+
+  @Autowired private ArticleRepository articleRepository;
+
+  @Test
+  @DisplayName("findMySessions — member 격리: 타 member 세션 미포함")
+  void findMySessions_isolatesByMember() {
+    UUID id1 = UUID.randomUUID();
+    UUID id2 = UUID.randomUUID();
+    Member m1 = memberRepository.save(member(id1, "u1@test.com"));
+    Member m2 = memberRepository.save(member(id2, "u2@test.com"));
+
+    AnalysisSession s1 = sessionRepository.save(session(m1));
+    sessionRepository.save(session(m2)); // 타 member
+
+    List<AnalysisSessionHistoryResponse> result = analysisHistoryService.findMySessions(id1);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getSessionId()).isEqualTo(s1.getId());
+  }
+
+  @Test
+  @DisplayName("findMySessions — requested_at DESC 정렬")
+  void findMySessions_orderedByRequestedAtDesc() {
+    UUID id = UUID.randomUUID();
+    Member m = memberRepository.save(member(id, id + "@test.com"));
+
+    AnalysisSession older = sessionRepository.save(sessionAt(m, LocalDateTime.now().minusHours(2)));
+    AnalysisSession newer = sessionRepository.save(sessionAt(m, LocalDateTime.now()));
+
+    List<AnalysisSessionHistoryResponse> result = analysisHistoryService.findMySessions(id);
+
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).getSessionId()).isEqualTo(newer.getId());
+    assertThat(result.get(1).getSessionId()).isEqualTo(older.getId());
+  }
+
+  @Test
+  @DisplayName("findMySessions — article 없는 세션(PENDING)도 포함, article 필드는 null")
+  void findMySessions_pendingSessionWithoutArticle() {
+    UUID id = UUID.randomUUID();
+    Member m = memberRepository.save(member(id, id + "@test.com"));
+    sessionRepository.save(session(m));
+
+    List<AnalysisSessionHistoryResponse> result = analysisHistoryService.findMySessions(id);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getArticleId()).isNull();
+    assertThat(result.get(0).getArticleTitle()).isNull();
+  }
+
+  @Test
+  @DisplayName("findMySessions — article 있는 세션은 article 필드 채워져 반환")
+  void findMySessions_sessionWithArticle() {
+    UUID id = UUID.randomUUID();
+    Member m = memberRepository.save(member(id, id + "@test.com"));
+    AnalysisSession s = sessionRepository.save(session(m));
+    Article article =
+        Article.extract("https://news.example.com/1", "테스트 제목", "본문", "ko", "news.example.com")
+            .attachTo(s);
+    articleRepository.save(article);
+
+    List<AnalysisSessionHistoryResponse> result = analysisHistoryService.findMySessions(id);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getArticleTitle()).isEqualTo("테스트 제목");
+    assertThat(result.get(0).getArticleDomain()).isEqualTo("news.example.com");
+  }
+
+  // ─── helpers ───
+
+  private static Member member(UUID id, String email) {
+    return Member.builder().id(id).email(email).nickname("nick").role(MemberRole.USER).build();
+  }
+
+  private static AnalysisSession session(Member member) {
+    return sessionAt(member, LocalDateTime.now());
+  }
+
+  private static AnalysisSession sessionAt(Member member, LocalDateTime requestedAt) {
+    return AnalysisSession.builder()
+        .member(member)
+        .status(SessionStatus.PENDING)
+        .requestedAt(requestedAt)
+        .build();
+  }
+}

--- a/app/src/test/java/com/truthscope/web/service/MemberServiceTest.java
+++ b/app/src/test/java/com/truthscope/web/service/MemberServiceTest.java
@@ -1,0 +1,94 @@
+package com.truthscope.web.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.truthscope.web.entity.Member;
+import com.truthscope.web.entity.enums.MemberRole;
+import com.truthscope.web.repository.MemberRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+/** MemberService.upsert 단위 테스트 (Mockito 기반, Docker 불필요). */
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+  @Mock private MemberRepository memberRepository;
+
+  @InjectMocks private MemberService memberService;
+
+  @Test
+  @DisplayName("upsert — 신규 member: findById 없음 -> save 1회 호출, member 반환")
+  void upsert_newMember_savesOnce() {
+    UUID id = UUID.randomUUID();
+    Member saved =
+        Member.builder().id(id).email("a@b.com").nickname("a").role(MemberRole.USER).build();
+    given(memberRepository.findById(id)).willReturn(Optional.empty());
+    given(memberRepository.save(any())).willReturn(saved);
+
+    Member result = memberService.upsert(id, "a@b.com");
+
+    assertThat(result.getId()).isEqualTo(id);
+    verify(memberRepository, times(1)).save(any());
+  }
+
+  @Test
+  @DisplayName("upsert — 기존 member: findById 있음 -> save 호출 없음, 기존 member 반환")
+  void upsert_existingMember_noSave() {
+    UUID id = UUID.randomUUID();
+    Member existing =
+        Member.builder().id(id).email("a@b.com").nickname("a").role(MemberRole.USER).build();
+    given(memberRepository.findById(id)).willReturn(Optional.of(existing));
+
+    Member result = memberService.upsert(id, "a@b.com");
+
+    assertThat(result).isSameAs(existing);
+    verify(memberRepository, times(0)).save(any());
+  }
+
+  @Test
+  @DisplayName("upsert — nickname은 email prefix(@이전 부분)로 설정된다")
+  void upsert_nickname_derivedFromEmailPrefix() {
+    UUID id = UUID.randomUUID();
+    Member saved =
+        Member.builder()
+            .id(id)
+            .email("testuser@example.com")
+            .nickname("testuser")
+            .role(MemberRole.USER)
+            .build();
+    given(memberRepository.findById(id)).willReturn(Optional.empty());
+    given(memberRepository.save(any())).willReturn(saved);
+
+    Member result = memberService.upsert(id, "testuser@example.com");
+
+    assertThat(result.getNickname()).isEqualTo("testuser");
+  }
+
+  @Test
+  @DisplayName("upsert — DataIntegrityViolationException 시 재조회로 멱등 보장")
+  void upsert_raceCondition_reReadsOnConflict() {
+    UUID id = UUID.randomUUID();
+    Member existing =
+        Member.builder().id(id).email("a@b.com").nickname("a").role(MemberRole.USER).build();
+    given(memberRepository.findById(id))
+        .willReturn(Optional.empty()) // 1차 조회 없음
+        .willReturn(Optional.of(existing)); // 충돌 후 재조회
+    given(memberRepository.save(any())).willThrow(new DataIntegrityViolationException("dup"));
+
+    Member result = memberService.upsert(id, "a@b.com");
+
+    assertThat(result).isSameAs(existing);
+    verify(memberRepository, times(2)).findById(id); // 1차 + 재조회
+  }
+}

--- a/app/src/test/java/com/truthscope/web/service/MemberServiceTest.java
+++ b/app/src/test/java/com/truthscope/web/service/MemberServiceTest.java
@@ -34,12 +34,12 @@ class MemberServiceTest {
     Member saved =
         Member.builder().id(id).email("a@b.com").nickname("a").role(MemberRole.USER).build();
     given(memberRepository.findById(id)).willReturn(Optional.empty());
-    given(memberRepository.save(any())).willReturn(saved);
+    given(memberRepository.saveAndFlush(any())).willReturn(saved);
 
     Member result = memberService.upsert(id, "a@b.com");
 
     assertThat(result.getId()).isEqualTo(id);
-    verify(memberRepository, times(1)).save(any());
+    verify(memberRepository, times(1)).saveAndFlush(any());
   }
 
   @Test
@@ -53,7 +53,7 @@ class MemberServiceTest {
     Member result = memberService.upsert(id, "a@b.com");
 
     assertThat(result).isSameAs(existing);
-    verify(memberRepository, times(0)).save(any());
+    verify(memberRepository, times(0)).saveAndFlush(any());
   }
 
   @Test
@@ -68,7 +68,7 @@ class MemberServiceTest {
             .role(MemberRole.USER)
             .build();
     given(memberRepository.findById(id)).willReturn(Optional.empty());
-    given(memberRepository.save(any())).willReturn(saved);
+    given(memberRepository.saveAndFlush(any())).willReturn(saved);
 
     Member result = memberService.upsert(id, "testuser@example.com");
 
@@ -84,7 +84,8 @@ class MemberServiceTest {
     given(memberRepository.findById(id))
         .willReturn(Optional.empty()) // 1차 조회 없음
         .willReturn(Optional.of(existing)); // 충돌 후 재조회
-    given(memberRepository.save(any())).willThrow(new DataIntegrityViolationException("dup"));
+    given(memberRepository.saveAndFlush(any()))
+        .willThrow(new DataIntegrityViolationException("dup"));
 
     Member result = memberService.upsert(id, "a@b.com");
 

--- a/core/src/main/java/com/truthscope/web/converter/AnalysisSessionHistoryConverter.java
+++ b/core/src/main/java/com/truthscope/web/converter/AnalysisSessionHistoryConverter.java
@@ -1,0 +1,25 @@
+package com.truthscope.web.converter;
+
+import com.truthscope.web.dto.projection.AnalysisSessionHistoryRow;
+import com.truthscope.web.dto.response.AnalysisSessionHistoryResponse;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/** 이력 조회 Row projection → 응답 DTO 변환기. */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AnalysisSessionHistoryConverter {
+
+  public static AnalysisSessionHistoryResponse toResponse(AnalysisSessionHistoryRow row) {
+    return AnalysisSessionHistoryResponse.builder()
+        .sessionId(row.sessionId())
+        .articleId(row.articleId())
+        .articleTitle(row.articleTitle())
+        .articleUrl(row.articleUrl())
+        .articleDomain(row.articleDomain())
+        .status(row.status() == null ? null : row.status().name())
+        .totalScore(row.totalScore())
+        .requestedAt(row.requestedAt())
+        .completedAt(row.completedAt())
+        .build();
+  }
+}

--- a/core/src/main/java/com/truthscope/web/dto/AuthenticatedUser.java
+++ b/core/src/main/java/com/truthscope/web/dto/AuthenticatedUser.java
@@ -1,0 +1,6 @@
+package com.truthscope.web.dto;
+
+import java.util.UUID;
+
+/** 인증된 사용자 정보 (Supabase JWT sub + email). 보안 패키지 의존 없음 — core 모듈 배치 가능. */
+public record AuthenticatedUser(UUID id, String email) {}

--- a/core/src/main/java/com/truthscope/web/dto/projection/AnalysisSessionHistoryRow.java
+++ b/core/src/main/java/com/truthscope/web/dto/projection/AnalysisSessionHistoryRow.java
@@ -1,0 +1,17 @@
+package com.truthscope.web.dto.projection;
+
+import com.truthscope.web.entity.enums.SessionStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/** JPQL projection record — findHistoryByMemberId 결과 매핑. */
+public record AnalysisSessionHistoryRow(
+    UUID sessionId,
+    UUID articleId,
+    String articleTitle,
+    String articleUrl,
+    String articleDomain,
+    SessionStatus status,
+    Short totalScore,
+    LocalDateTime requestedAt,
+    LocalDateTime completedAt) {}

--- a/core/src/main/java/com/truthscope/web/dto/response/AnalysisSessionHistoryResponse.java
+++ b/core/src/main/java/com/truthscope/web/dto/response/AnalysisSessionHistoryResponse.java
@@ -1,0 +1,36 @@
+package com.truthscope.web.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 인증 사용자 분석 이력 단건 응답 DTO. */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnalysisSessionHistoryResponse {
+
+  private UUID sessionId;
+
+  /** null = 아직 기사 추출 전 (PENDING) */
+  private UUID articleId;
+
+  private String articleTitle;
+  private String articleUrl;
+  private String articleDomain;
+
+  /** SessionStatus.name() 문자열 */
+  private String status;
+
+  /** null = 검증 가능 주장 없음 */
+  private Short totalScore;
+
+  private LocalDateTime requestedAt;
+
+  /** null = 미완료 */
+  private LocalDateTime completedAt;
+}

--- a/core/src/main/java/com/truthscope/web/exception/UnauthorizedException.java
+++ b/core/src/main/java/com/truthscope/web/exception/UnauthorizedException.java
@@ -1,0 +1,9 @@
+package com.truthscope.web.exception;
+
+/** 인증 실패 예외 — 401 상태 코드 */
+public class UnauthorizedException extends AppException {
+
+  public UnauthorizedException(String message) {
+    super(401, message);
+  }
+}


### PR DESCRIPTION
<!-- SAFE_OP_START -->
Assumptions: Supabase JWT는 ES256 비대칭(JWKS) 실측 확정(`.well-known/jwks.json` ES256 키 1개). 배포처(Heroku)에 env `SUPABASE_JWK_SET_URI`, `SUPABASE_ISSUER` 설정 필요(application.yml에 로컬 fallback 존재). Flyway 마이그레이션 불필요(member_id 컬럼/FK/idx 이미 V1/V2 존재).
Scope: app/build.gradle, config/SecurityConfig.java, security/SupabaseAuthenticationEntryPoint.java, service/MemberService.java, service/AnalysisHistoryService.java, service/AnalysisService.java, service/AnalysisTransactionService.java, controller/NewsController.java, repository/AnalysisSessionRepository.java, core dto/AuthenticatedUser.java, core dto/projection/AnalysisSessionHistoryRow.java, core dto/response/AnalysisSessionHistoryResponse.java, core converter/AnalysisSessionHistoryConverter.java, resources/application.yml, resources/application-prod.yml, 관련 테스트(NewsControllerTest, MemberServiceTest, AnalysisHistoryServiceTest, ArticleControllerTest/GlobalExceptionHandlerTest의 SecurityConfig 컨텍스트 로드 보강).
Out-of-scope: Flyway 마이그레이션(불필요), CORS 정책 변경(GET/OPTIONS 유지), 익명→로그인 세션 병합, RLS(ADR-009 V4 이연), 이메일/비번 인증.
<!-- SAFE_OP_END -->

## Done

- [✅] **요구사항 목록**: (입력) 로그인 사용자의 Supabase ES256 JWT를 Bearer로 수신. (출력) 분석 POST 시 member lazy upsert 후 member_id 바인딩 + `GET /api/v1/analysis-sessions`가 인증 사용자 이력을 requested_at DESC로 반환. (에러) 토큰 부재/무효 시 401 `{status:"fail",statusCode:401,message}`. (경계) 익명 분석(토큰 없음)은 그대로 201, member_id NULL 유지.
- [✅] **산출물 목록**: oauth2-resource-server 의존성, SecurityConfig(JwtDecoder ES256+issuer+aud 검증, GET만 authenticated), SupabaseAuthenticationEntryPoint, MemberService.upsert, AnalysisService 3-인자 오버로드, createPendingSession(Member), NewsController POST(선택적 JWT)+GET, AnalysisSessionRepository.findHistoryByMemberId(JPQL projection), AnalysisHistoryService, AnalysisSessionHistoryResponse/Row/Converter.
- [✅] **수용 테스트**: NewsControllerTest(익명 201 / 무토큰 GET 401 / jwt GET 200 / 무효 Bearer 401), MemberServiceTest(upsert 멱등 + race 재조회), AnalysisHistoryServiceTest(Testcontainers 실 HQL: member 격리, DESC 정렬, article 없는 세션 포함). 회귀 시뮬레이션 B(MemberService logic)+C(SecurityConfig contract) fail→pass 실측 박제(`.plans/70-history-real-data/regression-sim/be-{B,C}-*.log`).

## Behavior Gates 자체 점검

- [✅] Gate 1 — Goal Defined
- [✅] Gate 2 — Assumption Surfaced
- [✅] Gate 3 — Surgical Diff (변경은 인증 도입 + member 바인딩 + 이력 조회에 직접 추적. SecurityConfig 변경으로 깨진 기존 @WebMvcTest 2건은 명문 예외 b로 mock bean 보강)
- [✅] Gate 4 — Minimum Code

---

## 관련 Issue
Phase 70 (history-real-data). 단일 GitHub 이슈 없음 — `.plans/70-history-real-data/PLAN.md` 기준.

## 변경 사항
- Supabase JWT(ES256 JWKS) 리소스 서버 도입: SecurityConfig + JwtDecoder(jwsAlgorithm ES256 명시, issuer + aud=authenticated 검증) + 401 JSON 엔트리포인트.
- POST `/api/v1/analysis-sessions`는 선택적 인증(permitAll + `@AuthenticationPrincipal Jwt` nullable) — 익명 분석 흐름 보존. 유효 Bearer 시 member lazy upsert 후 세션에 member 바인딩.
- GET `/api/v1/analysis-sessions`(인증 필수) 신규: JPQL projection + Article ad-hoc 조인으로 N+1 없이 이력 목록 반환.
- Flyway 마이그레이션 없음(스키마 기존), CORS 무변경.

## 검증
- [✅] `./gradlew build` SUCCESSFUL
- [✅] `./gradlew test` 362 run / 0 fail (+ Docker로 AnalysisHistoryServiceTest Testcontainers 실 HQL green 별도 실측)
- [✅] checkstyle 0 / spotless 적용 / ArchitectureTest PASS
- [✅] 회귀 시뮬레이션 B·C fail→pass stdout 박제

> plan-review-deep 2모델(Claude code-reviewer + codex gpt-5.5) PROCEED-WITH-CONDITIONS 수렴, 조건 반영. ADR-027 신규(Edge 프록시 사용자 Bearer 경계). 잔여: 라이브 E2E(login→analyze→/history) 및 member 바인딩 종단 확인은 배포 후.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth2 JWT 기반 인증 지원이 추가되었습니다.
  * 인증된 사용자는 자신의 분석 세션 이력을 조회할 수 있습니다.
  * 분석 요청은 익명 또는 인증된 사용자 둘 다 허용됩니다.

* **Behavior / API**
  * 인증 실패 시 JSON 형식의 401 응답이 반환됩니다.
  * Supabase 관련 인증 설정을 환경변수로 구성할 수 있습니다.

* **Tests**
  * 인증 및 관련 엔드포인트 테스트가 확장/보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->