### PR TITLE
🐛fix(deploy): Heroku 프로파일 prod,production 추가 (stub 활성 버그 핫픽스)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -Dserver.port=$PORT $JAVA_OPTS -jar app/build/libs/app.jar --spring.profiles.active=prod
+web: java -Dserver.port=$PORT $JAVA_OPTS -jar app/build/libs/app.jar --spring.profiles.active=prod,production


### PR DESCRIPTION
## 문제

배포된 BE가 모든 기사에 대해 동일한 고정 주장 3개("정부는 2026년 경제성장률 전망치를 2.1%로 발표했다", "전문가들은 수출 회복세가 주요 요인이라고 분석했다", "일부 학계는 글로벌 금리 인하 가능성을 변수로 지적했다")를 반환했다. 기사 내용과 무관한 stub 픽스처가 그대로 노출됐다.

## 원인

Heroku Procfile이 `--spring.profiles.active=prod`만 켰다. 실 서비스 빈은 `@Profile("production")`, stub은 `@Profile("!production")`으로 게이트돼 있어서, `production` 프로파일이 빠진 상태에서는 stub(ClaimAnalysisStubService, FidelityClassifierStubService, ClaimExtractorStubService)이 활성화됐다.

## 수정

Procfile을 `prod,production`으로 변경. prod는 그대로 application-prod.yml을 로드하고, production이 추가되면서 실 빈(GeminiClient, ClaimAnalysisService, FidelityClassifierService)이 활성화되고 stub이 비활성화된다.

## 안전성

- application-production.yml은 존재하지 않아 추가 config 로드나 충돌이 없다.
- application-prod.yml의 폴백 없는 변수(GEMINI_API_KEY, DATA_GO_KR_KEY)는 v9가 prod 프로파일로 부팅 중이므로 이미 Heroku에 세팅돼 있다.
- 코드/테스트 변경 없음. 통합 테스트 5종은 이미 @ActiveProfiles("production")을 쓰고 있어 영향 없다.

## Done

- [✅] 요구사항(AC): Heroku prod 배포에서 실 서비스 빈(@Profile("production"))이 활성화되고 stub 빈(@Profile("!production"))이 비활성화된다. 모든 기사가 동일한 고정 픽스처 주장(경제성장률 2.1% 등)을 반환하지 않는다.
- [✅] 산출물: `truthscope-web-backend/Procfile` 1줄 변경 (`--spring.profiles.active=prod` → `prod,production`)
- [✅] 수용 테스트: 기존 통합 테스트 5종(@ActiveProfiles("production")) 영향 없음 + Heroku v11 배포 로그 `The following 2 profiles are active: "prod", "production"` + Tomcat 17초 부팅 + health 200 확인

<!-- SAFE_OP_START -->
Assumptions: 운영 Heroku(truthscope-web-be)에 GEMINI_API_KEY와 DATA_GO_KR_KEY가 이미 세팅돼 있음(v9가 prod 프로파일로 부팅 중이라 충족). application-production.yml은 존재하지 않음.
Scope: truthscope-web-backend/Procfile
Out-of-scope: 코드/테스트/application*.yml 무변경. GoogleFcAdapter 빈 제거 등 v1.7 정리 작업은 별도 PR.
<!-- SAFE_OP_END -->

## 배포

라이브 핫픽스라 이 브랜치를 Heroku에 직접 push해 적용 완료(Released v11). 본 PR은 dev 추적/머지용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
