### PR TITLE
✨feat(fidelity): 반박 evidence 보존하도록 관련성 필터 완화

### DIFF
--- a/app/src/main/java/com/truthscope/web/service/fidelity/FidelityClassifierService.java
+++ b/app/src/main/java/com/truthscope/web/service/fidelity/FidelityClassifierService.java
@@ -239,16 +239,18 @@ public class FidelityClassifierService implements FidelityClassifierPort {
   }
 
   /**
-   * 관련성 필터 (codex Round 2 조건 1 MANDATORY): stance ∈ {SUPPORTED, CONTRADICTED} 이고 matchedFields 비어
-   * 있지 않은 후보만 통과. NEUTRAL/UNRELATED/0-match 는 evidence 카운트에서 제외.
+   * 관련성 필터: stance ∈ {SUPPORTED, CONTRADICTED} 이고 필드 단위 대조가 실제로 성립한(matchedFields 또는
+   * mismatchedFields 중 하나라도 비어 있지 않은) 후보만 통과. 즉 topical relevance 필터가 아니라 utility-bearing
+   * field-comparison 필터다. refuting evidence도 field-level mismatch가 있으면 양성 검증 신호로 보존한다
+   * (FEVER/SciFact/AVeriTeC/FNC-1 정합). NEUTRAL/UNRELATED 및 대조 0건(matched·mismatched 모두 빈)은 제외.
    */
-  private List<EvidenceSnapshot> applyRelevanceFilter(List<EvidenceSnapshot> snapshots) {
+  static List<EvidenceSnapshot> applyRelevanceFilter(List<EvidenceSnapshot> snapshots) {
     return snapshots.stream()
         .filter(
             s ->
                 ("SUPPORTED".equals(s.stance()) || "CONTRADICTED".equals(s.stance()))
-                    && s.matchedFields() != null
-                    && !s.matchedFields().isEmpty())
+                    && ((s.matchedFields() != null && !s.matchedFields().isEmpty())
+                        || (s.mismatchedFields() != null && !s.mismatchedFields().isEmpty())))
         .toList();
   }
 

