### PR TITLE
🐛 fix(scoring): 반박 evidence를 stance 정합으로 점수·판정 반영

### DIFF
--- a/app/src/main/java/com/truthscope/web/service/AnalysisTransactionService.java
+++ b/app/src/main/java/com/truthscope/web/service/AnalysisTransactionService.java
@@ -26,6 +26,7 @@ import com.truthscope.web.scoring.ClaimDraft;
 import com.truthscope.web.scoring.ClaimScoreStatus;
 import com.truthscope.web.scoring.ClaimVerificationSignal;
 import com.truthscope.web.scoring.CoverageSummary;
+import com.truthscope.web.scoring.EvidenceSnapshot;
 import com.truthscope.web.scoring.SourceTransparencySummary;
 import com.truthscope.web.scoring.TruthLabel;
 import java.time.LocalDateTime;
@@ -175,10 +176,11 @@ public class AnalysisTransactionService {
 
     // 1. signals → VerificationResult entity 영속화 + VerifySource 저장 (인덱스 페어링)
     for (int i = 0; i < signals.size(); i++) {
+      List<EvidenceSnapshot> evidence = cascadeResults.get(i).evidence();
       VerificationResult saved =
-          verificationResultRepository.save(buildResult(signals.get(i), savedClaims.get(i)));
-      List<VerifySource> rows =
-          VerifySourceConverter.toEntities(saved, cascadeResults.get(i).evidence());
+          verificationResultRepository.save(
+              buildResult(signals.get(i), savedClaims.get(i), evidence));
+      List<VerifySource> rows = VerifySourceConverter.toEntities(saved, evidence);
       verifySourceRepository.saveAll(rows);
     }
 
@@ -237,29 +239,34 @@ public class AnalysisTransactionService {
   }
 
   /**
-   * ClaimScoreStatus를 Verdict로 매핑한다.
-   *
-   * <p>VerificationResult.verdict 컬럼은 NOT NULL이므로 모든 status에 대해 Verdict 값을 반환한다. SCORABLE claim의
-   * Verdict(SUPPORTED/CONTRADICTED 구분)는 Tier 2 stance 점수 기반 정밀 구분이 필요하나, v1.x에서는 점수 > 50을
-   * SUPPORTED로 보수적 매핑한다 (Phase 55 scope 밖, µ2.5 이후 정밀화 예정).
-   *
-   * @param status ClaimVerificationSignal 의 status
-   * @return 대응 Verdict
+   * status와 evidence stance를 Verdict로 매핑한다. SCORABLE은 evidence 다수결: 반박이 뒷받침보다 많으면 CONTRADICTED, 그
+   * 외(동률·evidence 없음 포함)는 SUPPORTED. verdict 컬럼 NOT NULL이라 모든 status에 값을 반환한다.
    */
-  private Verdict mapVerdict(ClaimScoreStatus status) {
+  private Verdict mapVerdict(ClaimScoreStatus status, List<EvidenceSnapshot> evidence) {
     return switch (status) {
-      case SCORABLE -> Verdict.SUPPORTED;
+      case SCORABLE -> isMajorityContradicted(evidence) ? Verdict.CONTRADICTED : Verdict.SUPPORTED;
       case INSUFFICIENT -> Verdict.INSUFFICIENT;
       case TIME_SENSITIVE -> Verdict.TIME_SENSITIVE;
       case OUT_OF_SCOPE -> Verdict.OUT_OF_SCOPE;
     };
   }
 
+  /** evidence stance 다수결 — CONTRADICTED 수가 SUPPORTED 수보다 많으면 true (null/빈 리스트는 false). */
+  static boolean isMajorityContradicted(List<EvidenceSnapshot> evidence) {
+    if (evidence == null || evidence.isEmpty()) {
+      return false;
+    }
+    long contradicted = evidence.stream().filter(e -> "CONTRADICTED".equals(e.stance())).count();
+    long supported = evidence.stream().filter(e -> "SUPPORTED".equals(e.stance())).count();
+    return contradicted > supported;
+  }
+
   /**
    * 단일 ClaimVerificationSignal을 VerificationResult entity로 변환한다 (R1-8 score 변환 + R2-6 disclaimer +
    * verdict/tier3Reason/reason 매핑 포함).
    */
-  private VerificationResult buildResult(ClaimVerificationSignal signal, Claim claim) {
+  private VerificationResult buildResult(
+      ClaimVerificationSignal signal, Claim claim, List<EvidenceSnapshot> evidence) {
     Short shortScore =
         signal.score() == null ? null : (short) Math.min(100, Math.max(0, signal.score()));
     String disclaimer = signal.tier() == 2 ? "AI 분석이며 기관 검증이 아닙니다. 참고 용도로만 활용하세요." : null;
@@ -267,7 +274,7 @@ public class AnalysisTransactionService {
         .claim(claim)
         .tier(signal.tier())
         .score(shortScore)
-        .verdict(mapVerdict(signal.status()))
+        .verdict(mapVerdict(signal.status(), evidence))
         .tier3Reason(mapTier3Reason(signal.status()))
         .reason(buildReason(signal))
         .disclaimer(disclaimer)

--- a/app/src/test/java/com/truthscope/web/service/AnalysisTransactionServiceTest.java
+++ b/app/src/test/java/com/truthscope/web/service/AnalysisTransactionServiceTest.java
@@ -1,0 +1,70 @@
+package com.truthscope.web.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.truthscope.web.scoring.EvidenceSnapshot;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * AnalysisTransactionService 단위 테스트.
+ *
+ * <p>verdict 매핑의 stance 다수결 로직(isMajorityContradicted)을 직접 검증한다. 영속화 경로 전체는 Repository 다수 의존으로 통합
+ * 테스트(VerificationPipelineIntegrationTest) 소관이며, 여기서는 순수 판정 헬퍼만 검증한다.
+ */
+@DisplayName("AnalysisTransactionService.isMajorityContradicted")
+class AnalysisTransactionServiceTest {
+
+  private EvidenceSnapshot ev(String stance) {
+    return new EvidenceSnapshot("http://x", "p", "t", stance, Map.of(), Map.of());
+  }
+
+  @Test
+  @DisplayName("반박(CONTRADICTED) 출처가 더 많으면 true")
+  void 반박_우세면_true() {
+    assertThat(
+            AnalysisTransactionService.isMajorityContradicted(
+                List.of(ev("CONTRADICTED"), ev("CONTRADICTED"), ev("SUPPORTED"))))
+        .isTrue();
+  }
+
+  @Test
+  @DisplayName("순수 반박 1건이면 true")
+  void 순수_반박_1건이면_true() {
+    assertThat(AnalysisTransactionService.isMajorityContradicted(List.of(ev("CONTRADICTED"))))
+        .isTrue();
+  }
+
+  @Test
+  @DisplayName("뒷받침 우세 또는 동률이면 false (뒷받침으로 간주)")
+  void 뒷받침_우세_또는_동률이면_false() {
+    assertThat(
+            AnalysisTransactionService.isMajorityContradicted(
+                List.of(ev("SUPPORTED"), ev("SUPPORTED"), ev("CONTRADICTED"))))
+        .isFalse();
+    // 동률 -> 뒷받침으로 간주
+    assertThat(
+            AnalysisTransactionService.isMajorityContradicted(
+                List.of(ev("SUPPORTED"), ev("CONTRADICTED"))))
+        .isFalse();
+  }
+
+  @Test
+  @DisplayName("evidence 없음(Tier 1 캐시 히트 등)이면 false")
+  void evidence_없으면_false() {
+    assertThat(AnalysisTransactionService.isMajorityContradicted(List.of())).isFalse();
+    assertThat(AnalysisTransactionService.isMajorityContradicted(null)).isFalse();
+  }
+
+  @Test
+  @DisplayName("NEUTRAL 은 양쪽 모두 아니므로 카운트 제외 — 뒷받침/반박 동수면 false")
+  void neutral_제외() {
+    // CONTRADICTED 1 vs SUPPORTED 1 (+ NEUTRAL 1) -> 동률 -> false
+    assertThat(
+            AnalysisTransactionService.isMajorityContradicted(
+                List.of(ev("CONTRADICTED"), ev("SUPPORTED"), ev("NEUTRAL"))))
+        .isFalse();
+  }
+}

--- a/core/src/main/java/com/truthscope/web/scoring/PolicyEvidenceScorer.java
+++ b/core/src/main/java/com/truthscope/web/scoring/PolicyEvidenceScorer.java
@@ -9,8 +9,14 @@ import java.util.Optional;
  * <p>v2: critical field 불일치 감지 시만 cap=criticalFieldCapPercent 적용(ADR-021 조건부 cap). source 가
  * sourceCountThreshold 미만이면 Optional.empty(), 이상이면 matchedFields 의 평균 일치율을 0..100 로 환산. mismatch
  * 없으면 ratio 그대로 반환(최대 100). mismatch 있으면 criticalFieldCapPercent(50) 상한.
+ *
+ * <p>stance 정합: CONTRADICTED(반박) 출처의 matchedFields 는 claim 을 뒷받침하지 않으므로 양성 일치율에 합산하지 않는다.
+ * refuting-evidence retention 정합 — 반박 출처는 필터에서 보존되지만 score 는 0 쪽으로 강하하여 truthLabel 이 NOT_FACT 로
+ * 도출되게 한다. 분모(totalFields × 전체 source 수)는 그대로 두어 반박 출처가 점수를 희석한다.
  */
 public class PolicyEvidenceScorer implements ClaimScoreCalculator {
+
+  private static final String CONTRADICTED = "CONTRADICTED";
 
   @Override
   public Optional<Integer> calculate(
@@ -25,6 +31,10 @@ public class PolicyEvidenceScorer implements ClaimScoreCalculator {
     }
     int matchedCount = 0;
     for (EvidenceSnapshot src : sources) {
+      // 반박 출처의 일치 필드는 claim 뒷받침이 아니므로 양성 점수에 합산하지 않는다 (stance 정합).
+      if (CONTRADICTED.equals(src.stance())) {
+        continue;
+      }
       if (src.matchedFields() != null) {
         matchedCount += src.matchedFields().size();
       }

--- a/core/src/test/java/com/truthscope/web/scoring/PolicyEvidenceScorerTest.java
+++ b/core/src/test/java/com/truthscope/web/scoring/PolicyEvidenceScorerTest.java
@@ -194,4 +194,41 @@ class PolicyEvidenceScorerTest {
     // hasCriticalMismatch=false -> cap 해제 -> ratio=100 -> score=100
     assertThat(result.get()).isEqualTo(100);
   }
+
+  // (9) stance 정합: CONTRADICTED 출처의 matchedFields 는 양성 점수에 합산되지 않는다 -> 순수 반박 score = 0
+  @Test
+  void calculate_excludesContradictedMatchedFields_scoresZero() {
+    Map<String, String> matched = Map.of("일자", "2025", "대상", "GDP");
+    Map<String, String> mismatched = Map.of("수치", "2.8%");
+    List<EvidenceSnapshot> sources =
+        List.of(
+            new EvidenceSnapshot("http://a.com", "A", "A제목", "CONTRADICTED", matched, mismatched),
+            new EvidenceSnapshot("http://b.com", "B", "B제목", "CONTRADICTED", matched, mismatched),
+            new EvidenceSnapshot("http://c.com", "C", "C제목", "CONTRADICTED", matched, mismatched));
+    Optional<Integer> result = scorer.calculate(CLAIM, sources, POLICY);
+    assertThat(result).isPresent();
+    // 모든 출처가 CONTRADICTED -> matchedCount 0 -> ratio 0 -> 수치 mismatch cap min(0,50)=0
+    assertThat(result.get()).isEqualTo(0);
+  }
+
+  // (10) 혼합 stance: SUPPORTED matched 만 합산, CONTRADICTED 는 분모만 차지해 점수 희석
+  @Test
+  void calculate_mixedStance_countsOnlySupportedMatches() {
+    Map<String, String> allFields =
+        Map.of("수치", "3%", "일자", "2025", "대상", "GDP", "금액", "N/A", "제도명", "성장률 발표");
+    Map<String, String> mismatched = Map.of("수치", "2.8%");
+    List<EvidenceSnapshot> sources =
+        List.of(
+            new EvidenceSnapshot(
+                "http://a.com", "A", "A제목", "SUPPORTED", allFields, Collections.emptyMap()),
+            new EvidenceSnapshot(
+                "http://b.com", "B", "B제목", "SUPPORTED", allFields, Collections.emptyMap()),
+            new EvidenceSnapshot(
+                "http://c.com", "C", "C제목", "CONTRADICTED", allFields, mismatched));
+    Optional<Integer> result = scorer.calculate(CLAIM, sources, POLICY);
+    assertThat(result).isPresent();
+    // numerator = 5+5 (SUPPORTED 2건만) = 10, denom = 5*3 = 15 -> ratio 66, 수치(critical) mismatch ->
+    // cap 50
+    assertThat(result.get()).isEqualTo(50);
+  }
 }


### PR DESCRIPTION
<!-- SAFE_OP_START -->
Assumptions: EvidenceSnapshot.stance는 FidelityClassifierService.toSnapshot에서 SUPPORTED/CONTRADICTED/NEUTRAL로 정규화된다. FE 결과 카드는 verdict가 아니라 score 파생 truthLabel을 배지로 렌더하므로, 사용자에게 보이는 교정은 score 경로다.
Scope: scoring/PolicyEvidenceScorer (CONTRADICTED 일치필드 양성합산 제외), service/AnalysisTransactionService (mapVerdict stance 다수결) + 대응 테스트
Out-of-scope: StanceRatioScorer, scorer 우선순위, FidelityClassifier 필터(반박 evidence 보존 유지), 집계/articleLabel coverage 가드(FE coverage 배지), DB 스키마
<!-- SAFE_OP_END -->

## Done

- **요구사항 목록** (입력 / 출력 / 경계):
  - 입력: Tier 2 evidence 스냅샷(stance + matchedFields/mismatchedFields) 보유 claim
  - 출력: 반박(CONTRADICTED) 근거만 있는 주장은 score 0 → truthLabel NOT_FACT("사실 아님")으로 표시. verdict도 CONTRADICTED.
  - 경계: 뒷받침 우세 또는 동률 또는 evidence 없음(Tier 1) → 기존대로 SUPPORTED. 혼합(2 SUPPORTED + 1 CONTRADICTED)은 반박 출처가 분모만 차지해 점수 희석 + critical mismatch cap 50.
- **산출물 목록**:
  - `PolicyEvidenceScorer.calculate`: CONTRADICTED 출처의 matchedFields를 양성 ratio에 합산 제외(분모는 전체 출처 유지)
  - `AnalysisTransactionService.mapVerdict(status, evidence)` + `isMajorityContradicted` 헬퍼, `buildResult`가 evidence 전달
- **수용 테스트** (단위, 자동화):
  - `PolicyEvidenceScorerTest` +2 (순수 반박 3건 → score 0, 혼합 → SUPPORTED만 합산 score 50)
  - `AnalysisTransactionServiceTest` 신규 5 (stance 다수결: 반박 우세/순수반박/동률/뒷받침우세/evidence없음/NEUTRAL제외)
  - 기존 PolicyEvidenceScorerTest 8건(모두 SUPPORTED) 회귀 없음
  - 검증: `:core:test` + `:app:test` 통과 + spotlessCheck + checkstyle + spotbugs + assemble 성공

## Behavior Gates 자체 점검

- [✅] Gate 1 — Goal Defined (위 Done)
- [✅] Gate 2 — Assumption Surfaced (SAFE_OP)
- [✅] Gate 3 — Surgical Diff (stance 정합 외 인접 로직 변경 없음, 반박 evidence 보존 필터 불변)
- [✅] Gate 4 — Minimum Code (scorer 1조건 + verdict 다수결 헬퍼, 불필요 추상화 없음)

> 실행/검증(테스트·CI green)은 F1.a-d로 위임. 본 점검은 PR-level 입력 계약만.

---

## 변경 사항

production 적대적 검증에서, 주장을 **반박하는 근거(refutes/CONTRADICTED)**가 있는데도 화면에 "일부 사실"로 표시되는 결함을 확인(면세유 기사 claim 2건 재현).

- 원인: `PolicyEvidenceScorer`가 stance를 무시하고 `matchedFields` 수만 세어 반박 근거도 양수 점수(40)를 부여 → score 파생 truthLabel이 "일부 사실".
- 수정: CONTRADICTED 출처의 일치 필드를 양성 점수에 합산하지 않음 → 반박 주장 0점 NOT_FACT. `mapVerdict`도 evidence stance 다수결로 SUPPORTED/CONTRADICTED 구분(API verdict 정합).
- 직전 "refuting-evidence retention" 설계 정합: 반박 출처는 필터에서 계속 보존(Tier 3 INSUFFICIENT 회귀 없음), 다만 점수가 0으로 강하.

## 체크리스트
- [✅] 빌드 성공
- [✅] 관련 테스트 통과
- [✅] 불필요한 로그 출력 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 주장의 판정 결과가 증거의 입장(지지/반박)에 따라 더 정확하게 계산되도록 개선되었습니다.
  * 반박하는 출처에 대한 점수 계산이 개선되어 검증 결과의 신뢰성이 향상되었습니다.

* **테스트**
  * 증거 기반 판정 로직의 안정성을 보장하는 단위 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->