### PR TITLE
🐛fix: Phase 71 — 추출 실패 시 세션 미생성(재시도 중복 FAILED 세션 방지)

### DIFF
--- a/app/src/main/java/com/truthscope/web/service/AnalysisService.java
+++ b/app/src/main/java/com/truthscope/web/service/AnalysisService.java
@@ -26,13 +26,17 @@ public class AnalysisService {
    * <p>단계:
    *
    * <ol>
-   *   <li>세션 생성 (트랜잭션, 인증 시 member 바인딩)
-   *   <li>기사 본문 추출 (트랜잭션 밖, 외부 HTTP Jsoup)
+   *   <li>기사 본문 추출 (트랜잭션 밖, 외부 HTTP Jsoup) — B1: 세션 생성 전 선행 수행
+   *   <li>세션 생성 (트랜잭션, 인증 시 member 바인딩) — 추출 성공 시에만 실행
    *   <li>Article 저장 + 상태 EXTRACTING 전이 (트랜잭션, 즉시 커밋)
    *   <li>EXTRACTING 스냅샷 DTO 반환 + 비동기 프로세서에 claims 이후 위임
    * </ol>
    *
-   * <p>동기 구간에서 RuntimeException 발생 시 세션을 FAILED로 전이한다. markFailed 자체 실패 시 원본 예외에 suppressed로 추가.
+   * <p>추출 실패(예: korea.kr 타임아웃) 시 세션/member를 생성하지 않는다. 이로써 FE 프록시 재시도(MAX_ATTEMPTS=3)가 중복 FAILED 세션을
+   * 남기지 않는다(Phase 71 B1).
+   *
+   * <p>persistArticleAndUpdateStatus/asyncProcessor 단계 RuntimeException 발생 시 세션을 FAILED로 전이한다.
+   * markFailed 자체 실패 시 원본 예외에 suppressed로 추가.
    *
    * @param request 분석 요청 (URL)
    * @param userApiKey BYOK 사용자 Gemini API 키 (null이면 서버 기본 키)
@@ -40,10 +44,12 @@ public class AnalysisService {
    */
   public AnalysisResponse analyze(
       AnalysisRequest request, @Nullable String userApiKey, @Nullable AuthenticatedUser user) {
+    // B1: 추출을 세션 생성보다 먼저 수행. 실패(예: korea.kr 타임아웃) 시 세션/member 미생성 →
+    //     프록시 재시도가 중복 FAILED 세션을 남기지 않음(Phase 71).
+    ExtractedArticle extracted = contentExtractService.extract(request.url());
     Member member = (user == null) ? null : memberService.upsert(user.id(), user.email());
     UUID sessionId = transactionService.createPendingSession(member);
     try {
-      ExtractedArticle extracted = contentExtractService.extract(request.url());
       // persistArticleAndUpdateStatus는 독립 @Transactional이므로 메서드 반환 시 즉시 커밋.
       // 반환 AnalysisResponse는 AnalysisConverter.toResponse(session, article)로 빌드된 EXTRACTING 스냅샷
       // DTO.

--- a/app/src/test/java/com/truthscope/web/integration/VerificationPipelineIntegrationTest.java
+++ b/app/src/test/java/com/truthscope/web/integration/VerificationPipelineIntegrationTest.java
@@ -723,25 +723,26 @@ class VerificationPipelineIntegrationTest {
     }
 
     /**
-     * R-4 RuntimeException → markFailed 전이 + 500 응답.
+     * R-4 추출 RuntimeException → 세션 미생성 + 500 응답 (Phase 71 B1 정합).
      *
-     * <p>contentExtractService throw RuntimeException → AnalysisService catch → markFailed →
-     * suppressed 보존 후 rethrow → GlobalExceptionHandler.handleException → 500 응답.
+     * <p>Phase 71 B1 변경 후 동작: contentExtractService.extract throw RuntimeException →
+     * AnalysisService가 세션 생성 전 예외 전파 → 세션 미생성 → GlobalExceptionHandler.handleException → 500 응답.
      *
-     * <p>rev.2 H-2 + L-1 amend: 500 응답 body에 sessionId 부재 → sessionRepo.findAll() filter로 session
-     * FAILED 검증. Mockito.verify(transactionService).markFailed는 production bean이라 직접 verify 불가.
+     * <p>이전(B1 전) 동작과 차이: B1 전에는 세션이 PENDING으로 생성됐다가 catch 블록에서 FAILED로 전이(delta=1). B1 후에는 추출 실패 시
+     * 세션 자체를 만들지 않으므로 delta=0.
+     *
+     * <p>rev.2 H-2 + L-1 amend 유지: 500 응답 body에 sessionId 부재 → sessionRepo.findAll() delta로 검증.
      */
     @Test
-    @DisplayName("R-4 RuntimeException → markFailed 전이 + 500 응답")
-    void runtimeExceptionInContentExtract_markFailedAnd500Response() throws Exception {
+    @DisplayName("R-4 추출 RuntimeException → 세션 미생성(delta=0) + 500 응답 (Phase 71 B1)")
+    void runtimeExceptionInContentExtract_noSessionCreatedAnd500Response() throws Exception {
       // Given: contentExtract throw RuntimeException
       when(contentExtractService.extract(anyString()))
           .thenThrow(new RuntimeException("외부 사이트 응답 실패"));
 
       // CodeRabbit fix A2: delta 기반 검증 (global state 의존 회피).
       // @AfterEach cleanup으로 매 시나리오 시작 시 0 보장이나 견고성 향상.
-      long beforeFailed =
-          sessionRepo.findAll().stream().filter(s -> s.getStatus() == SessionStatus.FAILED).count();
+      long beforeTotal = sessionRepo.count();
 
       // When + Then: HTTP 500 + ApiErrorResponse JSON fragment
       mockMvc
@@ -754,10 +755,9 @@ class VerificationPipelineIntegrationTest {
           .andExpect(jsonPath("$.statusCode").value(500))
           .andExpect(jsonPath("$.message").value("서버 내부 오류"));
 
-      // DB: FAILED 세션 count delta = 1 (response body에 sessionId 부재 → delta 검증)
-      long afterFailed =
-          sessionRepo.findAll().stream().filter(s -> s.getStatus() == SessionStatus.FAILED).count();
-      assertThat(afterFailed - beforeFailed).isEqualTo(1L);
+      // Phase 71 B1: 추출 실패 시 세션 미생성 → delta = 0 (FAILED 세션조차 생기지 않음)
+      long afterTotal = sessionRepo.count();
+      assertThat(afterTotal - beforeTotal).isEqualTo(0L);
     }
 
     /**

--- a/app/src/test/java/com/truthscope/web/service/AnalysisServiceTest.java
+++ b/app/src/test/java/com/truthscope/web/service/AnalysisServiceTest.java
@@ -1,0 +1,104 @@
+package com.truthscope.web.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.truthscope.web.dto.request.AnalysisRequest;
+import com.truthscope.web.dto.response.AnalysisResponse;
+import com.truthscope.web.dto.response.ExtractedArticle;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Phase 71 B1 단위 테스트 — 추출 실패 시 세션/member 미생성.
+ *
+ * <p>핵심 단언: contentExtractService.extract 가 RuntimeException을 던질 때 createPendingSession 및
+ * memberService.upsert 가 호출되지 않음을 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AnalysisService — Phase 71 B1 추출 선행 + 세션 미생성")
+class AnalysisServiceTest {
+
+  @Mock private AnalysisTransactionService transactionService;
+
+  @Mock private ContentExtractService contentExtractService;
+
+  @Mock private AsyncAnalysisService asyncProcessor;
+
+  @Mock private MemberService memberService;
+
+  @InjectMocks private AnalysisService analysisService;
+
+  /**
+   * B1 핵심 시나리오: 추출 실패 시 세션/member 미생성.
+   *
+   * <p>contentExtractService.extract 가 RuntimeException을 던지면 — createPendingSession 과
+   * memberService.upsert 는 절대 호출되지 않아야 한다.
+   */
+  @Test
+  @DisplayName("추출 실패(RuntimeException) 시 세션 미생성 + member upsert 미호출")
+  void extractFails_noSessionCreated() {
+    // Given
+    AnalysisRequest request = new AnalysisRequest("https://example.com/article");
+    when(contentExtractService.extract(anyString())).thenThrow(new RuntimeException("연결 타임아웃"));
+
+    // When + Then: 예외 전파 확인
+    assertThatThrownBy(() -> analysisService.analyze(request, null, null))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("연결 타임아웃");
+
+    // 세션 생성 및 member upsert 가 호출되지 않아야 함 (B1 핵심 단언)
+    verify(transactionService, never()).createPendingSession(any());
+    verify(memberService, never()).upsert(any(), any());
+  }
+
+  /**
+   * 정상 흐름: 추출 성공 시 세션 생성 1회 + persistArticleAndUpdateStatus 호출.
+   *
+   * <p>extract 정상 반환 → createPendingSession 1회 호출됨을 검증한다.
+   */
+  @Test
+  @DisplayName("추출 성공(happy path) 시 세션 생성 1회 호출")
+  void happyPath_createsSession() {
+    // Given
+    AnalysisRequest request = new AnalysisRequest("https://example.com/article");
+    UUID sessionId = UUID.randomUUID();
+    UUID articleId = UUID.randomUUID();
+
+    ExtractedArticle stubArticle =
+        ExtractedArticle.builder()
+            .title("테스트 기사 제목")
+            .body("테스트 기사 본문")
+            .lang("ko")
+            .domain("example.com")
+            .build();
+
+    AnalysisResponse stubResponse =
+        AnalysisResponse.builder()
+            .sessionId(sessionId)
+            .articleId(articleId)
+            .status("EXTRACTING")
+            .build();
+
+    when(contentExtractService.extract(anyString())).thenReturn(stubArticle);
+    when(transactionService.createPendingSession(any())).thenReturn(sessionId);
+    when(transactionService.persistArticleAndUpdateStatus(any(), anyString(), any()))
+        .thenReturn(stubResponse);
+
+    // When
+    AnalysisResponse response = analysisService.analyze(request, null, null);
+
+    // Then: createPendingSession 1회 호출됨
+    verify(transactionService).createPendingSession(null); // user=null → member=null
+    verify(transactionService).persistArticleAndUpdateStatus(sessionId, request.url(), stubArticle);
+  }
+}


### PR DESCRIPTION
<!-- SAFE_OP_START -->
Assumptions: 없음. Phase 70 라이브에서 관찰된 "추출 실패 재시도가 중복 FAILED 세션 생성"의 근본 수정(Option B1).
Scope: app/src/main/java/com/truthscope/web/service/AnalysisService.java(analyze 재정렬), app/src/test/.../service/AnalysisServiceTest.java(신규 단위), app/src/test/.../integration/VerificationPipelineIntegrationTest.java(R-4 단언 정정).
Out-of-scope: FE 변경 없음(프록시 재시도 유지가 의도). 완전 idempotency(B3, FE idempotency key)는 후속. 추출 성공 후 async/persist 실패로 인한 정당한 FAILED 세션(article 있음)은 그대로 노출.
<!-- SAFE_OP_END -->

## Done

- [✅] **요구사항 목록**: (입력) korea.kr 등 본문 추출이 타임아웃하는 URL 분석. (출력) 추출 실패 시 분석 세션을 **생성하지 않음**(member도 미생성) → 프록시 자동 재시도가 중복 "분석 실패/기사 제목 없음" 세션을 이력에 남기지 않음. (경계) 추출 성공 시 기존과 동일하게 세션 1건 생성 + 정상 파이프라인.
- [✅] **산출물 목록**: `AnalysisService.analyze()` 재정렬(extract를 createPendingSession/member upsert 앞으로), `AnalysisServiceTest`(신규), `VerificationPipelineIntegrationTest` R-4 단언 정정.
- [✅] **수용 테스트**: AnalysisServiceTest 2건(extract 실패→세션/멤버 미생성 verify, happy path→세션 1회), VerificationPipelineIntegrationTest R-4(Testcontainers 실 Postgres: 추출 실패 후 session count delta=0). 회귀 A(재정렬 되돌림→`extractFails_noSessionCreated` FAIL `NeverWantedButInvoked: createPendingSession`→복구 PASS) 박제(`.plans/71-extract-fail-no-session/regression-sim/`).

## Behavior Gates 자체 점검
- [✅] Gate 1 Goal / [✅] Gate 2 Assumption / [✅] Gate 3 Surgical Diff / [✅] Gate 4 Minimum Code

---

## 관련 Issue
Phase 71 (extract-fail-no-session). Phase 70 라이브 후속. `.plans/71-extract-fail-no-session/PLAN.md`.

## 변경 사항
- `AnalysisService.analyze(request, key, user)`: `contentExtractService.extract(url)`를 `createPendingSession()`/`memberService.upsert()` **앞**으로 이동. 추출 실패 시 예외가 전파되며 세션·member를 만들지 않는다. markFailed는 추출 이후(persist/async) 실패에만 적용.
- 효과: 한 번 클릭이 korea.kr 타임아웃으로 프록시 재시도(최대 3회)를 타도, 실패한 시도는 세션을 남기지 않아 `/history`가 오염되지 않는다(전부 실패 시 0건 + 사용자 5xx, 결국 성공 시 1건).

## 근본 원인(Phase 70 라이브 + Heroku 로그 실측)
1. korea.kr 본문 추출 간헐 타임아웃(`UrlValidator: 연결/읽기 타임아웃`). 2. BE가 추출 전에 세션 선생성 → 실패 시 FAILED(article 없음). 3. FE Edge 프록시가 5xx에 최대 3회 재시도 → 매 시도 새 세션 → 중복 FAILED. 4. Phase 70이 member 바인딩 세션을 이력 노출하며 가시화.

## 검증
- [✅] `./gradlew build` SUCCESSFUL(전체 unit + 통합 테스트 Testcontainers 포함, 회귀 0)
- [✅] AnalysisServiceTest 2/2, VerificationPipelineIntegrationTest 9(1 pre-existing @Disabled)
- [✅] 회귀 A fail→pass stdout 박제

🤖 Generated with [Claude Code](https://claude.com/claude-code)