--- a/app/src/test/java/com/truthscope/web/service/fidelity/FidelityClassifierServiceTest.java
+++ b/app/src/test/java/com/truthscope/web/service/fidelity/FidelityClassifierServiceTest.java
@@ -1,0 +1,67 @@
+package com.truthscope.web.service.fidelity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.truthscope.web.scoring.EvidenceSnapshot;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * applyRelevanceFilter 단위 테스트. refuting evidence 보존(field 단위 대조가 성립하면 matched 0이어도 통과)이
+ * FEVER/SciFact/AVeriTeC/FNC-1 설계 원칙과 정합함을 검증한다.
+ */
+class FidelityClassifierServiceTest {
+
+  private static EvidenceSnapshot snap(
+      String stance, Map<String, String> matched, Map<String, String> mismatched) {
+    return new EvidenceSnapshot("http://a.example", "출처", "제목", stance, matched, mismatched);
+  }
+
+  @Test
+  @DisplayName("CONTRADICTED + matched 0 + mismatched 1 → 통과 (순수 반박 evidence 보존)")
+  void contradicted_pureMismatch_passes() {
+    List<EvidenceSnapshot> in =
+        List.of(snap("CONTRADICTED", Collections.emptyMap(), Map.of("수치", "2.8%")));
+    assertThat(FidelityClassifierService.applyRelevanceFilter(in)).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("CONTRADICTED + matched 0 + mismatched 0 → 탈락 (대조 0건)")
+  void contradicted_noComparison_rejected() {
+    List<EvidenceSnapshot> in =
+        List.of(snap("CONTRADICTED", Collections.emptyMap(), Collections.emptyMap()));
+    assertThat(FidelityClassifierService.applyRelevanceFilter(in)).isEmpty();
+  }
+
+  @Test
+  @DisplayName("SUPPORTED + matched 1 → 통과 (기존 동작 유지)")
+  void supported_withMatch_passes() {
+    List<EvidenceSnapshot> in =
+        List.of(snap("SUPPORTED", Map.of("제도명", "성장률 발표"), Collections.emptyMap()));
+    assertThat(FidelityClassifierService.applyRelevanceFilter(in)).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("순수 반박 출처 1건이 필터를 통과해 scoring 까지 도달한다 (Tier3 insufficient 회귀 방지)")
+  void pureRefutation_reachesScoring_notDropped() {
+    // matched 0 + mismatched>0 인 CONTRADICTED 출처만 있는 경우 과거에는 필터에서 전부 제거되어
+    // validSnapshots=0 -> Tier3 INSUFFICIENT 로 빠졌다. 이제 1건 이상 남아 sourceCountThreshold(1)를
+    // 충족하므로 tryTier2Score 에서 PolicyEvidenceScorer 까지 도달한다.
+    List<EvidenceSnapshot> in =
+        List.of(snap("CONTRADICTED", Collections.emptyMap(), Map.of("수치", "다른 값")));
+    List<EvidenceSnapshot> survived = FidelityClassifierService.applyRelevanceFilter(in);
+    assertThat(survived).isNotEmpty();
+    assertThat(survived.get(0).stance()).isEqualTo("CONTRADICTED");
+  }
+
+  @Test
+  @DisplayName("NEUTRAL stance는 matched가 있어도 탈락")
+  void neutral_rejected() {
+    List<EvidenceSnapshot> in =
+        List.of(snap("NEUTRAL", Map.of("일자", "2025"), Collections.emptyMap()));
+    assertThat(FidelityClassifierService.applyRelevanceFilter(in)).isEmpty();
+  }
+}


### PR DESCRIPTION
## 변경

- FidelityClassifierService.applyRelevanceFilter: 통과 조건을 matchedFields 존재에서 필드 단위 대조 성립(matched 또는 mismatched 존재)으로 완화. 순수 반박(matched 0, mismatched 1 이상) CONTRADICTED 출처가 검증 불가로 누락되지 않고 scoring 까지 도달한다. 메서드를 static으로 바꿔 단위 테스트 가능하게 함.
- FidelityClassifierServiceTest 신규: 필터 5 케이스.

근거: 2차 딥리서치(adversarial 3표 검증) + codex(gpt-5.5) cross-check. refuting evidence 는 topical alignment 를 통과한 양성 검증 신호(AVeriTeC 3-0, FNC-1 3-0, SciFact 2-1). 회귀: 모든 출처가 순수 반박인 주장은 기존 INSUFFICIENT(검증 불가)에서 낮은 점수(NOT_FACT 계열)로 바뀐다.

<!-- SAFE_OP_START -->
Assumptions: 없음
Scope: app/src/main/java/com/truthscope/web/service/fidelity/FidelityClassifierService.java, app/src/test/java/com/truthscope/web/service/fidelity/FidelityClassifierServiceTest.java
Out-of-scope: StanceRatioScorer 라우팅(점수체계 재설계라 이번 제외), 다른 scorer/필터, 수치 정규화·단계형 cap·기하평균(근거 미확립으로 문서화만)
<!-- SAFE_OP_END -->

## Done

- 요구사항(AC): CONTRADICTED + matched 0 + mismatched 1 이상 출처가 필터를 통과한다(과거 탈락). matched 0 + mismatched 0 은 탈락한다. SUPPORTED + matched 통과(기존 유지). NEUTRAL 은 탈락한다.
- 산출물: 위 Scope 2개 파일.
- 수용 테스트: FidelityClassifierServiceTest 5 케이스 통과, ./gradlew build BUILD SUCCESSFUL(spotbugs/test 포함).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 증거 관련성 필터링 조건을 개선하여 모순되는 증거도 올바르게 식별하도록 수정했습니다.

* **Tests**
  * 필터링 로직의 다양한 시나리오에 대한 포괄적인 테스트 커버리지를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->