### PR TITLE
🚀 release: Tier 3 오판정 정밀도 버그 2건 dev→main (단어 경계 + evidence 윈도우 발행일)

### DIFF
--- a/app/src/main/java/com/truthscope/web/adapter/verification/EvidenceWindowResolver.java
+++ b/app/src/main/java/com/truthscope/web/adapter/verification/EvidenceWindowResolver.java
@@ -32,14 +32,28 @@ public class EvidenceWindowResolver {
    * @return 윈도우 (from 포함, to 포함, 최대 3일 차이)
    */
   public Window resolve(String claimText) {
-    if (claimText != null) {
-      LocalDate extracted = tryExtract(claimText);
-      if (extracted != null) {
-        return new Window(extracted.minusDays(3), extracted);
-      }
+    return resolve(claimText, null);
+  }
+
+  /**
+   * 윈도우 기준일 우선순위: claimText 추출 날짜 우선, 없으면 기사 발행일(fallbackDate), 그것도 없으면 today.
+   *
+   * <p>기사 발행일을 기준으로 두면 과거 기사(예: 2025-12 발행)도 발행 시점의 data.go.kr 원문을 검색한다. today 폴백만 쓰면 발행 시점과 어긋나 매칭
+   * 0건(INSUFFICIENT)이 된다.
+   *
+   * @param claimText 검증 대상 claim 텍스트
+   * @param fallbackDate 기사 발행일 (nullable). claimText 에 날짜가 없을 때 기준일로 사용.
+   * @return 윈도우 (from 포함, to 포함, 최대 3일 차이)
+   */
+  public Window resolve(String claimText, LocalDate fallbackDate) {
+    LocalDate base = (claimText != null) ? tryExtract(claimText) : null;
+    if (base == null) {
+      base = fallbackDate;
     }
-    LocalDate today = LocalDate.now();
-    return new Window(today.minusDays(3), today);
+    if (base == null) {
+      base = LocalDate.now();
+    }
+    return new Window(base.minusDays(3), base);
   }
 
   private LocalDate tryExtract(String text) {

--- a/app/src/main/java/com/truthscope/web/claim/validation/HeuristicValidator.java
+++ b/app/src/main/java/com/truthscope/web/claim/validation/HeuristicValidator.java
@@ -3,6 +3,8 @@ package com.truthscope.web.claim.validation;
 import com.truthscope.web.scoring.ClaimDraft;
 import com.truthscope.web.scoring.Tier3ReasonPolicy;
 import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
 import org.springframework.stereotype.Component;
 
 /**
@@ -10,11 +12,98 @@ import org.springframework.stereotype.Component;
  *
  * <p>Tier3ReasonPolicy 의 timeKeywords / outOfScopePatterns 매칭 + missingRefDateThresholdDays 검증. 매칭
  * 시 Optional<Tier3ReasonCandidate> 반환, 매칭 X 시 Optional.empty (SCORABLE 후보).
+ *
+ * <p>timeKeywords 는 단어 경계 매칭을 적용한다. 한국어는 교착어라 "청년미래적금"·"미래성장" 같은 복합어가 공백 없는 한 어절이므로 단순 contains 로는
+ * 키워드 "미래"가 오탐된다(ACL P03-1060). Java 정규식 \\b 는 한글에 무효이므로(\\w=ASCII) 공백·구두점 토큰화 후 token==키워드 또는
+ * token이 키워드로 시작하고 나머지가 조사·어미인 경우만 매칭한다(precision 우선). 공백을 포함한 구문형 timeKeyword(예 "증가할 것")는 contains
+ * 로 처리한다. outOfScopePatterns 는 어간형 패턴(바람직·평가하면 등) 활용형까지 잡아야 하므로 기존 contains 를 유지한다.
  */
 @Component
 public class HeuristicValidator {
 
   private final Tier3ReasonPolicy policy;
+
+  // 공백 + Hangul/영숫자 아닌 문자(구두점·기호)로 어절 분리.
+  private static final Pattern TOKEN_SPLIT = Pattern.compile("[^\\p{IsHangul}\\p{Alnum}]+");
+
+  // 키워드(명사) 뒤에 붙을 수 있는 기능 형태소: 조사 + 서술격(이다)/되다/하다 활용형. 내용 명사(성장·적금 등)는 포함하지
+  // 않으므로 "미래성장"·"청년미래적금"의 "미래"는 매칭되지 않고, "예정되어"·"내년에"는 매칭된다.
+  private static final Set<String> SUFFIXES =
+      Set.of(
+          // 조사
+          "에",
+          "에는",
+          "에서",
+          "에서는",
+          "은",
+          "는",
+          "이",
+          "가",
+          "을",
+          "를",
+          "의",
+          "도",
+          "만",
+          "까지",
+          "부터",
+          "로",
+          "으로",
+          "와",
+          "과",
+          "에게",
+          "한테",
+          "라도",
+          "이라도",
+          "이나",
+          "나",
+          "며",
+          "이며",
+          "마다",
+          "밖에",
+          "뿐",
+          "보다",
+          "처럼",
+          "만큼",
+          // 이다(서술격) 활용
+          "다",
+          "이다",
+          "인",
+          "일",
+          "이고",
+          "였다",
+          "이었다",
+          "이라",
+          "이라서",
+          // 되다 활용
+          "되다",
+          "된다",
+          "되어",
+          "되었다",
+          "됐다",
+          "되며",
+          "되는",
+          "된",
+          "될",
+          "되고",
+          "되면",
+          "되니",
+          "됩니다",
+          "되어야",
+          // 하다 활용
+          "하다",
+          "한다",
+          "하여",
+          "했다",
+          "하며",
+          "하는",
+          "한",
+          "할",
+          "하고",
+          "하지",
+          "합니다",
+          "해",
+          "해서",
+          "하면");
 
   public HeuristicValidator(Tier3ReasonPolicy policy) {
     this.policy = policy;
@@ -30,19 +119,39 @@ public class HeuristicValidator {
       return Optional.empty();
     }
     String text = draft.claimText();
-    // OUT_OF_SCOPE 패턴 우선 (DISCUSS Q4 정합 - opinion/evaluation/찬반 등)
+    // OUT_OF_SCOPE 패턴 우선 (DISCUSS Q4 정합 - opinion/evaluation/찬반 등). 어간 활용형 보존 위해 contains 유지.
     for (String pattern : policy.outOfScopePatterns()) {
       if (text.contains(pattern)) {
         return Optional.of(Tier3ReasonCandidate.OUT_OF_SCOPE);
       }
     }
-    // TIME_SENSITIVE 키워드 매칭
+    // TIME_SENSITIVE 키워드 매칭 (단어 경계 인식).
+    String[] tokens = TOKEN_SPLIT.split(text);
     for (String keyword : policy.timeKeywords()) {
-      if (text.contains(keyword)) {
+      if (matchesTimeKeyword(text, tokens, keyword)) {
         return Optional.of(Tier3ReasonCandidate.TIME_SENSITIVE);
       }
     }
     return Optional.empty();
+  }
+
+  /** 공백 포함 구문형은 contains, 단어형은 어절==키워드 또는 어절==키워드+조사/어미. */
+  static boolean matchesTimeKeyword(String text, String[] tokens, String keyword) {
+    if (keyword.indexOf(' ') >= 0) {
+      return text.contains(keyword);
+    }
+    for (String token : tokens) {
+      if (token.isEmpty()) {
+        continue;
+      }
+      if (token.equals(keyword)) {
+        return true;
+      }
+      if (token.startsWith(keyword) && SUFFIXES.contains(token.substring(keyword.length()))) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public enum Tier3ReasonCandidate {

--- a/app/src/main/java/com/truthscope/web/html/ArticleHtmlParser.java
+++ b/app/src/main/java/com/truthscope/web/html/ArticleHtmlParser.java
@@ -2,6 +2,9 @@ package com.truthscope.web.html;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.LocalDate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.jsoup.nodes.Document;
@@ -79,6 +82,112 @@ public final class ArticleHtmlParser {
       }
     }
     return "unknown";
+  }
+
+  // 발행일 추출용 meta selector (우선순위 순). OpenGraph/article > 표준 date > Dublin Core > schema.org
+  // itemprop.
+  private static final String[] PUBLISHED_META_SELECTORS = {
+    "meta[property=article:published_time]",
+    "meta[name=article:published_time]",
+    "meta[property=og:article:published_time]",
+    "meta[name=date]",
+    "meta[name=dc.date]",
+    "meta[name=dc.date.issued]",
+    "meta[name=dcterms.date]",
+    "meta[itemprop=datePublished]",
+  };
+
+  // 문자열 내 yyyy-MM-dd / yyyy.MM.dd / yyyy/MM/dd 추출 (ISO 8601 datetime 의 날짜부 포함).
+  private static final Pattern ISO_DATE_IN_TEXT =
+      Pattern.compile("(\\d{4})[-./](\\d{1,2})[-./](\\d{1,2})");
+
+  // yyyyMMdd 8자리 압축 표기 (네이버 등 일부 언론사 meta).
+  private static final Pattern COMPACT_DATE =
+      Pattern.compile("(?<!\\d)(\\d{4})(\\d{2})(\\d{2})(?!\\d)");
+
+  // JSON-LD 의 datePublished 값 (JSON 파서 없이 정규식으로 추출 — 외부 의존 회피).
+  private static final Pattern JSONLD_DATE =
+      Pattern.compile("\"datePublished\"\\s*:\\s*\"([^\"]+)\"");
+
+  /**
+   * 기사 HTML 에서 발행일을 추출한다. 추출 실패 시 null.
+   *
+   * <p>우선순위: (1) article:published_time 등 meta 태그 (2) {@code <time datetime>} (3) JSON-LD
+   * datePublished. 어느 경로든 yyyy-MM-dd / yyyy.MM.dd / yyyyMMdd 형식의 날짜를 찾으면 LocalDate 로 반환한다.
+   *
+   * @param doc Jsoup Document
+   * @return 발행일 LocalDate, 추출 불가 시 null
+   */
+  public static LocalDate extractPublishedAt(Document doc) {
+    if (doc == null) {
+      return null;
+    }
+    for (String selector : PUBLISHED_META_SELECTORS) {
+      Element el = doc.selectFirst(selector);
+      if (el != null) {
+        LocalDate parsed = parseFlexibleDate(el.attr("content"));
+        if (parsed != null) {
+          return parsed;
+        }
+      }
+    }
+    Element time = doc.selectFirst("time[datetime]");
+    if (time != null) {
+      LocalDate parsed = parseFlexibleDate(time.attr("datetime"));
+      if (parsed != null) {
+        return parsed;
+      }
+    }
+    for (Element script : doc.select("script[type=application/ld+json]")) {
+      LocalDate parsed = extractJsonLdDate(script.data());
+      if (parsed != null) {
+        return parsed;
+      }
+    }
+    return null;
+  }
+
+  /** 임의 문자열에서 첫 번째 yyyy-MM-dd(또는 ./) 또는 yyyyMMdd 날짜를 추출한다. */
+  static LocalDate parseFlexibleDate(String raw) {
+    if (raw == null || raw.isBlank()) {
+      return null;
+    }
+    Matcher m = ISO_DATE_IN_TEXT.matcher(raw);
+    if (m.find()) {
+      return safeDate(m.group(1), m.group(2), m.group(3));
+    }
+    Matcher c = COMPACT_DATE.matcher(raw);
+    if (c.find()) {
+      return safeDate(c.group(1), c.group(2), c.group(3));
+    }
+    return null;
+  }
+
+  /** JSON-LD 문자열에서 datePublished 값을 추출한다. */
+  static LocalDate extractJsonLdDate(String json) {
+    if (json == null || json.isBlank()) {
+      return null;
+    }
+    Matcher m = JSONLD_DATE.matcher(json);
+    if (m.find()) {
+      return parseFlexibleDate(m.group(1));
+    }
+    return null;
+  }
+
+  /** 범위 검증 후 LocalDate 생성. 비정상 값은 null. */
+  private static LocalDate safeDate(String yearStr, String monthStr, String dayStr) {
+    try {
+      int year = Integer.parseInt(yearStr);
+      int month = Integer.parseInt(monthStr);
+      int day = Integer.parseInt(dayStr);
+      if (year < 2000 || year > 2100 || month < 1 || month > 12 || day < 1 || day > 31) {
+        return null;
+      }
+      return LocalDate.of(year, month, day);
+    } catch (RuntimeException e) {
+      return null;
+    }
   }
 
   public static String truncate(String text) {

--- a/app/src/main/java/com/truthscope/web/service/AnalysisService.java
+++ b/app/src/main/java/com/truthscope/web/service/AnalysisService.java
@@ -56,7 +56,12 @@ public class AnalysisService {
       AnalysisResponse response =
           transactionService.persistArticleAndUpdateStatus(sessionId, request.url(), extracted);
       // 커밋 후 제출이므로 비동기 스레드가 미커밋 session/article을 못 보는 race가 없다.
-      asyncProcessor.process(sessionId, response.getArticleId(), extracted.getBody(), userApiKey);
+      asyncProcessor.process(
+          sessionId,
+          response.getArticleId(),
+          extracted.getBody(),
+          extracted.getPublishedAt(),
+          userApiKey);
       return response; // EXTRACTING 스냅샷 (process가 인라인 실행돼 DB가 COMPLETED여도 이 DTO 문자열은 EXTRACTING
       // 고정).
     } catch (RuntimeException ex) {

--- a/app/src/main/java/com/truthscope/web/service/AsyncAnalysisService.java
+++ b/app/src/main/java/com/truthscope/web/service/AsyncAnalysisService.java
@@ -17,6 +17,7 @@ import com.truthscope.web.scoring.TruthLabel;
 import com.truthscope.web.scoring.TruthLabelDeriver;
 import com.truthscope.web.service.verification.VerificationCascadeService;
 import jakarta.annotation.Nullable;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -41,14 +42,22 @@ public class AsyncAnalysisService {
    * 비동기 분석 후반부: markAnalyzing, claims, cascade, 집계, persist(COMPLETED).
    *
    * <p>@Async void라 예외 전파 불가 - 내부 try/catch에서 markFailed. markFailed 자체 실패도 중첩 try/catch로 로깅.
+   *
+   * @param publishedAt 기사 발행일 (nullable). Tier 2 evidence 윈도우의 기준일 폴백으로 cascade 에 전달된다. claimText 에
+   *     날짜가 없을 때 발행 시점의 data.go.kr 원문을 검색하기 위함 (today 폴백 시 과거 기사가 매칭 0건이 되는 문제 회피).
    */
   @Async("analysisExecutor")
-  public void process(UUID sessionId, UUID articleId, String body, @Nullable String userApiKey) {
+  public void process(
+      UUID sessionId,
+      UUID articleId,
+      String body,
+      @Nullable LocalDate publishedAt,
+      @Nullable String userApiKey) {
     try {
       transactionService.markAnalyzing(sessionId);
       List<ClaimDraft> drafts = claimAnalysisPort.analyze(body, userApiKey);
       List<Claim> savedClaims = transactionService.persistClaims(articleId, drafts);
-      List<ClaimCascadeResult> results = verificationCascadeService.cascade(drafts);
+      List<ClaimCascadeResult> results = verificationCascadeService.cascade(drafts, publishedAt);
       // signals는 집계 4함수에만 사용. persistCascadeResults는 cascadeResults에서 signals를 자체 재도출.
       List<ClaimVerificationSignal> signals =
           results.stream().map(ClaimCascadeResult::signal).toList();

--- a/app/src/main/java/com/truthscope/web/service/ContentExtractService.java
+++ b/app/src/main/java/com/truthscope/web/service/ContentExtractService.java
@@ -87,11 +87,18 @@ public class ContentExtractService {
     String title = ArticleHtmlParser.extractTitle(doc);
     String bodyText = ArticleHtmlParser.extractBody(doc);
     String lang = ArticleHtmlParser.extractLang(doc);
+    java.time.LocalDate publishedAt = ArticleHtmlParser.extractPublishedAt(doc);
 
     if (bodyText.isBlank()) {
       throw new ExtractionFailedException("기사 본문을 추출할 수 없습니다");
     }
-    return ExtractedArticle.builder().title(title).body(bodyText).lang(lang).domain(domain).build();
+    return ExtractedArticle.builder()
+        .title(title)
+        .body(bodyText)
+        .lang(lang)
+        .domain(domain)
+        .publishedAt(publishedAt)
+        .build();
   }
 
   /** Per-extraction redirect loop with re-validation through SsrfGuard. */

--- a/app/src/main/java/com/truthscope/web/service/verification/HybridCascadeService.java
+++ b/app/src/main/java/com/truthscope/web/service/verification/HybridCascadeService.java
@@ -39,19 +39,32 @@ public class HybridCascadeService {
   private final EvidencePrefilter prefilter;
 
   /**
+   * claimText 에 대한 evidence 목록을 반환한다 (기사 발행일 미지정 — claimText 날짜 또는 today 윈도우).
+   *
+   * @param claimText 검증 대상 claim 텍스트
+   * @param topK 반환할 최대 evidence 수
+   * @return EvidenceSnapshot 목록. 실패 시 빈 목록.
+   */
+  public List<EvidenceSnapshot> retrieve(String claimText, int topK) {
+    return retrieve(claimText, topK, null);
+  }
+
+  /**
    * claimText 에 대한 evidence 목록을 반환한다.
    *
    * <p>@Transactional 없음 (RC-01 — 외부 HTTP 포함).
    *
    * @param claimText 검증 대상 claim 텍스트
    * @param topK 반환할 최대 evidence 수
+   * @param fallbackDate 기사 발행일 (nullable). claimText 에 날짜가 없을 때 evidence 윈도우 기준일로 사용. null 이면 today
+   *     기준. 과거 기사도 발행 시점의 data.go.kr 원문을 검색하게 하여 매칭 0건(INSUFFICIENT)을 방지한다.
    * @return stance SUPPORTED/CONTRADICTED 이고 matchedFields 비어 있지 않은 EvidenceSnapshot 목록. data.go.kr
    *     + Naver URL dedupe 병합 결과. 실패 시 빈 목록.
    */
-  public List<EvidenceSnapshot> retrieve(String claimText, int topK) {
+  public List<EvidenceSnapshot> retrieve(String claimText, int topK, LocalDate fallbackDate) {
     try {
-      // 1) 날짜 윈도우 결정
-      EvidenceWindowResolver.Window window = windowResolver.resolve(claimText);
+      // 1) 날짜 윈도우 결정 (claimText 날짜 우선, 없으면 기사 발행일, 그것도 없으면 today)
+      EvidenceWindowResolver.Window window = windowResolver.resolve(claimText, fallbackDate);
       LocalDate from = window.from();
       LocalDate to = window.to();
 

--- a/app/src/main/java/com/truthscope/web/service/verification/VerificationCascadeService.java
+++ b/app/src/main/java/com/truthscope/web/service/verification/VerificationCascadeService.java
@@ -12,6 +12,8 @@ import com.truthscope.web.scoring.ClaimVerificationSignal;
 import com.truthscope.web.scoring.EvidenceSnapshot;
 import com.truthscope.web.scoring.SourceTransparency;
 import com.truthscope.web.url.UrlValidator;
+import jakarta.annotation.Nullable;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -41,13 +43,25 @@ public class VerificationCascadeService {
   private final ClaimAttributionService attributionService;
 
   /**
-   * 주어진 ClaimDraft 목록을 3-Tier Cascade 로 검증하고 ClaimCascadeResult 목록을 반환한다.
+   * 주어진 ClaimDraft 목록을 3-Tier Cascade 로 검증하고 ClaimCascadeResult 목록을 반환한다 (기사 발행일 미지정).
    *
    * @param drafts Wave 1 ClaimAnalysisService 가 추출한 draft 목록
    * @return 각 draft 에 대응하는 ClaimCascadeResult 목록 (순서 보존)
    */
   public List<ClaimCascadeResult> cascade(List<ClaimDraft> drafts) {
-    return drafts.stream().map(this::cascadeOne).toList();
+    return cascade(drafts, null);
+  }
+
+  /**
+   * 주어진 ClaimDraft 목록을 3-Tier Cascade 로 검증한다. 기사 발행일을 Tier 2 evidence 윈도우의 기준일 폴백으로 전달한다.
+   *
+   * @param drafts Wave 1 ClaimAnalysisService 가 추출한 draft 목록
+   * @param articlePublishedAt 기사 발행일 (nullable). claimText 에 날짜가 없을 때 evidence 윈도우 기준일로 사용.
+   * @return 각 draft 에 대응하는 ClaimCascadeResult 목록 (순서 보존)
+   */
+  public List<ClaimCascadeResult> cascade(
+      List<ClaimDraft> drafts, @Nullable LocalDate articlePublishedAt) {
+    return drafts.stream().map(draft -> cascadeOne(draft, articlePublishedAt)).toList();
   }
 
   /**
@@ -65,9 +79,10 @@ public class VerificationCascadeService {
    * <p>attribution 부착은 v1.x 에서 스킵 (DB 부하 절약). µ2.4 persistCascadeResults 에서 처리.
    *
    * @param draft 검증 대상 ClaimDraft
+   * @param articlePublishedAt 기사 발행일 (nullable). Tier 2 evidence 윈도우 기준일 폴백.
    * @return ClaimCascadeResult (signal compact constructor 불변식 보장, Tier 2 경우 evidence 포함)
    */
-  private ClaimCascadeResult cascadeOne(ClaimDraft draft) {
+  private ClaimCascadeResult cascadeOne(ClaimDraft draft, @Nullable LocalDate articlePublishedAt) {
 
     // Tier 1: factcheck_cache 전문 검색
     List<?> cacheHits = factcheckCacheRepository.searchByText(draft.claimText());
@@ -82,8 +97,9 @@ public class VerificationCascadeService {
           List.of());
     }
 
-    // Tier 2: HybridCascadeService -> URL 검증 -> 점수 산출
-    List<EvidenceSnapshot> snapshots = hybridCascade.retrieve(draft.claimText(), 5);
+    // Tier 2: HybridCascadeService -> URL 검증 -> 점수 산출 (기사 발행일을 윈도우 기준일 폴백으로 전달)
+    List<EvidenceSnapshot> snapshots =
+        hybridCascade.retrieve(draft.claimText(), 5, articlePublishedAt);
     List<EvidenceSnapshot> validSnapshots =
         snapshots.stream().filter(s -> urlValidator.validate(s.url())).toList();
 

--- a/app/src/test/java/com/truthscope/web/adapter/verification/EvidenceWindowResolverTest.java
+++ b/app/src/test/java/com/truthscope/web/adapter/verification/EvidenceWindowResolverTest.java
@@ -1,0 +1,88 @@
+package com.truthscope.web.adapter.verification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * EvidenceWindowResolver 단위 테스트.
+ *
+ * <p>윈도우 기준일 우선순위 검증: claimText 추출 날짜 우선, 없으면 기사 발행일(fallbackDate), 그것도 없으면 today. window 는 항상
+ * [기준일-3, 기준일] (data.go.kr 검색기간 제약 ≤ 3 정합).
+ */
+@DisplayName("EvidenceWindowResolver 단위 테스트")
+class EvidenceWindowResolverTest {
+
+  private final EvidenceWindowResolver resolver = new EvidenceWindowResolver();
+
+  @Test
+  @DisplayName("claimText 한국어 날짜 추출 시 해당 날짜 기준 [date-3, date]")
+  void 한국어_날짜_추출() {
+    EvidenceWindowResolver.Window window = resolver.resolve("2025년 3월 10일 정부가 발표했다.");
+
+    assertThat(window.to()).isEqualTo(LocalDate.of(2025, 3, 10));
+    assertThat(window.from()).isEqualTo(LocalDate.of(2025, 3, 7));
+  }
+
+  @Test
+  @DisplayName("claimText ISO 날짜 추출")
+  void iso_날짜_추출() {
+    EvidenceWindowResolver.Window window = resolver.resolve("2024-06-15 기준 수치이다.");
+
+    assertThat(window.to()).isEqualTo(LocalDate.of(2024, 6, 15));
+    assertThat(window.from()).isEqualTo(LocalDate.of(2024, 6, 12));
+  }
+
+  @Test
+  @DisplayName("claimText 날짜가 fallbackDate 보다 우선한다")
+  void claim_날짜가_fallback보다_우선() {
+    EvidenceWindowResolver.Window window =
+        resolver.resolve("2025년 1월 5일 발표 내용이다.", LocalDate.of(2025, 12, 1));
+
+    assertThat(window.to()).isEqualTo(LocalDate.of(2025, 1, 5));
+    assertThat(window.from()).isEqualTo(LocalDate.of(2025, 1, 2));
+  }
+
+  @Test
+  @DisplayName("claimText 날짜 없으면 fallbackDate(기사 발행일) 기준")
+  void 날짜없으면_fallback_기준() {
+    EvidenceWindowResolver.Window window =
+        resolver.resolve("정부가 청년 지원을 확대한다.", LocalDate.of(2025, 12, 1));
+
+    assertThat(window.to()).isEqualTo(LocalDate.of(2025, 12, 1));
+    assertThat(window.from()).isEqualTo(LocalDate.of(2025, 11, 28));
+  }
+
+  @Test
+  @DisplayName("claimText 날짜 없고 fallbackDate null 이면 today 기준")
+  void 날짜없고_fallback_null이면_today() {
+    LocalDate today = LocalDate.now();
+
+    EvidenceWindowResolver.Window window = resolver.resolve("정부가 청년 지원을 확대한다.", null);
+
+    assertThat(window.to()).isEqualTo(today);
+    assertThat(window.from()).isEqualTo(today.minusDays(3));
+  }
+
+  @Test
+  @DisplayName("단일 인자 resolve 는 fallback null 위임 — 날짜 없으면 today")
+  void 단일인자_resolve_today() {
+    LocalDate today = LocalDate.now();
+
+    EvidenceWindowResolver.Window window = resolver.resolve("날짜 없는 일반 문장이다.");
+
+    assertThat(window.to()).isEqualTo(today);
+    assertThat(window.from()).isEqualTo(today.minusDays(3));
+  }
+
+  @Test
+  @DisplayName("claimText null 이면 fallbackDate 기준")
+  void claimText_null이면_fallback() {
+    EvidenceWindowResolver.Window window = resolver.resolve(null, LocalDate.of(2025, 5, 8));
+
+    assertThat(window.to()).isEqualTo(LocalDate.of(2025, 5, 8));
+    assertThat(window.from()).isEqualTo(LocalDate.of(2025, 5, 5));
+  }
+}

--- a/app/src/test/java/com/truthscope/web/claim/validation/HeuristicValidatorTest.java
+++ b/app/src/test/java/com/truthscope/web/claim/validation/HeuristicValidatorTest.java
@@ -109,4 +109,41 @@ class HeuristicValidatorTest {
     assertThat(result).isPresent();
     assertThat(result.get()).isEqualTo(HeuristicValidator.Tier3ReasonCandidate.TIME_SENSITIVE);
   }
+
+  // --- 단어 경계 매칭 (복합어 부분문자열 오탐 방지) ---
+
+  private HeuristicValidator boundaryValidator() {
+    return new HeuristicValidator(new Tier3ReasonPolicy(Set.of("미래", "내년"), Set.of(), 30));
+  }
+
+  @Test
+  @DisplayName("복합어_청년미래적금_미래성장은_TIME_SENSITIVE_아님_SCORABLE")
+  void 복합어_미래_부분문자열_매칭안됨() {
+    HeuristicValidator v = boundaryValidator();
+    // "미래"가 "청년미래적금"(제도명)·"미래성장"(일반어)의 부분문자열이지만 단어 경계로는 불일치 -> SCORABLE
+    assertThat(v.validate(buildDraft("청년미래적금 대상자가 10만명에서 160만명으로 확대된다."))).isEmpty();
+    assertThat(v.validate(buildDraft("세출예산의 75%를 미래성장 분야에 배정한다."))).isEmpty();
+  }
+
+  @Test
+  @DisplayName("내년_조사_활용형_내년에_내년부터_내년_단독_TIME_SENSITIVE")
+  void 내년_단어형_조사형_매칭() {
+    HeuristicValidator v = boundaryValidator();
+    assertThat(v.validate(buildDraft("내년에 제도가 시행된다.")))
+        .contains(HeuristicValidator.Tier3ReasonCandidate.TIME_SENSITIVE);
+    assertThat(v.validate(buildDraft("내년부터 단가가 인상된다.")))
+        .contains(HeuristicValidator.Tier3ReasonCandidate.TIME_SENSITIVE);
+    assertThat(v.validate(buildDraft("내년 예산은 727조원이다.")))
+        .contains(HeuristicValidator.Tier3ReasonCandidate.TIME_SENSITIVE);
+  }
+
+  @Test
+  @DisplayName("미래_단독_미래에_되다활용은_TIME_SENSITIVE")
+  void 미래_단어형_매칭() {
+    HeuristicValidator v = boundaryValidator();
+    assertThat(v.validate(buildDraft("미래 세대를 위한 투자다.")))
+        .contains(HeuristicValidator.Tier3ReasonCandidate.TIME_SENSITIVE);
+    assertThat(v.validate(buildDraft("이 사업은 미래에 시행된다.")))
+        .contains(HeuristicValidator.Tier3ReasonCandidate.TIME_SENSITIVE);
+  }
 }

--- a/app/src/test/java/com/truthscope/web/html/ArticleHtmlParserTest.java
+++ b/app/src/test/java/com/truthscope/web/html/ArticleHtmlParserTest.java
@@ -1,0 +1,107 @@
+package com.truthscope.web.html;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** ArticleHtmlParser 발행일 추출 단위 테스트. */
+@DisplayName("ArticleHtmlParser.extractPublishedAt")
+class ArticleHtmlParserTest {
+
+  private Document parse(String html) {
+    return Jsoup.parse(html);
+  }
+
+  @Test
+  @DisplayName("article:published_time meta (ISO datetime) 추출")
+  void articlePublishedTime_meta() {
+    Document doc =
+        parse(
+            "<html><head>"
+                + "<meta property=\"article:published_time\" content=\"2026-05-08T09:30:00+09:00\">"
+                + "</head><body>본문</body></html>");
+
+    assertThat(ArticleHtmlParser.extractPublishedAt(doc)).isEqualTo(LocalDate.of(2026, 5, 8));
+  }
+
+  @Test
+  @DisplayName("name=date meta 추출")
+  void nameDate_meta() {
+    Document doc =
+        parse(
+            "<html><head><meta name=\"date\" content=\"2025.12.01\"></head><body>본문</body></html>");
+
+    assertThat(ArticleHtmlParser.extractPublishedAt(doc)).isEqualTo(LocalDate.of(2025, 12, 1));
+  }
+
+  @Test
+  @DisplayName("JSON-LD datePublished 추출 (meta 부재 시)")
+  void jsonLd_datePublished() {
+    Document doc =
+        parse(
+            "<html><head>"
+                + "<script type=\"application/ld+json\">"
+                + "{\"@type\":\"NewsArticle\",\"datePublished\":\"2024-06-15T00:00:00Z\"}"
+                + "</script></head><body>본문</body></html>");
+
+    assertThat(ArticleHtmlParser.extractPublishedAt(doc)).isEqualTo(LocalDate.of(2024, 6, 15));
+  }
+
+  @Test
+  @DisplayName("time[datetime] 추출 (meta·JSON-LD 부재 시)")
+  void timeDatetime() {
+    Document doc =
+        parse("<html><body><time datetime=\"2025-03-10\">3월 10일</time> 본문</body></html>");
+
+    assertThat(ArticleHtmlParser.extractPublishedAt(doc)).isEqualTo(LocalDate.of(2025, 3, 10));
+  }
+
+  @Test
+  @DisplayName("yyyyMMdd 압축 표기 meta 추출")
+  void compactDate_meta() {
+    Document doc =
+        parse("<html><head><meta name=\"date\" content=\"20260508\"></head><body>본문</body></html>");
+
+    assertThat(ArticleHtmlParser.extractPublishedAt(doc)).isEqualTo(LocalDate.of(2026, 5, 8));
+  }
+
+  @Test
+  @DisplayName("meta 우선순위: article:published_time 가 JSON-LD 보다 우선")
+  void metaPriority_overJsonLd() {
+    Document doc =
+        parse(
+            "<html><head>"
+                + "<meta property=\"article:published_time\" content=\"2026-05-08\">"
+                + "<script type=\"application/ld+json\">{\"datePublished\":\"2020-01-01\"}</script>"
+                + "</head><body>본문</body></html>");
+
+    assertThat(ArticleHtmlParser.extractPublishedAt(doc)).isEqualTo(LocalDate.of(2026, 5, 8));
+  }
+
+  @Test
+  @DisplayName("날짜 정보 없으면 null")
+  void noDate_returnsNull() {
+    Document doc = parse("<html><head><title>제목</title></head><body>본문만 있음</body></html>");
+
+    assertThat(ArticleHtmlParser.extractPublishedAt(doc)).isNull();
+  }
+
+  @Test
+  @DisplayName("null Document 는 null")
+  void nullDoc_returnsNull() {
+    assertThat(ArticleHtmlParser.extractPublishedAt(null)).isNull();
+  }
+
+  @Test
+  @DisplayName("parseFlexibleDate: 범위 밖 날짜는 null")
+  void parseFlexibleDate_outOfRange() {
+    assertThat(ArticleHtmlParser.parseFlexibleDate("1999-13-40")).isNull();
+    assertThat(ArticleHtmlParser.parseFlexibleDate("no date here")).isNull();
+    assertThat(ArticleHtmlParser.parseFlexibleDate("")).isNull();
+    assertThat(ArticleHtmlParser.parseFlexibleDate(null)).isNull();
+  }
+}

--- a/app/src/test/java/com/truthscope/web/integration/VerificationPipelineIntegrationTest.java
+++ b/app/src/test/java/com/truthscope/web/integration/VerificationPipelineIntegrationTest.java
@@ -314,7 +314,7 @@ class VerificationPipelineIntegrationTest {
                   "SUPPORTED",
                   Map.of(),
                   java.util.Collections.emptyMap()));
-      when(hybridCascade.retrieve(anyString(), anyInt())).thenReturn(snapshots);
+      when(hybridCascade.retrieve(anyString(), anyInt(), any())).thenReturn(snapshots);
 
       // rev.3 RC-2 amend: UrlValidator 실 HTTP HEAD 차단
       when(urlValidator.validate(anyString())).thenReturn(true);
@@ -560,7 +560,7 @@ class VerificationPipelineIntegrationTest {
       when(factcheckCacheRepo.searchByText(eq(insufficientText))).thenReturn(List.of());
 
       // hybridCascade empty → Tier 2 진입 불가 → Tier 3 INSUFFICIENT 기본
-      when(hybridCascade.retrieve(anyString(), anyInt())).thenReturn(List.of());
+      when(hybridCascade.retrieve(anyString(), anyInt(), any())).thenReturn(List.of());
 
       ExtractedArticle fixtureArticle =
           ExtractedArticle.builder()
@@ -624,7 +624,7 @@ class VerificationPipelineIntegrationTest {
     void tier3Fallback_cacheMissAndEmptyCascade_insufficientReason() throws Exception {
       // Given: factcheck miss + hybridCascade empty + SCORABLE 1건
       when(factcheckCacheRepo.searchByText(anyString())).thenReturn(List.of());
-      when(hybridCascade.retrieve(anyString(), anyInt())).thenReturn(List.of());
+      when(hybridCascade.retrieve(anyString(), anyInt(), any())).thenReturn(List.of());
 
       ExtractedArticle fixtureArticle =
           ExtractedArticle.builder()

--- a/app/src/test/java/com/truthscope/web/service/AsyncAnalysisServiceTest.java
+++ b/app/src/test/java/com/truthscope/web/service/AsyncAnalysisServiceTest.java
@@ -59,15 +59,15 @@ class AsyncAnalysisServiceTest {
     // 빈 cascade 경로: SCORABLE signal 0건이라 집계 4함수가 policy를 건드리지 않고 안전하게 종료(persist까지 도달).
     when(claimAnalysisPort.analyze(body, null)).thenReturn(List.of());
     when(transactionService.persistClaims(eq(articleId), any())).thenReturn(List.of());
-    when(verificationCascadeService.cascade(any())).thenReturn(List.of());
+    when(verificationCascadeService.cascade(any(), any())).thenReturn(List.of());
 
-    asyncAnalysisService.process(sessionId, articleId, body, null);
+    asyncAnalysisService.process(sessionId, articleId, body, null, null);
 
     InOrder order = inOrder(transactionService, claimAnalysisPort, verificationCascadeService);
     order.verify(transactionService).markAnalyzing(sessionId);
     order.verify(claimAnalysisPort).analyze(body, null);
     order.verify(transactionService).persistClaims(eq(articleId), any());
-    order.verify(verificationCascadeService).cascade(any());
+    order.verify(verificationCascadeService).cascade(any(), any());
     order
         .verify(transactionService)
         .persistCascadeResults(eq(sessionId), any(), any(), any(), any(), any(), any());
@@ -82,7 +82,7 @@ class AsyncAnalysisServiceTest {
 
     doThrow(new RuntimeException("Gemini 호출 실패")).when(claimAnalysisPort).analyze(body, null);
 
-    asyncAnalysisService.process(sessionId, articleId, body, null);
+    asyncAnalysisService.process(sessionId, articleId, body, null, null);
 
     verify(transactionService, times(1)).markFailed(sessionId);
   }

--- a/app/src/test/java/com/truthscope/web/service/verification/VerificationCascadeServiceTest.java
+++ b/app/src/test/java/com/truthscope/web/service/verification/VerificationCascadeServiceTest.java
@@ -102,7 +102,7 @@ class VerificationCascadeServiceTest {
   void cascade_returnsSignalListForGivenClaims() {
     ClaimDraft draft = buildDraft("정부는 2025년 GDP 3% 성장을 발표했다.");
     when(factcheckCacheRepository.searchByText(anyString())).thenReturn(List.of());
-    when(hybridCascade.retrieve(anyString(), anyInt())).thenReturn(List.of());
+    when(hybridCascade.retrieve(anyString(), anyInt(), any())).thenReturn(List.of());
     when(tier3Validator.validate(any())).thenReturn(Optional.empty());
 
     List<ClaimCascadeResult> result = service.cascade(List.of(draft));
@@ -126,7 +126,7 @@ class VerificationCascadeServiceTest {
     assertThat(signal.tier()).isEqualTo((short) 1);
     assertThat(signal.score()).isNotNull().isBetween(0, 100);
     // Tier 1 히트 시 HybridCascadeService 호출 안 됨
-    verify(hybridCascade, never()).retrieve(anyString(), anyInt());
+    verify(hybridCascade, never()).retrieve(anyString(), anyInt(), any());
   }
 
   @Test
@@ -158,14 +158,15 @@ class VerificationCascadeServiceTest {
             Map.of(),
             java.util.Collections.emptyMap());
     when(factcheckCacheRepository.searchByText(anyString())).thenReturn(List.of());
-    when(hybridCascade.retrieve(anyString(), anyInt())).thenReturn(List.of(snap1, snap2, snap3));
+    when(hybridCascade.retrieve(anyString(), anyInt(), any()))
+        .thenReturn(List.of(snap1, snap2, snap3));
     when(urlValidator.validate(anyString())).thenReturn(true);
     when(policyScorer.calculate(any(), anyList(), any())).thenReturn(Optional.of(75));
 
     List<ClaimCascadeResult> result = service.cascade(List.of(draft));
 
     // cache miss → HybridCascade → policyScorer 경로 → Tier 2 SCORABLE 신호 산출
-    verify(hybridCascade, atLeastOnce()).retrieve(eq(draft.claimText()), anyInt());
+    verify(hybridCascade, atLeastOnce()).retrieve(eq(draft.claimText()), anyInt(), any());
     assertThat(result).hasSize(1);
     ClaimVerificationSignal signal = result.get(0).signal();
     assertThat(signal.tier()).isEqualTo((short) 2);
@@ -178,7 +179,7 @@ class VerificationCascadeServiceTest {
   void cascade_routesUnsufficientToTier3() {
     ClaimDraft draft = buildDraft("검증 불가 claim");
     when(factcheckCacheRepository.searchByText(anyString())).thenReturn(List.of());
-    when(hybridCascade.retrieve(anyString(), anyInt())).thenReturn(List.of());
+    when(hybridCascade.retrieve(anyString(), anyInt(), any())).thenReturn(List.of());
     when(tier3Validator.validate(any()))
         .thenReturn(Optional.of(HeuristicValidator.Tier3ReasonCandidate.INSUFFICIENT));
 
@@ -218,7 +219,7 @@ class VerificationCascadeServiceTest {
             null);
 
     when(factcheckCacheRepository.searchByText(anyString())).thenReturn(List.of());
-    when(hybridCascade.retrieve(anyString(), anyInt())).thenReturn(List.of());
+    when(hybridCascade.retrieve(anyString(), anyInt(), any())).thenReturn(List.of());
     when(tier3Validator.validate(any())).thenReturn(Optional.empty());
 
     List<ClaimCascadeResult> result = service.cascade(List.of(draftWithAttribution));
@@ -237,7 +238,7 @@ class VerificationCascadeServiceTest {
     ClaimDraft draft3 = buildDraft("claim 3");
 
     when(factcheckCacheRepository.searchByText(anyString())).thenReturn(List.of());
-    when(hybridCascade.retrieve(anyString(), anyInt())).thenReturn(List.of());
+    when(hybridCascade.retrieve(anyString(), anyInt(), any())).thenReturn(List.of());
     when(tier3Validator.validate(any())).thenReturn(Optional.empty());
 
     List<ClaimCascadeResult> result = service.cascade(List.of(draft1, draft2, draft3));
@@ -256,7 +257,7 @@ class VerificationCascadeServiceTest {
 
     assertThat(result).isEmpty();
     verify(factcheckCacheRepository, never()).searchByText(anyString());
-    verify(hybridCascade, never()).retrieve(anyString(), anyInt());
+    verify(hybridCascade, never()).retrieve(anyString(), anyInt(), any());
   }
 
   @Test
@@ -269,7 +270,7 @@ class VerificationCascadeServiceTest {
     EvidenceSnapshot s3 = buildSnapshot("https://example3.com");
 
     when(factcheckCacheRepository.searchByText(anyString())).thenReturn(List.of());
-    when(hybridCascade.retrieve(anyString(), anyInt())).thenReturn(List.of(s1, s2, s3));
+    when(hybridCascade.retrieve(anyString(), anyInt(), any())).thenReturn(List.of(s1, s2, s3));
     when(urlValidator.validate(anyString())).thenReturn(true);
     when(policyScorer.calculate(any(), any(), any())).thenReturn(Optional.of(80));
 

--- a/core/src/main/java/com/truthscope/web/dto/response/ExtractedArticle.java
+++ b/core/src/main/java/com/truthscope/web/dto/response/ExtractedArticle.java
@@ -1,5 +1,6 @@
 package com.truthscope.web.dto.response;
 
+import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,4 +24,10 @@ public class ExtractedArticle {
 
   /** 도메인 (예: "news.naver.com") */
   private String domain;
+
+  /**
+   * 기사 발행일 (nullable). meta 태그(article:published_time / JSON-LD datePublished / Dublin Core)에서 추출.
+   * 추출 실패 시 null. Tier 2 evidence 윈도우의 기준일 폴백으로 사용된다 (claimText 날짜 우선, 없으면 이 발행일, 그것도 없으면 today).
+   */
+  private LocalDate publishedAt;
 }


### PR DESCRIPTION
<!-- SAFE_OP_START -->
Assumptions: 비동기 cascade는 in-memory drafts를 받으므로 발행일은 메서드 파라미터로 전달 가능 (DB 마이그레이션 불필요). 기사 발행일 meta는 article:published_time / JSON-LD datePublished / Dublin Core / time[datetime] 중 하나에 존재할 수 있다.
Scope: claim/validation/HeuristicValidator, adapter/verification/EvidenceWindowResolver, html/ArticleHtmlParser, dto/response/ExtractedArticle, service/ContentExtractService, service/AnalysisService, service/AsyncAnalysisService, service/verification/HybridCascadeService, service/verification/VerificationCascadeService + 대응 테스트
Out-of-scope: PolicyEvidenceScorer / FidelityClassifier 점수 로직, factcheck_cache(Tier 1), Naver/data.go.kr 어댑터 내부, FE, DB 스키마
<!-- SAFE_OP_END -->

## Done

- **요구사항 목록** (입력 / 출력 / 경계):
  - 입력: 뉴스 URL → 추출 본문 + 발행일, claim 텍스트
  - 출력: 복합어("청년미래적금")가 TIME_SENSITIVE로 오판정되지 않음. 과거 발행 기사의 evidence 윈도우가 today가 아니라 기사 발행일 기준으로 잡힘
  - 경계: claim 날짜 > 기사 발행일 > today 우선순위. 발행일 추출 실패 시 null → today 폴백(기존 동작 보존)
- **산출물 목록**:
  - `HeuristicValidator` 토큰 경계 매칭(`matchesTimeKeyword` + SUFFIXES)
  - `ArticleHtmlParser.extractPublishedAt` (meta/JSON-LD/time 파싱)
  - `ExtractedArticle.publishedAt` 필드
  - `EvidenceWindowResolver.resolve(claimText, fallbackDate)` 오버로드
  - `ContentExtractService → AnalysisService → AsyncAnalysisService.process → VerificationCascadeService.cascade → HybridCascadeService.retrieve` 발행일 전달 플러밍
- **수용 테스트** (단위, 자동화):
  - `HeuristicValidatorTest` +3 (복합어 오탐 방지, 조사/활용형 매칭)
  - `EvidenceWindowResolverTest` 7 (claim 날짜 > fallback > today 우선순위)
  - `ArticleHtmlParserTest` 9 (meta/JSON-LD/time/compact 추출 + null)
  - 기존 `VerificationCascadeServiceTest` / `AsyncAnalysisServiceTest` / `VerificationPipelineIntegrationTest` 시그니처 정합 갱신 후 green
  - 검증: `:app:test` 전체 통과 + spotlessCheck + checkstyle + spotbugs + assemble 성공

## Behavior Gates 자체 점검

- [✅] Gate 1 — Goal Defined (위 Done 명시)
- [✅] Gate 2 — Assumption Surfaced (SAFE_OP 블록 작성)
- [✅] Gate 3 — Surgical Diff (Tier 3 오판정 2건 외 인접 코드 변경 없음)
- [✅] Gate 4 — Minimum Code (발행일 전달은 단일 경로 파라미터, 불필요 추상화 없음)

> 실행/검증(테스트·CI green)은 F1.a-d로 위임. 본 점검은 PR-level 입력 계약만.

---

## 변경 사항

데모에서 분석 점수가 전부 Tier 3(검증 불가)로 나오던 원인 버그 2건을 추적해 수정.

1. **시간 키워드 단어 경계 매칭** (`🐛 fix(claim)`): `contains` 매칭이 "청년미래적금"·"미래성장" 복합어에서 키워드 "미래"를 오탐 → 정상 claim을 TIME_SENSITIVE로 추락시킴. 한글은 `\b`가 무효라 공백·구두점 토큰화 후 어절==키워드 또는 키워드+조사/어미(되다·하다·이다 활용형 포함)일 때만 매칭.
2. **evidence 윈도우 기준일을 기사 발행일로 폴백** (`🐛 fix(verification)`): claim에 날짜가 없으면 윈도우를 today로 잡아, 며칠 전 발행 기사가 발행 시점 data.go.kr 원문과 어긋나 매칭 0건(INSUFFICIENT). 기사 meta에서 발행일을 추출해 cascade까지 전달, 윈도우 기준일을 claim 날짜 > 발행일 > today 순으로 결정.

## 체크리스트
- [✅] 빌드 성공
- [✅] 관련 테스트 통과
- [✅] 불필요한 로그 출력 없음
