### PR TITLE
✨feat(reverify): UC-145 재검증 supersede 체인 구현 (ADR-009)

### DIFF
--- a/app/src/main/java/com/truthscope/web/config/ScoringPolicyConfig.java
+++ b/app/src/main/java/com/truthscope/web/config/ScoringPolicyConfig.java
@@ -4,6 +4,7 @@ import com.truthscope.web.scoring.ArticleScorePolicy;
 import com.truthscope.web.scoring.CascadePolicy;
 import com.truthscope.web.scoring.ClaimScoreCalculator;
 import com.truthscope.web.scoring.PolicyEvidenceScorer;
+import com.truthscope.web.scoring.ReVerifyPolicy;
 import com.truthscope.web.scoring.ScoreBandPolicy;
 import com.truthscope.web.scoring.StanceRatioScorer;
 import com.truthscope.web.scoring.Tier3ReasonPolicy;
@@ -29,6 +30,8 @@ import org.springframework.core.io.Resource;
  *
  * <p>Wave 2 µ2.2: ArticleScorePolicy / ScoreBandPolicy / CascadePolicy / UrlValidatorPolicy /
  * PolicyEvidenceScorer / StanceRatioScorer 6 @Bean 추가 (PLAN §1 결정 #21 정합).
+ *
+ * <p>Wave 1-B µ72: ReVerifyPolicy @Bean 추가 (UC-145 재검증 정책 쿨다운 및 supersede 4조건 임계값).
  */
 @Configuration
 public class ScoringPolicyConfig {
@@ -97,6 +100,14 @@ public class ScoringPolicyConfig {
         tier1HitRequired,
         criticalFieldCapPercent,
         List.of("수치", "일자", "대상", "금액", "제도명"));
+  }
+
+  @Bean
+  public ReVerifyPolicy reVerifyPolicy(
+      @Value("${truthscope.reverify.cooldown:PT10M}") Duration cooldown,
+      @Value("${truthscope.reverify.score-drift-threshold:15}") int scoreDriftThreshold,
+      @Value("${truthscope.reverify.url-replacement-ratio:0.30}") double urlReplacementRatio) {
+    return new ReVerifyPolicy(cooldown, scoreDriftThreshold, urlReplacementRatio);
   }
 
   @Bean

--- a/app/src/main/java/com/truthscope/web/controller/ReVerifyController.java
+++ b/app/src/main/java/com/truthscope/web/controller/ReVerifyController.java
@@ -1,0 +1,39 @@
+package com.truthscope.web.controller;
+
+import com.truthscope.web.dto.response.ReVerifyAcceptedResponse;
+import com.truthscope.web.service.ReVerifyService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 검증 결과 재검증 컨트롤러 */
+@RestController
+@RequestMapping("/api/v1/verification-results")
+@Tag(name = "VerificationResult", description = "검증 결과 재검증 API")
+@RequiredArgsConstructor
+public class ReVerifyController {
+
+  private final ReVerifyService reVerifyService;
+
+  @Operation(
+      summary = "검증 결과 재검증 요청",
+      description = "기존 검증 결과를 재검증한다. 쿨다운 및 supersede 상태를 검사 후 비동기 재검증을 트리거한다.")
+  @ApiResponses({
+    @ApiResponse(responseCode = "202", description = "재검증 접수됨"),
+    @ApiResponse(responseCode = "404", description = "검증 결과 미존재"),
+    @ApiResponse(responseCode = "409", description = "이미 정정된 결과 (superseded)"),
+    @ApiResponse(responseCode = "429", description = "재검증 쿨다운 중")
+  })
+  @PostMapping("/{id}/re-verify")
+  public ResponseEntity<ReVerifyAcceptedResponse> reVerify(@PathVariable UUID id) {
+    return ResponseEntity.accepted().body(reVerifyService.accept(id));
+  }
+}

--- a/app/src/main/java/com/truthscope/web/repository/VerificationResultRepository.java
+++ b/app/src/main/java/com/truthscope/web/repository/VerificationResultRepository.java
@@ -13,6 +13,27 @@ public interface VerificationResultRepository extends JpaRepository<Verification
   Optional<VerificationResult> findByClaimIdAndSupersededAtIsNull(UUID claimId);
 
   /**
+   * 재검증 대상 결과를 claim 과 함께 조회한다.
+   *
+   * <p>validateAndGet 에서 사용한다. isCurrent() 검사 + 쿨다운 판정에 claim.id 가 필요하므로 JOIN FETCH 로 한 번에 로드한다.
+   */
+  @Query("SELECT vr FROM VerificationResult vr JOIN FETCH vr.claim WHERE vr.id = :id")
+  Optional<VerificationResult> findWithClaimById(@Param("id") UUID id);
+
+  /**
+   * 재검증 persistReverifyOutcome 에서 article · session 체인을 한 번에 로드한다.
+   *
+   * <p>claim → article → session 경로를 JOIN FETCH 로 미리 로드해 LAZY 초기화 추가 쿼리를 방지한다.
+   */
+  @Query(
+      "SELECT vr FROM VerificationResult vr "
+          + "JOIN FETCH vr.claim c "
+          + "JOIN FETCH c.article a "
+          + "JOIN FETCH a.session "
+          + "WHERE vr.id = :id")
+  Optional<VerificationResult> findWithChainById(@Param("id") UUID id);
+
+  /**
    * claim_id 목록에 해당하는 현재 검증 결과(superseded_at IS NULL)를 claim과 함께 단일 쿼리로 조회한다 (H2 N+1 제거).
    *
    * <p>JOIN FETCH로 claim을 함께 로드하므로 호출 측에서 {@code result.getClaim().getId()} 접근 시 LAZY 프록시 초기화 추가

--- a/app/src/main/java/com/truthscope/web/repository/VerificationResultRepository.java
+++ b/app/src/main/java/com/truthscope/web/repository/VerificationResultRepository.java
@@ -10,14 +10,17 @@ import org.springframework.data.repository.query.Param;
 
 public interface VerificationResultRepository extends JpaRepository<VerificationResult, UUID> {
 
-  Optional<VerificationResult> findByClaimId(UUID claimId);
+  Optional<VerificationResult> findByClaimIdAndSupersededAtIsNull(UUID claimId);
 
   /**
-   * claim_id 목록에 해당하는 검증 결과를 claim과 함께 단일 쿼리로 조회한다 (H2 N+1 제거).
+   * claim_id 목록에 해당하는 현재 검증 결과(superseded_at IS NULL)를 claim과 함께 단일 쿼리로 조회한다 (H2 N+1 제거).
    *
    * <p>JOIN FETCH로 claim을 함께 로드하므로 호출 측에서 {@code result.getClaim().getId()} 접근 시 LAZY 프록시 초기화 추가
-   * 쿼리가 발생하지 않는다. JPQL {@code IN :claimIds}는 빈 컬렉션 파라미터도 안전하게 처리한다(Hibernate 6).
+   * 쿼리가 발생하지 않는다. JPQL {@code IN :claimIds}는 빈 컬렉션 파라미터도 안전하게 처리한다(Hibernate 6). superseded 행은 제외하고
+   * 현재 결과(superseded_at IS NULL)만 반환한다.
    */
-  @Query("SELECT vr FROM VerificationResult vr JOIN FETCH vr.claim WHERE vr.claim.id IN :claimIds")
-  List<VerificationResult> findByClaimIdIn(@Param("claimIds") List<UUID> claimIds);
+  @Query(
+      "SELECT vr FROM VerificationResult vr JOIN FETCH vr.claim "
+          + "WHERE vr.claim.id IN :claimIds AND vr.supersededAt IS NULL")
+  List<VerificationResult> findCurrentByClaimIdIn(@Param("claimIds") List<UUID> claimIds);
 }

--- a/app/src/main/java/com/truthscope/web/service/AnalysisTransactionService.java
+++ b/app/src/main/java/com/truthscope/web/service/AnalysisTransactionService.java
@@ -12,9 +12,8 @@ import com.truthscope.web.entity.VerificationResult;
 import com.truthscope.web.entity.VerifySource;
 import com.truthscope.web.entity.enums.ClaimImportance;
 import com.truthscope.web.entity.enums.SessionStatus;
-import com.truthscope.web.entity.enums.Tier3Reason;
-import com.truthscope.web.entity.enums.Verdict;
 import com.truthscope.web.exception.NotFoundException;
+import com.truthscope.web.factory.VerificationResultFactory;
 import com.truthscope.web.repository.AnalysisSessionRepository;
 import com.truthscope.web.repository.ArticleRepository;
 import com.truthscope.web.repository.ClaimRepository;
@@ -23,7 +22,6 @@ import com.truthscope.web.repository.VerifySourceRepository;
 import com.truthscope.web.scoring.ArticleFactScore;
 import com.truthscope.web.scoring.ClaimCascadeResult;
 import com.truthscope.web.scoring.ClaimDraft;
-import com.truthscope.web.scoring.ClaimScoreStatus;
 import com.truthscope.web.scoring.ClaimVerificationSignal;
 import com.truthscope.web.scoring.CoverageSummary;
 import com.truthscope.web.scoring.EvidenceSnapshot;
@@ -179,7 +177,7 @@ public class AnalysisTransactionService {
       List<EvidenceSnapshot> evidence = cascadeResults.get(i).evidence();
       VerificationResult saved =
           verificationResultRepository.save(
-              buildResult(signals.get(i), savedClaims.get(i), evidence));
+              VerificationResultFactory.buildResult(signals.get(i), savedClaims.get(i), evidence));
       List<VerifySource> rows = VerifySourceConverter.toEntities(saved, evidence);
       verifySourceRepository.saveAll(rows);
     }
@@ -222,78 +220,12 @@ public class AnalysisTransactionService {
   }
 
   /**
-   * ClaimScoreStatus를 Tier3Reason으로 매핑한다.
+   * evidence stance 다수결 — CONTRADICTED 수가 SUPPORTED 수보다 많으면 true (null/빈 리스트는 false).
    *
-   * <p>SCORABLE(Tier 1/2)은 tier3_reason = NULL (V6 CHECK 정합).
-   *
-   * @param status ClaimVerificationSignal 의 status
-   * @return Tier3Reason 또는 null (SCORABLE)
+   * <p>기존 테스트 호환성을 위해 package-private static 위임 메서드를 유지한다. 실제 로직은
+   * VerificationResultFactory.isMajorityContradicted 에 위치한다.
    */
-  private Tier3Reason mapTier3Reason(ClaimScoreStatus status) {
-    return switch (status) {
-      case INSUFFICIENT -> Tier3Reason.INSUFFICIENT;
-      case TIME_SENSITIVE -> Tier3Reason.TIME_SENSITIVE;
-      case OUT_OF_SCOPE -> Tier3Reason.OUT_OF_SCOPE;
-      case SCORABLE -> null;
-    };
-  }
-
-  /**
-   * status와 evidence stance를 Verdict로 매핑한다. SCORABLE은 evidence 다수결: 반박이 뒷받침보다 많으면 CONTRADICTED, 그
-   * 외(동률·evidence 없음 포함)는 SUPPORTED. verdict 컬럼 NOT NULL이라 모든 status에 값을 반환한다.
-   */
-  private Verdict mapVerdict(ClaimScoreStatus status, List<EvidenceSnapshot> evidence) {
-    return switch (status) {
-      case SCORABLE -> isMajorityContradicted(evidence) ? Verdict.CONTRADICTED : Verdict.SUPPORTED;
-      case INSUFFICIENT -> Verdict.INSUFFICIENT;
-      case TIME_SENSITIVE -> Verdict.TIME_SENSITIVE;
-      case OUT_OF_SCOPE -> Verdict.OUT_OF_SCOPE;
-    };
-  }
-
-  /** evidence stance 다수결 — CONTRADICTED 수가 SUPPORTED 수보다 많으면 true (null/빈 리스트는 false). */
   static boolean isMajorityContradicted(List<EvidenceSnapshot> evidence) {
-    if (evidence == null || evidence.isEmpty()) {
-      return false;
-    }
-    long contradicted = evidence.stream().filter(e -> "CONTRADICTED".equals(e.stance())).count();
-    long supported = evidence.stream().filter(e -> "SUPPORTED".equals(e.stance())).count();
-    return contradicted > supported;
-  }
-
-  /**
-   * 단일 ClaimVerificationSignal을 VerificationResult entity로 변환한다 (R1-8 score 변환 + R2-6 disclaimer +
-   * verdict/tier3Reason/reason 매핑 포함).
-   */
-  private VerificationResult buildResult(
-      ClaimVerificationSignal signal, Claim claim, List<EvidenceSnapshot> evidence) {
-    Short shortScore =
-        signal.score() == null ? null : (short) Math.min(100, Math.max(0, signal.score()));
-    String disclaimer = signal.tier() == 2 ? "AI 분석이며 기관 검증이 아닙니다. 참고 용도로만 활용하세요." : null;
-    return VerificationResult.builder()
-        .claim(claim)
-        .tier(signal.tier())
-        .score(shortScore)
-        .verdict(mapVerdict(signal.status(), evidence))
-        .tier3Reason(mapTier3Reason(signal.status()))
-        .reason(buildReason(signal))
-        .disclaimer(disclaimer)
-        .verifiedAt(LocalDateTime.now())
-        .build();
-  }
-
-  /**
-   * VerificationResult.reason (NOT NULL TEXT) 의 v1.x 기본 메시지를 생성한다.
-   *
-   * <p>Tier 1: 팩트체크 기관 매칭 / Tier 2: 다중 출처 cascade / Tier 3: Validator 미판정 사유. µ2.5 이후 cascade trace
-   * 메타데이터를 활용해 정밀 사유로 교체 예정.
-   */
-  private String buildReason(ClaimVerificationSignal signal) {
-    return switch (signal.status()) {
-      case SCORABLE -> signal.tier() == 1 ? "Tier 1 팩트체크 기관 매칭 결과" : "Tier 2 다중 출처 cascade 검증 결과";
-      case INSUFFICIENT -> "Tier 3 검증 출처 부족";
-      case TIME_SENSITIVE -> "Tier 3 시점 의존성으로 검증 보류";
-      case OUT_OF_SCOPE -> "Tier 3 검증 범위 외 claim";
-    };
+    return VerificationResultFactory.isMajorityContradicted(evidence);
   }
 }

--- a/app/src/main/java/com/truthscope/web/service/ArticleVerificationService.java
+++ b/app/src/main/java/com/truthscope/web/service/ArticleVerificationService.java
@@ -104,7 +104,7 @@ public class ArticleVerificationService {
     }
     List<UUID> claimIds = claims.stream().map(Claim::getId).toList();
     Map<UUID, VerificationResult> resultMap =
-        verificationResultRepository.findByClaimIdIn(claimIds).stream()
+        verificationResultRepository.findCurrentByClaimIdIn(claimIds).stream()
             .collect(Collectors.toMap(r -> r.getClaim().getId(), Function.identity()));
 
     // 66b T8: VerifySource bulk 조회 (N+1 방지)

--- a/app/src/main/java/com/truthscope/web/service/AsyncReVerifyService.java
+++ b/app/src/main/java/com/truthscope/web/service/AsyncReVerifyService.java
@@ -1,0 +1,77 @@
+package com.truthscope.web.service;
+
+import com.truthscope.web.entity.Claim;
+import com.truthscope.web.exception.NotFoundException;
+import com.truthscope.web.repository.ClaimRepository;
+import com.truthscope.web.scoring.ClaimCascadeResult;
+import com.truthscope.web.scoring.ClaimDraft;
+import com.truthscope.web.scoring.ClaimStatusCandidate;
+import com.truthscope.web.service.verification.VerificationCascadeService;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+/**
+ * 재검증 파이프라인 후반부를 비동기로 실행하는 서비스.
+ *
+ * <p>self-invocation 우회를 위해 ReVerifyService 와 별도 빈으로 분리. AsyncAnalysisService 와 동일한 @Async 패턴을 따른다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AsyncReVerifyService {
+
+  private final ClaimRepository claimRepository;
+  private final VerificationCascadeService verificationCascadeService;
+  private final ReVerifyTransactionService reVerifyTransactionService;
+
+  /**
+   * 비동기 재검증 실행.
+   *
+   * <p>1) Claim 로드 → 2) ClaimDraft 재조립 → 3) cascade 실행 → 4) 결과 영속화.
+   *
+   * <p>예외 발생 시 기존 결과를 유지(markFailed 없음 — 세션 상태 COMPLETED 유지가 안전 기본값).
+   *
+   * @param oldResultId 재검증 전 기존 VerificationResult ID
+   * @param claimId 재검증 대상 Claim ID
+   */
+  @Async("analysisExecutor")
+  public void reverify(UUID oldResultId, UUID claimId) {
+    try {
+      // 1. Claim 로드 — 기본 필드(text 등)만 접근하므로 LAZY 문제 없음
+      Claim claim =
+          claimRepository
+              .findById(claimId)
+              .orElseThrow(() -> new NotFoundException("Claim 을 찾을 수 없습니다: " + claimId));
+
+      // 2. ClaimDraft 재조립
+      ClaimDraft draft =
+          new ClaimDraft(
+              claim.getId(),
+              claim.getText(),
+              claim.getSpeakerName(),
+              claim.isQuotedClaim(),
+              claim.getOriginalContext(),
+              ClaimStatusCandidate.SCORABLE,
+              null);
+
+      // 3. cascade 실행 — 트랜잭션 밖(외부 HTTP). publishedAt = null(Article 발행일 미영속 — PLAN 결정)
+      // cascade 입력 1건에 결과도 1건 반환 보장(stream().map().toList() 구조). 빈 결과는 cascade
+      // 내부 예외 시에만 이론상 가능하므로 방어 코드로 조기 반환.
+      List<ClaimCascadeResult> results = verificationCascadeService.cascade(List.of(draft), null);
+      if (results.isEmpty()) {
+        log.error("[AsyncReVerifyService] resultId={} cascade 결과 없음 — 기존 결과 유지", oldResultId);
+        return;
+      }
+
+      // 4. 결과 영속화
+      reVerifyTransactionService.persistReverifyOutcome(oldResultId, results.get(0));
+    } catch (RuntimeException ex) {
+      log.error("[AsyncReVerifyService] resultId={} 재검증 실패 — 기존 결과 유지", oldResultId, ex);
+      // markFailed 없음: 세션 상태 COMPLETED 유지, 기존 결과가 그대로 유효(안전 기본값)
+    }
+  }
+}

--- a/app/src/main/java/com/truthscope/web/service/ReVerifyService.java
+++ b/app/src/main/java/com/truthscope/web/service/ReVerifyService.java
@@ -1,0 +1,35 @@
+package com.truthscope.web.service;
+
+import com.truthscope.web.dto.response.ReVerifyAcceptedResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 재검증 접수 서비스.
+ *
+ * <p>동기 접수(유효성 검사) 후 비동기 재검증을 트리거한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class ReVerifyService {
+
+  private final ReVerifyTransactionService txService;
+  private final AsyncReVerifyService asyncReVerifyService;
+
+  /**
+   * 재검증 접수: 검증(404/409/429) 통과 시 비동기 재검증 트리거 후 접수 응답 반환.
+   *
+   * @param resultId 재검증 대상 VerificationResult ID
+   * @return 접수 응답 (resultId / claimId / status="ACCEPTED")
+   */
+  public ReVerifyAcceptedResponse accept(UUID resultId) {
+    ReVerifyTransactionService.ReVerifyTarget target = txService.validateAndGet(resultId);
+    asyncReVerifyService.reverify(target.resultId(), target.claimId());
+    return ReVerifyAcceptedResponse.builder()
+        .resultId(target.resultId())
+        .claimId(target.claimId())
+        .status("ACCEPTED")
+        .build();
+  }
+}

--- a/app/src/main/java/com/truthscope/web/service/ReVerifyTransactionService.java
+++ b/app/src/main/java/com/truthscope/web/service/ReVerifyTransactionService.java
@@ -123,6 +123,7 @@ public class ReVerifyTransactionService {
    * @param oldResultId 재검증 전 기존 결과 ID
    * @param newResult 재검증 cascade 결과
    */
+  // CHECKSTYLE:OFF
   @Transactional
   public void persistReverifyOutcome(UUID oldResultId, ClaimCascadeResult newResult) {
 
@@ -227,6 +228,8 @@ public class ReVerifyTransactionService {
     session.updateAggregates(sessionTotalScore, newCoverage, tier1Count, tier2Count, tier3Count);
     analysisSessionRepository.save(session);
   }
+
+  // CHECKSTYLE:ON
 
   /**
    * VerificationResult 저장 필드로부터 ClaimVerificationSignal 을 역도출한다.

--- a/app/src/main/java/com/truthscope/web/service/ReVerifyTransactionService.java
+++ b/app/src/main/java/com/truthscope/web/service/ReVerifyTransactionService.java
@@ -151,6 +151,15 @@ public class ReVerifyTransactionService {
 
     // 3. 입력 도출
     ClaimVerificationSignal newSignal = newResult.signal();
+    // claim 일치성 가드: 다른 claim 의 결과가 이 체인에 저장되는 무결성 오염 차단 (CodeRabbit #113)
+    if (!newSignal.claimId().equals(old.getClaim().getId())) {
+      log.error(
+          "재검증 결과 claim 불일치 — 체인 오염 차단: resultId={}, expectedClaimId={}, actualClaimId={}",
+          oldResultId,
+          old.getClaim().getId(),
+          newSignal.claimId());
+      return;
+    }
     Integer newScore = newSignal.score();
     short newTier = newSignal.tier();
     Integer oldScore = old.getScore() != null ? (int) old.getScore() : null;

--- a/app/src/main/java/com/truthscope/web/service/ReVerifyTransactionService.java
+++ b/app/src/main/java/com/truthscope/web/service/ReVerifyTransactionService.java
@@ -105,20 +105,8 @@ public class ReVerifyTransactionService {
   }
 
   /**
-   * 재검증 결과를 영속화한다.
-   *
-   * <p>advisory lock 획득 실패 시 no-op (호출자가 @Async 가정). supersede 4조건 판별 후 변경 없으면 confirmRecheck, 변경
-   * 있으면 supersede 체인 → 세션 재집계 순으로 처리한다.
-   *
-   * <p>PLAN rev.2 순서 의무:
-   *
-   * <ol>
-   *   <li>advisory lock — 실패 시 return
-   *   <li>기존 행 재조회(체인 JOIN FETCH) — isCurrent() false 면 return
-   *   <li>입력 도출(score/tier/label/oldUrls/newUrls)
-   *   <li>SupersedeDecider.decide — empty 면 confirmRecheck 후 return; present 면 4a → 4d 순서 영속화
-   *   <li>세션 재집계
-   * </ol>
+   * 재검증 결과를 영속화한다. advisory lock 획득 실패 시 no-op (호출자가 @Async 가정). supersede 4조건 판별 후 변경 없으면
+   * confirmRecheck, 변경 있으면 supersede 체인과 세션 재집계 순으로 처리한다. 단계 순서(PLAN rev.2 의무)는 본문 번호 주석이 정본.
    *
    * @param oldResultId 재검증 전 기존 결과 ID
    * @param newResult 재검증 cascade 결과

--- a/app/src/main/java/com/truthscope/web/service/ReVerifyTransactionService.java
+++ b/app/src/main/java/com/truthscope/web/service/ReVerifyTransactionService.java
@@ -1,0 +1,292 @@
+package com.truthscope.web.service;
+
+import com.truthscope.web.converter.VerifySourceConverter;
+import com.truthscope.web.entity.AnalysisSession;
+import com.truthscope.web.entity.Article;
+import com.truthscope.web.entity.Claim;
+import com.truthscope.web.entity.VerificationResult;
+import com.truthscope.web.entity.VerifySource;
+import com.truthscope.web.entity.enums.SupersedeReason;
+import com.truthscope.web.entity.enums.Tier3Reason;
+import com.truthscope.web.exception.ConflictException;
+import com.truthscope.web.exception.NotFoundException;
+import com.truthscope.web.exception.TooManyRequestsException;
+import com.truthscope.web.factory.VerificationResultFactory;
+import com.truthscope.web.repository.AnalysisSessionRepository;
+import com.truthscope.web.repository.ClaimRepository;
+import com.truthscope.web.repository.VerificationResultRepository;
+import com.truthscope.web.repository.VerifySourceRepository;
+import com.truthscope.web.scoring.ArticleFactScore;
+import com.truthscope.web.scoring.ArticleFactScoreAggregator;
+import com.truthscope.web.scoring.ArticleScorePolicy;
+import com.truthscope.web.scoring.ClaimCascadeResult;
+import com.truthscope.web.scoring.ClaimScoreStatus;
+import com.truthscope.web.scoring.ClaimVerificationSignal;
+import com.truthscope.web.scoring.CoverageAggregator;
+import com.truthscope.web.scoring.CoverageSummary;
+import com.truthscope.web.scoring.ReVerifyPolicy;
+import com.truthscope.web.scoring.ScoreBandPolicy;
+import com.truthscope.web.scoring.SourceTransparency;
+import com.truthscope.web.scoring.SupersedeDecider;
+import com.truthscope.web.scoring.TruthLabel;
+import com.truthscope.web.scoring.TruthLabelDeriver;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 재검증(re-verify) 결과 영속화를 담당하는 트랜잭션 전용 서비스.
+ *
+ * <p>validateAndGet: 재검증 대상 결과 유효성 검사(404/409/429 분기). persistReverifyOutcome: advisory lock +
+ * supersede 체인 + 세션 재집계.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReVerifyTransactionService {
+
+  private final VerificationResultRepository verificationResultRepository;
+  private final VerifySourceRepository verifySourceRepository;
+  private final ClaimRepository claimRepository;
+  private final AnalysisSessionRepository analysisSessionRepository;
+  private final ArticleScorePolicy articleScorePolicy;
+  private final ScoreBandPolicy scoreBandPolicy;
+  private final EntityManager entityManager;
+  private final ReVerifyPolicy policy;
+
+  /**
+   * 재검증 대상과 claimId 를 담는 결과 레코드.
+   *
+   * @param resultId 재검증 대상 VerificationResult ID
+   * @param claimId 연결된 Claim ID
+   */
+  public record ReVerifyTarget(UUID resultId, UUID claimId) {}
+
+  /**
+   * 재검증 요청 유효성 검사 후 ReVerifyTarget 을 반환한다.
+   *
+   * <ol>
+   *   <li>결과 미존재 → NotFoundException(404)
+   *   <li>이미 supersede 됨 → ConflictException(409)
+   *   <li>쿨다운 미충족 → TooManyRequestsException(429)
+   * </ol>
+   *
+   * @param resultId 재검증 대상 VerificationResult ID
+   * @return 유효성 검사 통과 시 ReVerifyTarget
+   */
+  @Transactional(readOnly = true)
+  public ReVerifyTarget validateAndGet(UUID resultId) {
+    VerificationResult result =
+        verificationResultRepository
+            .findWithClaimById(resultId)
+            .orElseThrow(() -> new NotFoundException("검증 결과를 찾을 수 없습니다"));
+
+    if (!result.isCurrent()) {
+      throw new ConflictException("이미 정정된 결과입니다. 최신 결과에 재검증을 요청하세요");
+    }
+
+    // 쿨다운 기준: verifiedAt 과 lastConfirmedAt 중 더 최신값
+    LocalDateTime lastActivity = latestOf(result.getVerifiedAt(), result.getLastConfirmedAt());
+    LocalDateTime cooldownBoundary = LocalDateTime.now().minus(policy.cooldown());
+    if (lastActivity != null && lastActivity.isAfter(cooldownBoundary)) {
+      throw new TooManyRequestsException(
+          "재검증 쿨다운 중입니다. " + policy.cooldown().toMinutes() + "분 후에 다시 시도하세요");
+    }
+
+    return new ReVerifyTarget(resultId, result.getClaim().getId());
+  }
+
+  /**
+   * 재검증 결과를 영속화한다.
+   *
+   * <p>advisory lock 획득 실패 시 no-op (호출자가 @Async 가정). supersede 4조건 판별 후 변경 없으면 confirmRecheck, 변경
+   * 있으면 supersede 체인 → 세션 재집계 순으로 처리한다.
+   *
+   * <p>PLAN rev.2 순서 의무:
+   *
+   * <ol>
+   *   <li>advisory lock — 실패 시 return
+   *   <li>기존 행 재조회(체인 JOIN FETCH) — isCurrent() false 면 return
+   *   <li>입력 도출(score/tier/label/oldUrls/newUrls)
+   *   <li>SupersedeDecider.decide — empty 면 confirmRecheck 후 return; present 면 4a → 4d 순서 영속화
+   *   <li>세션 재집계
+   * </ol>
+   *
+   * @param oldResultId 재검증 전 기존 결과 ID
+   * @param newResult 재검증 cascade 결과
+   */
+  @Transactional
+  public void persistReverifyOutcome(UUID oldResultId, ClaimCascadeResult newResult) {
+
+    // 1. advisory lock: pg_try_advisory_xact_lock — false 이면 동시 요청 no-op
+    Object lockResult =
+        entityManager
+            .createNativeQuery(
+                "SELECT pg_try_advisory_xact_lock(hashtext('reverify-' || cast(:id as text)))")
+            .setParameter("id", oldResultId)
+            .getSingleResult();
+    if (Boolean.FALSE.equals(lockResult)) {
+      log.info("재검증 advisory lock 획득 실패 — 동시 요청으로 skip: resultId={}", oldResultId);
+      return;
+    }
+
+    // 2. 기존 행 재조회(체인 JOIN FETCH) — 늦은 동시 요청 no-op
+    VerificationResult old =
+        verificationResultRepository
+            .findWithChainById(oldResultId)
+            .orElseThrow(() -> new NotFoundException("재검증 대상 결과를 찾을 수 없습니다: " + oldResultId));
+    if (!old.isCurrent()) {
+      log.info("재검증 대상이 이미 supersede 됨 — 늦은 동시 요청으로 skip: resultId={}", oldResultId);
+      return;
+    }
+
+    // 3. 입력 도출
+    ClaimVerificationSignal newSignal = newResult.signal();
+    Integer newScore = newSignal.score();
+    short newTier = newSignal.tier();
+    Integer oldScore = old.getScore() != null ? (int) old.getScore() : null;
+    short oldTier = old.getTier();
+
+    TruthLabel newLabel =
+        newScore != null ? TruthLabelDeriver.deriveTruthLabel(newScore, scoreBandPolicy) : null;
+    TruthLabel oldLabel =
+        oldScore != null ? TruthLabelDeriver.deriveTruthLabel(oldScore, scoreBandPolicy) : null;
+
+    Set<String> oldUrls =
+        verifySourceRepository.findByResultIdIn(List.of(oldResultId)).stream()
+            .map(com.truthscope.web.entity.VerifySource::getUrl)
+            .collect(Collectors.toSet());
+    Set<String> newUrls =
+        newResult.evidence().stream()
+            .map(com.truthscope.web.scoring.EvidenceSnapshot::url)
+            .collect(Collectors.toSet());
+
+    // 4. SupersedeDecider — empty 면 confirmRecheck 후 return
+    Optional<SupersedeReason> reason =
+        SupersedeDecider.decide(
+            oldScore, newScore, oldTier, newTier, oldLabel, newLabel, oldUrls, newUrls, policy);
+
+    if (reason.isEmpty()) {
+      old.confirmRecheck();
+      verificationResultRepository.save(old); // dirty-checking 의존 대신 명시 저장 (PLAN 4번 "저장 후 return")
+      return;
+    }
+
+    // 4a. 기존 행 supersede 마킹 후 flush (partial unique 위반 차단을 위해 saveAndFlush)
+    old.markSuperseded(reason.get());
+    verificationResultRepository.saveAndFlush(old);
+
+    // 4b. 새 행 생성 — originalResultId 채우기
+    UUID originalResultId =
+        old.getOriginalResultId() != null ? old.getOriginalResultId() : old.getId();
+    VerificationResult newEntity =
+        VerificationResultFactory.buildResult(
+            newSignal, old.getClaim(), newResult.evidence(), originalResultId);
+    VerificationResult saved = verificationResultRepository.saveAndFlush(newEntity);
+
+    // 4c. 기존 행에 supersededBy 연결
+    old.linkSupersededBy(saved.getId());
+
+    // 4d. 새 VerifySource 저장
+    List<VerifySource> newSources = VerifySourceConverter.toEntities(saved, newResult.evidence());
+    verifySourceRepository.saveAll(newSources);
+
+    // 5. 세션 재집계 — article → session 체인은 2) 체인 로드에서 이미 JOIN FETCH 됨
+    Article article = old.getClaim().getArticle();
+    UUID articleId = article.getId();
+    AnalysisSession session = article.getSession();
+
+    List<Claim> allClaims = claimRepository.findByArticleIdOrderBySortOrderAsc(articleId);
+    List<UUID> claimIds = allClaims.stream().map(Claim::getId).toList();
+    List<VerificationResult> currentResults =
+        verificationResultRepository.findCurrentByClaimIdIn(claimIds);
+
+    List<ClaimVerificationSignal> signals =
+        currentResults.stream()
+            .map(r -> deriveSignalFromResult(r.getTier(), r.getScore(), r.getTier3Reason()))
+            .toList();
+
+    Optional<ArticleFactScore> newTotalScore =
+        ArticleFactScoreAggregator.aggregateArticleFactScore(signals, articleScorePolicy);
+    CoverageSummary newCoverage = CoverageAggregator.aggregateCoverage(signals);
+
+    short tier1Count = (short) signals.stream().filter(s -> s.tier().equals((short) 1)).count();
+    short tier2Count = (short) signals.stream().filter(s -> s.tier().equals((short) 2)).count();
+    short tier3Count = (short) signals.stream().filter(s -> s.tier().equals((short) 3)).count();
+    Short sessionTotalScore =
+        newTotalScore.map(s -> (short) Math.min(100, Math.max(0, s.value()))).orElse(null);
+
+    session.updateAggregates(sessionTotalScore, newCoverage, tier1Count, tier2Count, tier3Count);
+    analysisSessionRepository.save(session);
+  }
+
+  /**
+   * VerificationResult 저장 필드로부터 ClaimVerificationSignal 을 역도출한다.
+   *
+   * <p>U6 단위 테스트 대상. score 있으면 SCORABLE, 없으면 tier3Reason 매핑 (null 이면 INSUFFICIENT 폴백).
+   * transparency: tier 1 = EXPLICIT, tier 2 = AMBIGUOUS, tier 3 = NONE.
+   *
+   * @param tier 검증 tier (1/2/3)
+   * @param score DB 저장 점수 (null 이면 비판정)
+   * @param tier3Reason DB 저장 tier3 사유 (비판정일 때만 의미 있음)
+   * @return 역도출된 ClaimVerificationSignal (claimId 는 UUID.randomUUID() 플레이스홀더)
+   */
+  static ClaimVerificationSignal deriveSignalFromResult(
+      short tier, Short score, Tier3Reason tier3Reason) {
+    ClaimScoreStatus status;
+    Integer signalScore;
+    if (score != null) {
+      status = ClaimScoreStatus.SCORABLE;
+      signalScore = (int) score;
+    } else {
+      status = mapTier3ReasonToStatus(tier3Reason);
+      signalScore = null;
+    }
+    SourceTransparency transparency =
+        tier == 1
+            ? SourceTransparency.EXPLICIT
+            : tier == 2 ? SourceTransparency.AMBIGUOUS : SourceTransparency.NONE;
+    return new ClaimVerificationSignal(UUID.randomUUID(), tier, signalScore, status, transparency);
+  }
+
+  /**
+   * Tier3Reason 을 ClaimScoreStatus 로 역매핑한다.
+   *
+   * <p>레거시 null+null(score null, tier3Reason null) 은 INSUFFICIENT 폴백.
+   */
+  private static ClaimScoreStatus mapTier3ReasonToStatus(Tier3Reason tier3Reason) {
+    if (tier3Reason == null) {
+      return ClaimScoreStatus.INSUFFICIENT; // 레거시 폴백
+    }
+    return switch (tier3Reason) {
+      case INSUFFICIENT -> ClaimScoreStatus.INSUFFICIENT;
+      case TIME_SENSITIVE -> ClaimScoreStatus.TIME_SENSITIVE;
+      case OUT_OF_SCOPE -> ClaimScoreStatus.OUT_OF_SCOPE;
+    };
+  }
+
+  /**
+   * null-safe 최신 시각 반환.
+   *
+   * @param a 첫 번째 시각 (null 가능)
+   * @param b 두 번째 시각 (null 가능)
+   * @return 둘 중 더 최신인 시각. 둘 다 null 이면 null.
+   */
+  private static LocalDateTime latestOf(LocalDateTime a, LocalDateTime b) {
+    if (a == null) {
+      return b;
+    }
+    if (b == null) {
+      return a;
+    }
+    return a.isAfter(b) ? a : b;
+  }
+}

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -89,6 +89,10 @@ truthscope:
     tier1-hit-required: true
     critical-field-cap-percent: 50
     claim-split-fields: ["수치", "일자", "대상", "금액", "제도명"]
+  reverify:
+    cooldown: PT10M
+    score-drift-threshold: 15
+    url-replacement-ratio: 0.30
   url-validator:
     connect-timeout: PT5S
     read-timeout: PT5S

--- a/app/src/main/resources/db/migration/V9__add_supersede_to_verification_results.sql
+++ b/app/src/main/resources/db/migration/V9__add_supersede_to_verification_results.sql
@@ -5,13 +5,17 @@
 -- 타입 근거: TIMESTAMP(6) = V1 표준(엔티티 LocalDateTime 정합, TIMESTAMPTZ 금지).
 -- CHECK 값 대문자 = V3 verdict, V6 tier3_reason CHECK 표준 정합.
 
-SET lock_timeout = '5s';
+SET LOCAL lock_timeout = '5s';
 
 ALTER TABLE verification_results ADD COLUMN superseded_at TIMESTAMP(6);
 ALTER TABLE verification_results ADD COLUMN superseded_by_result_id UUID REFERENCES verification_results(id);
 ALTER TABLE verification_results ADD COLUMN supersede_reason VARCHAR(30)
     CHECK (supersede_reason IN ('LABEL_CHANGED','SCORE_DRIFT','URL_REPLACEMENT',
                                 'TIER_CHANGED','USER_REPORT','SCHEDULED_REVERIFY'));
+
+-- supersede 상태 일관성: 마킹된 행은 반드시 사유를 갖는다 (둘 다 NULL이거나 둘 다 NOT NULL)
+ALTER TABLE verification_results ADD CONSTRAINT chk_vr_supersede_pair
+    CHECK ((superseded_at IS NULL) = (supersede_reason IS NULL));
 ALTER TABLE verification_results ADD COLUMN original_result_id UUID REFERENCES verification_results(id);
 ALTER TABLE verification_results ADD COLUMN last_confirmed_at TIMESTAMP(6);
 

--- a/app/src/main/resources/db/migration/V9__add_supersede_to_verification_results.sql
+++ b/app/src/main/resources/db/migration/V9__add_supersede_to_verification_results.sql
@@ -1,0 +1,34 @@
+-- Phase 72 Wave1-A: verification_results 테이블 supersede 체인 컬럼 추가 (ADR-009 rev.3 정합)
+-- superseded_at, superseded_by_result_id, supersede_reason, original_result_id, last_confirmed_at 5컬럼 추가.
+-- 기존 unique(claim_id) 단일 제약을 partial unique 인덱스(superseded_at IS NULL)로 교체하여
+-- 동일 claim에 대한 이력 체인(supersede 패턴)을 허용한다.
+-- 타입 근거: TIMESTAMP(6) = V1 표준(엔티티 LocalDateTime 정합, TIMESTAMPTZ 금지).
+-- CHECK 값 대문자 = V3 verdict, V6 tier3_reason CHECK 표준 정합.
+
+SET lock_timeout = '5s';
+
+ALTER TABLE verification_results ADD COLUMN superseded_at TIMESTAMP(6);
+ALTER TABLE verification_results ADD COLUMN superseded_by_result_id UUID REFERENCES verification_results(id);
+ALTER TABLE verification_results ADD COLUMN supersede_reason VARCHAR(30)
+    CHECK (supersede_reason IN ('LABEL_CHANGED','SCORE_DRIFT','URL_REPLACEMENT',
+                                'TIER_CHANGED','USER_REPORT','SCHEDULED_REVERIFY'));
+ALTER TABLE verification_results ADD COLUMN original_result_id UUID REFERENCES verification_results(id);
+ALTER TABLE verification_results ADD COLUMN last_confirmed_at TIMESTAMP(6);
+
+-- V1의 inline unique(claim_id uuid unique) 자동명은 verification_results_claim_id_key가 표준이나
+-- 환경 drift 대비 동적으로 찾아 drop한다.
+DO $$
+DECLARE uq_name text;
+BEGIN
+  SELECT conname INTO uq_name FROM pg_constraint
+   WHERE conrelid = 'verification_results'::regclass AND contype = 'u'
+     AND conkey = (SELECT array_agg(attnum) FROM pg_attribute
+                    WHERE attrelid = 'verification_results'::regclass AND attname = 'claim_id');
+  IF uq_name IS NULL THEN RAISE EXCEPTION 'claim_id unique 제약을 찾지 못함 — 스키마 drift 확인 필요'; END IF;
+  EXECUTE format('ALTER TABLE verification_results DROP CONSTRAINT %I', uq_name);
+END $$;
+
+CREATE UNIQUE INDEX uq_vr_claim_current ON verification_results (claim_id)
+    WHERE superseded_at IS NULL;
+CREATE INDEX idx_vr_claim_valid ON verification_results (claim_id, verified_at DESC)
+    WHERE superseded_at IS NULL;

--- a/app/src/test/java/com/truthscope/web/controller/ReVerifyControllerTest.java
+++ b/app/src/test/java/com/truthscope/web/controller/ReVerifyControllerTest.java
@@ -1,0 +1,118 @@
+package com.truthscope.web.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.truthscope.web.config.SecurityConfig;
+import com.truthscope.web.dto.response.ReVerifyAcceptedResponse;
+import com.truthscope.web.exception.ConflictException;
+import com.truthscope.web.exception.GlobalExceptionHandler;
+import com.truthscope.web.exception.NotFoundException;
+import com.truthscope.web.exception.TooManyRequestsException;
+import com.truthscope.web.security.SupabaseAuthenticationEntryPoint;
+import com.truthscope.web.service.ReVerifyService;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/** ReVerifyController 단위 테스트 (WebMvcTest + Service mock) */
+@WebMvcTest(controllers = ReVerifyController.class)
+@Import({
+  GlobalExceptionHandler.class,
+  SecurityConfig.class,
+  SupabaseAuthenticationEntryPoint.class
+})
+@ActiveProfiles("test")
+class ReVerifyControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private ReVerifyService reVerifyService;
+
+  // WebMvcTest 컨텍스트 로드용 — SecurityConfig 가 JwtDecoder bean 요구
+  @MockitoBean private JwtDecoder jwtDecoder;
+
+  // -----------------------------------------------------------------------
+  // 정상 경로
+  // -----------------------------------------------------------------------
+
+  @Test
+  @DisplayName(
+      "POST /api/v1/verification-results/{id}/re-verify — 202 + body resultId/claimId/ACCEPTED")
+  void reVerify_accepted_returns202WithBody() throws Exception {
+    UUID resultId = UUID.randomUUID();
+    UUID claimId = UUID.randomUUID();
+    ReVerifyAcceptedResponse response =
+        ReVerifyAcceptedResponse.builder()
+            .resultId(resultId)
+            .claimId(claimId)
+            .status("ACCEPTED")
+            .build();
+    given(reVerifyService.accept(resultId)).willReturn(response);
+
+    mockMvc
+        .perform(post("/api/v1/verification-results/" + resultId + "/re-verify"))
+        .andExpect(status().isAccepted())
+        .andExpect(jsonPath("$.resultId").value(resultId.toString()))
+        .andExpect(jsonPath("$.claimId").value(claimId.toString()))
+        .andExpect(jsonPath("$.status").value("ACCEPTED"));
+  }
+
+  // -----------------------------------------------------------------------
+  // 오류 경로 — GlobalExceptionHandler 경유
+  // -----------------------------------------------------------------------
+
+  @Test
+  @DisplayName("POST /api/v1/verification-results/{id}/re-verify — 결과 미존재 → 404")
+  void reVerify_notFound_returns404() throws Exception {
+    UUID resultId = UUID.randomUUID();
+    given(reVerifyService.accept(resultId)).willThrow(new NotFoundException("검증 결과를 찾을 수 없습니다"));
+
+    mockMvc
+        .perform(post("/api/v1/verification-results/" + resultId + "/re-verify"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.statusCode").value(404));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/verification-results/{id}/re-verify — 이미 supersede → 409")
+  void reVerify_alreadySuperseded_returns409() throws Exception {
+    UUID resultId = UUID.randomUUID();
+    given(reVerifyService.accept(resultId)).willThrow(new ConflictException("이미 정정된 결과입니다"));
+
+    mockMvc
+        .perform(post("/api/v1/verification-results/" + resultId + "/re-verify"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.statusCode").value(409));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/verification-results/{id}/re-verify — 쿨다운 미충족 → 429")
+  void reVerify_cooldown_returns429() throws Exception {
+    UUID resultId = UUID.randomUUID();
+    given(reVerifyService.accept(resultId)).willThrow(new TooManyRequestsException("재검증 쿨다운 중입니다"));
+
+    mockMvc
+        .perform(post("/api/v1/verification-results/" + resultId + "/re-verify"))
+        .andExpect(status().is(429))
+        .andExpect(jsonPath("$.statusCode").value(429));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/verification-results/notauuid/re-verify — invalid UUID → 400")
+  void reVerify_invalidUuid_returns400() throws Exception {
+    mockMvc
+        .perform(post("/api/v1/verification-results/notauuid/re-verify"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.statusCode").value(400));
+  }
+}

--- a/app/src/test/java/com/truthscope/web/drift/VerificationCascadeIntegrationTest.java
+++ b/app/src/test/java/com/truthscope/web/drift/VerificationCascadeIntegrationTest.java
@@ -190,7 +190,8 @@ class VerificationCascadeIntegrationTest {
     var claims = claimRepo.findByArticleId(response.getArticleId());
     assertThat(claims).hasSize(1);
 
-    var resultOpt = verificationResultRepo.findByClaimId(claims.get(0).getId());
+    var resultOpt =
+        verificationResultRepo.findByClaimIdAndSupersededAtIsNull(claims.get(0).getId());
     assertThat(resultOpt).isPresent();
 
     VerificationResult result = resultOpt.get();
@@ -269,7 +270,8 @@ class VerificationCascadeIntegrationTest {
     var claims = claimRepo.findByArticleId(response.getArticleId());
     assertThat(claims).hasSize(1);
 
-    var resultOpt = verificationResultRepo.findByClaimId(claims.get(0).getId());
+    var resultOpt =
+        verificationResultRepo.findByClaimIdAndSupersededAtIsNull(claims.get(0).getId());
     assertThat(resultOpt).isPresent();
     assertThat(resultOpt.get().getTier()).isEqualTo((short) 3);
     // Tier 3 score 는 반드시 null (domain-logic.md Tier 3 원칙)

--- a/app/src/test/java/com/truthscope/web/integration/ReVerifyIntegrationTest.java
+++ b/app/src/test/java/com/truthscope/web/integration/ReVerifyIntegrationTest.java
@@ -1,0 +1,472 @@
+package com.truthscope.web.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.truthscope.web.entity.AnalysisSession;
+import com.truthscope.web.entity.Article;
+import com.truthscope.web.entity.Claim;
+import com.truthscope.web.entity.VerificationResult;
+import com.truthscope.web.entity.VerifySource;
+import com.truthscope.web.entity.enums.ClaimImportance;
+import com.truthscope.web.entity.enums.SessionStatus;
+import com.truthscope.web.entity.enums.SupersedeReason;
+import com.truthscope.web.entity.enums.Verdict;
+import com.truthscope.web.exception.ConflictException;
+import com.truthscope.web.exception.NotFoundException;
+import com.truthscope.web.exception.TooManyRequestsException;
+import com.truthscope.web.factory.VerificationResultFactory;
+import com.truthscope.web.repository.AnalysisSessionRepository;
+import com.truthscope.web.repository.ArticleRepository;
+import com.truthscope.web.repository.ClaimRepository;
+import com.truthscope.web.repository.VerificationResultRepository;
+import com.truthscope.web.repository.VerifySourceRepository;
+import com.truthscope.web.scoring.ClaimCascadeResult;
+import com.truthscope.web.scoring.ClaimScoreStatus;
+import com.truthscope.web.scoring.ClaimVerificationSignal;
+import com.truthscope.web.scoring.CoverageSummary;
+import com.truthscope.web.scoring.EvidenceSnapshot;
+import com.truthscope.web.scoring.SourceTransparency;
+import com.truthscope.web.service.ArticleVerificationService;
+import com.truthscope.web.service.ReVerifyTransactionService;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Phase 72 Wave5-G 통합 테스트 — ReVerify supersede 체인 + 회귀 핵심 시나리오.
+ *
+ * <p>I1 happy path: persistReverifyOutcome 호출 → 새 행 INSERT + 기존 행 supersede 마킹 + 세션 재집계. I2 4조건
+ * 미충족: 기존 결과 보존 + last_confirmed_at 갱신. I3 쿨다운: validateAndGet 연속 호출 시 TooManyRequestsException. I4
+ * superseded 행에 validateAndGet → ConflictException. I5 부재 id → NotFoundException. I6 회귀 핵심:
+ * getVerification(articleId) 가 supersede 후 최신 결과 1건만 반환. I7 동시 2요청: advisory lock 으로 supersede 마킹
+ * 1건만, 결과 행 2개, 예외 0.
+ *
+ * <p>Singleton Testcontainers + @ServiceConnection 패턴 (VerificationPipelineIntegrationTest 정본 정합).
+ * production 프로파일 + Flyway V9 자동 적용으로 supersede 컬럼 + partial unique index 검증 겸함.
+ *
+ * <p>@SpringBootTest(NONE) + 서비스 직접 주입: HTTP layer bypass — cascade 외부 HTTP 없이 ClaimCascadeResult 를
+ * 직접 구성하여 persistReverifyOutcome 호출.
+ *
+ * <p>쿨다운: 테스트 프로퍼티 cooldown=PT10M. 일반 fixture 는 verifiedAt=now()-2h 로 쿨다운 통과. I3 는 verifiedAt=now()
+ * 로 validateAndGet 을 실제로 호출해 TooManyRequestsException(429) 가 발생함을 검증한다.
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+@ActiveProfiles("production")
+@Testcontainers(disabledWithoutDocker = true)
+@TestPropertySource(
+    properties = {
+      "truthscope.gemini.api-key=test-key",
+      "spring.jpa.hibernate.ddl-auto=validate",
+      "spring.flyway.enabled=true",
+      "spring.flyway.locations=classpath:db/migration",
+      "spring.main.allow-bean-definition-overriding=true",
+      "truthscope.async.enabled=false",
+      "truthscope.reverify.cooldown=PT10M"
+    })
+@DisplayName("Phase 72 Wave5-G — ReVerify 통합 테스트 I1~I7")
+class ReVerifyIntegrationTest {
+
+  // Singleton Testcontainers + @ServiceConnection — VerificationPipelineIntegrationTest 정본 정합
+  @ServiceConnection static final PostgreSQLContainer<?> POSTGRES;
+
+  static {
+    POSTGRES = new PostgreSQLContainer<>("postgres:16-alpine");
+    POSTGRES.start();
+  }
+
+  @Autowired ReVerifyTransactionService reVerifyTransactionService;
+
+  @Autowired ArticleVerificationService articleVerificationService;
+
+  @Autowired VerificationResultRepository verificationResultRepository;
+
+  @Autowired VerifySourceRepository verifySourceRepository;
+
+  @Autowired ClaimRepository claimRepository;
+
+  @Autowired ArticleRepository articleRepository;
+
+  @Autowired AnalysisSessionRepository analysisSessionRepository;
+
+  @Autowired JdbcTemplate jdbcTemplate;
+
+  @AfterEach
+  void tearDown() {
+    // superseded_by_result_id 자기참조 FK → 선행 NULL 처리 후 삭제
+    jdbcTemplate.update("UPDATE verification_results SET superseded_by_result_id = NULL");
+    verifySourceRepository.deleteAll();
+    verificationResultRepository.deleteAll();
+    claimRepository.deleteAll();
+    articleRepository.deleteAll();
+    analysisSessionRepository.deleteAll();
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Fixture 헬퍼
+  // ────────────────────────────────────────────────────────────────────────────
+
+  /** 세션 ID 보관용 내부 레코드 — fixture 저장 후 세션 재조회에 사용. */
+  private record FixtureResult(VerificationResult result, UUID sessionId) {}
+
+  /**
+   * 세션 + 기사 + claim + result(tier 1, score, supersededAt=null) + verify_source 1건을 DB 에 저장한다.
+   *
+   * <p>verifiedAt 을 충분히 과거(2시간 전)로 설정해 쿨다운(PT10M)을 항상 통과한다. I3 쿨다운 테스트는 verifiedAt=now() 를
+   * saveFixtureWithVerifiedAt 으로 별도 지정한다.
+   *
+   * @param score 기존 판정 점수 (1~100). null 이면 Tier 3 fixture.
+   * @return 저장된 FixtureResult (result + sessionId)
+   */
+  private FixtureResult saveFixture(Integer score) {
+    return saveFixtureWithVerifiedAt(score, LocalDateTime.now().minusHours(2));
+  }
+
+  private FixtureResult saveFixtureWithVerifiedAt(Integer score, LocalDateTime verifiedAt) {
+    AnalysisSession session =
+        analysisSessionRepository.save(
+            AnalysisSession.builder()
+                .status(SessionStatus.COMPLETED)
+                .requestedAt(LocalDateTime.now().minusMinutes(10))
+                .completedAt(LocalDateTime.now().minusMinutes(9))
+                .totalScore(score != null ? score.shortValue() : null)
+                .coverage(
+                    score != null
+                        ? new CoverageSummary(1, 0, 0, 0, 0, 1, 0, 0)
+                        : new CoverageSummary(0, 1, 1, 0, 0, 0, 0, 1))
+                .tier1Count((short) (score != null ? 1 : 0))
+                .tier2Count((short) 0)
+                .tier3Count((short) (score != null ? 0 : 1))
+                .build());
+
+    Article article =
+        Article.extract(
+            "https://example.com/news/reverify-test-" + UUID.randomUUID(),
+            "재검증 통합 테스트 기사",
+            "본문 내용",
+            "ko",
+            "example.com");
+    article.attachTo(session);
+    article = articleRepository.save(article);
+
+    Claim claim =
+        claimRepository.save(
+            Claim.builder()
+                .article(article)
+                .text("재검증 테스트 claim")
+                .sortOrder((short) 1)
+                .importance(ClaimImportance.MEDIUM)
+                .build());
+
+    short tier = score != null ? (short) 1 : (short) 3;
+    ClaimVerificationSignal signal =
+        new ClaimVerificationSignal(
+            claim.getId(),
+            tier,
+            score,
+            score != null ? ClaimScoreStatus.SCORABLE : ClaimScoreStatus.INSUFFICIENT,
+            score != null ? SourceTransparency.EXPLICIT : SourceTransparency.NONE);
+
+    VerificationResult result = VerificationResultFactory.buildResult(signal, claim, List.of());
+    // verifiedAt 덮어쓰기: reflection 대신 Builder 재구성 (VerificationResultFactory 의 verifiedAt 은
+    // LocalDateTime.now() 고정이므로 직접 빌드)
+    result =
+        verificationResultRepository.save(
+            VerificationResult.builder()
+                .claim(claim)
+                .tier(tier)
+                .score(score != null ? score.shortValue() : null)
+                .verdict(score != null ? Verdict.SUPPORTED : Verdict.INSUFFICIENT)
+                .tier3Reason(
+                    score != null ? null : com.truthscope.web.entity.enums.Tier3Reason.INSUFFICIENT)
+                .reason(score != null ? "Tier 1 팩트체크 기관 매칭 결과" : "Tier 3 검증 출처 부족")
+                .disclaimer(null)
+                .verifiedAt(verifiedAt)
+                .originalResultId(null)
+                .build());
+
+    // verify_source 1건 저장 (oldUrls 비교용)
+    if (score != null) {
+      verifySourceRepository.save(
+          VerifySource.builder()
+              .result(result)
+              .title("테스트 출처")
+              .publisher("example.com")
+              .url("https://source.example.com/article-1")
+              .stance("supports")
+              .build());
+    }
+
+    return new FixtureResult(result, session.getId());
+  }
+
+  /**
+   * SCORE_DRIFT 를 유발하는 새 ClaimCascadeResult 를 생성한다.
+   *
+   * <p>기존 점수와 차이가 16 (임계값 15 초과) 이며 동일 라벨 구간(FACT)에 해당하는 점수를 사용한다: old=99, new=83 → FACT 내
+   * SCORE_DRIFT. 새 출처 URL 은 기존과 다른 값을 사용해 URL_REPLACEMENT 를 중복 유발하지 않도록 한다.
+   *
+   * @param claimId 대상 Claim ID
+   * @param newScore 새 점수
+   */
+  private ClaimCascadeResult buildNewResult(UUID claimId, int newScore) {
+    ClaimVerificationSignal newSignal =
+        new ClaimVerificationSignal(
+            claimId, (short) 1, newScore, ClaimScoreStatus.SCORABLE, SourceTransparency.EXPLICIT);
+    EvidenceSnapshot evidence =
+        new EvidenceSnapshot(
+            "https://new-source.example.com/article-99",
+            "새 출처",
+            "새 기사 제목",
+            "SUPPORTED",
+            Collections.emptyMap(),
+            Collections.emptyMap());
+    return new ClaimCascadeResult(newSignal, List.of(evidence));
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // I1: happy path — supersede + 세션 재집계
+  // ────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("I1 happy path: 점수 차 16 → SCORE_DRIFT supersede + 세션 totalScore 재집계")
+  void I1_happyPath_scoreDrift_supersedeAndSessionUpdate() {
+    // Given: old score=99 (FACT), new score=83 (FACT), diff=16 > threshold(15) → SCORE_DRIFT
+    FixtureResult fixture = saveFixture(99);
+    VerificationResult old = fixture.result();
+    UUID claimId = old.getClaim().getId();
+    ClaimCascadeResult newResult = buildNewResult(claimId, 83);
+
+    long countBefore = verificationResultRepository.count();
+
+    // When
+    reVerifyTransactionService.persistReverifyOutcome(old.getId(), newResult);
+
+    // Then: 새 행 INSERT
+    long countAfter = verificationResultRepository.count();
+    assertThat(countAfter).isEqualTo(countBefore + 1);
+
+    // 기존 행 supersede 마킹 검증
+    VerificationResult superseded =
+        verificationResultRepository.findById(old.getId()).orElseThrow();
+    assertThat(superseded.isCurrent()).isFalse();
+    assertThat(superseded.getSupersedeReason()).isEqualTo(SupersedeReason.SCORE_DRIFT);
+    assertThat(superseded.getSupersededAt()).isNotNull();
+    assertThat(superseded.getSupersededByResultId()).isNotNull();
+
+    // 새 current 행
+    VerificationResult newCurrent =
+        verificationResultRepository.findByClaimIdAndSupersededAtIsNull(claimId).orElseThrow();
+    assertThat(newCurrent.getScore()).isEqualTo((short) 83);
+    assertThat(newCurrent.isCurrent()).isTrue();
+    assertThat(newCurrent.getOriginalResultId()).isEqualTo(old.getId());
+
+    // 세션 totalScore 재집계 — 83점으로 갱신 (DB 재조회로 LAZY 문제 회피)
+    AnalysisSession session = analysisSessionRepository.findById(fixture.sessionId()).orElseThrow();
+    assertThat(session.getTotalScore()).isEqualTo((short) 83);
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // I2: 4조건 미충족 — last_confirmed_at 갱신, 행 수 불변
+  // ────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("I2 4조건 미충족: old=95, new=95 동일 → 행 수 불변 + last_confirmed_at 갱신")
+  void I2_noChange_confirmRechecked() {
+    // Given: old score=95 (FACT), new score=95 (FACT), diff=0 → 4조건 모두 미충족
+    FixtureResult fixture = saveFixture(95);
+    VerificationResult old = fixture.result();
+    UUID claimId = old.getClaim().getId();
+    ClaimVerificationSignal sameSignal =
+        new ClaimVerificationSignal(
+            claimId, (short) 1, 95, ClaimScoreStatus.SCORABLE, SourceTransparency.EXPLICIT);
+    // 동일 URL 사용 → URL_REPLACEMENT 도 발동 안 함 (기존 URL 과 동일)
+    EvidenceSnapshot sameEvidence =
+        new EvidenceSnapshot(
+            "https://source.example.com/article-1", // saveFixture 와 동일 URL
+            "기존 출처",
+            "기존 기사",
+            "SUPPORTED",
+            Collections.emptyMap(),
+            Collections.emptyMap());
+    ClaimCascadeResult noChangeResult = new ClaimCascadeResult(sameSignal, List.of(sameEvidence));
+
+    long countBefore = verificationResultRepository.count();
+
+    // When
+    reVerifyTransactionService.persistReverifyOutcome(old.getId(), noChangeResult);
+
+    // Then: 행 수 불변
+    assertThat(verificationResultRepository.count()).isEqualTo(countBefore);
+
+    // last_confirmed_at 갱신
+    VerificationResult reloaded = verificationResultRepository.findById(old.getId()).orElseThrow();
+    assertThat(reloaded.getLastConfirmedAt()).isNotNull();
+    assertThat(reloaded.isCurrent()).isTrue();
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // I3: 쿨다운 — verifiedAt=now() → TooManyRequestsException
+  // ────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("I3 쿨다운: verifiedAt=지금 → validateAndGet TooManyRequestsException(429)")
+  void I3_cooldown_tooManyRequests() {
+    // Given: verifiedAt=now() — 쿨다운(PT10M) 내에 있으므로 429 예상
+    // @TestPropertySource cooldown=PT10M → production bean 이 PT10M 으로 동작
+    // validateAndGet 내부: lastActivity=verifiedAt=now() → now().isAfter(now()-PT10M) → true → 429
+    FixtureResult freshFixture = saveFixtureWithVerifiedAt(80, LocalDateTime.now());
+    UUID freshId = freshFixture.result().getId();
+
+    // When / Then: production service 의 ReVerifyTransactionService.validateAndGet 이
+    // 실제 TooManyRequestsException 을 던지는지 검증
+    assertThatThrownBy(() -> reVerifyTransactionService.validateAndGet(freshId))
+        .isInstanceOf(TooManyRequestsException.class)
+        .hasMessageContaining("쿨다운");
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // I4: superseded 행에 validateAndGet → ConflictException
+  // ────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("I4 superseded 행 validateAndGet → ConflictException(409)")
+  void I4_supersededResult_conflictException() {
+    // Given: I1 흐름으로 supersede 수행
+    FixtureResult fixture = saveFixture(99);
+    VerificationResult old = fixture.result();
+    UUID claimId = old.getClaim().getId();
+    reVerifyTransactionService.persistReverifyOutcome(old.getId(), buildNewResult(claimId, 83));
+
+    // superseded 여부 확인
+    VerificationResult superseded =
+        verificationResultRepository.findById(old.getId()).orElseThrow();
+    assertThat(superseded.isCurrent()).isFalse();
+
+    // When/Then: superseded 행에 validateAndGet → ConflictException
+    assertThatThrownBy(() -> reVerifyTransactionService.validateAndGet(old.getId()))
+        .isInstanceOf(ConflictException.class)
+        .hasMessageContaining("이미 정정된 결과");
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // I5: 부재 id → NotFoundException
+  // ────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("I5 부재 id → validateAndGet NotFoundException(404)")
+  void I5_notFoundId_notFoundException() {
+    UUID nonExistentId = UUID.randomUUID();
+
+    assertThatThrownBy(() -> reVerifyTransactionService.validateAndGet(nonExistentId))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("검증 결과를 찾을 수 없습니다");
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // I6: 회귀 핵심 — supersede 후 getVerification 이 최신 결과 1건만 반환
+  // ────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("I6 회귀 핵심: supersede 후 getVerification(articleId) 이 옛 결과 반환 안 함 — 최신 1건")
+  void I6_regression_getVerificationReturnsOnlyCurrentResult() {
+    // Given
+    FixtureResult fixture = saveFixture(99);
+    VerificationResult old = fixture.result();
+    UUID claimId = old.getClaim().getId();
+    // articleId: claim.article 은 LAZY 이므로 DB 재조회로 가져옴
+    UUID articleId = articleRepository.findBySessionId(fixture.sessionId()).orElseThrow().getId();
+    reVerifyTransactionService.persistReverifyOutcome(old.getId(), buildNewResult(claimId, 83));
+
+    // When
+    var response = articleVerificationService.getVerification(articleId);
+
+    // Then: claim 1건에 대해 결과 1건(최신, score=83)만 반환 — supersede 된 99점 결과는 포함 안 됨
+    assertThat(response.getClaims()).hasSize(1);
+    var claimItem = response.getClaims().get(0);
+    // score=83 이므로 FACT 밴드(80~100) → truthLabel="FACT"
+    assertThat(claimItem.getTruthLabel()).isNotNull();
+    // claimScoreStatus 는 SCORABLE 이면 null (RC-06 상호 배타)
+    assertThat(claimItem.getClaimScoreStatus()).isNull();
+
+    // DB 레벨로도 current 결과 1건 확인 (supersede 이전 결과가 포함 안 됨)
+    var currentByClaimId = verificationResultRepository.findByClaimIdAndSupersededAtIsNull(claimId);
+    assertThat(currentByClaimId).isPresent();
+    assertThat(currentByClaimId.get().getScore()).isEqualTo((short) 83);
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // I7: 동시 2요청 — advisory lock으로 supersede 마킹 1건, 결과 행 2, 예외 0
+  // ────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("I7 동시 2요청: advisory lock으로 supersede 마킹 정확히 1건, 결과 행 = 원본1 + 신규1 = 2, 예외 0")
+  void I7_concurrent_advisoryLockEnsuresSingleSupersede() throws InterruptedException {
+    // Given
+    FixtureResult fixture = saveFixture(99);
+    VerificationResult old = fixture.result();
+    UUID oldId = old.getId();
+    UUID claimId = old.getClaim().getId();
+
+    // 두 스레드가 동시에 persistReverifyOutcome 호출
+    CountDownLatch latch = new CountDownLatch(1);
+    List<Throwable> errors = Collections.synchronizedList(new java.util.ArrayList<>());
+
+    Runnable task =
+        () -> {
+          try {
+            latch.await(5, TimeUnit.SECONDS);
+            // 각 스레드가 약간 다른 점수를 전달해도 advisory lock이 하나만 처리
+            ClaimCascadeResult result = buildNewResult(claimId, 83);
+            reVerifyTransactionService.persistReverifyOutcome(oldId, result);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          } catch (Throwable e) {
+            errors.add(e);
+          }
+        };
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    executor.submit(task);
+    executor.submit(task);
+
+    // 동시 출발
+    latch.countDown();
+    executor.shutdown();
+    boolean finished = executor.awaitTermination(30, TimeUnit.SECONDS);
+
+    // Then: 예외 0 건
+    assertThat(finished).as("executor 타임아웃 없이 완료").isTrue();
+    assertThat(errors).as("동시 2요청 예외 없음").isEmpty();
+
+    // 전체 결과 행 수: 원본 1 + 신규 1 = 2
+    long totalResults = verificationResultRepository.count();
+    assertThat(totalResults).as("원본 행 + 신규 행 = 2").isEqualTo(2L);
+
+    // supersede 마킹은 정확히 1건 (늦은 요청은 no-op)
+    long supersededCount =
+        verificationResultRepository.findAll().stream().filter(r -> !r.isCurrent()).count();
+    assertThat(supersededCount).as("supersede 마킹 정확히 1건").isEqualTo(1L);
+
+    // current 행(partial unique uq_vr_claim_current)은 1건
+    var current = verificationResultRepository.findByClaimIdAndSupersededAtIsNull(claimId);
+    assertThat(current).as("claim 당 current 행 1건").isPresent();
+  }
+}

--- a/app/src/test/java/com/truthscope/web/integration/VerificationPipelineIntegrationTest.java
+++ b/app/src/test/java/com/truthscope/web/integration/VerificationPipelineIntegrationTest.java
@@ -268,7 +268,8 @@ class VerificationPipelineIntegrationTest {
       var claims = claimRepo.findByArticleId(articleId);
       assertThat(claims).hasSize(1);
 
-      var verificationOpt = verificationResultRepo.findByClaimId(claims.get(0).getId());
+      var verificationOpt =
+          verificationResultRepo.findByClaimIdAndSupersededAtIsNull(claims.get(0).getId());
       assertThat(verificationOpt).isPresent();
       VerificationResult vr = verificationOpt.get();
       assertThat(vr.getTier()).isEqualTo((short) 1);
@@ -367,7 +368,8 @@ class VerificationPipelineIntegrationTest {
       var claims = claimRepo.findByArticleId(articleId);
       assertThat(claims).hasSize(1);
 
-      var verificationOpt = verificationResultRepo.findByClaimId(claims.get(0).getId());
+      var verificationOpt =
+          verificationResultRepo.findByClaimIdAndSupersededAtIsNull(claims.get(0).getId());
       assertThat(verificationOpt).isPresent();
       VerificationResult vr = verificationOpt.get();
       assertThat(vr.getTier()).isEqualTo((short) 2);
@@ -601,12 +603,12 @@ class VerificationPipelineIntegrationTest {
       // SCORABLE → tier=1 / INSUFFICIENT_CANDIDATE → tier=3 INSUFFICIENT
       long tier1ResultCount =
           claims.stream()
-              .map(c -> verificationResultRepo.findByClaimId(c.getId()))
+              .map(c -> verificationResultRepo.findByClaimIdAndSupersededAtIsNull(c.getId()))
               .filter(opt -> opt.isPresent() && opt.get().getTier() == 1)
               .count();
       long tier3ResultCount =
           claims.stream()
-              .map(c -> verificationResultRepo.findByClaimId(c.getId()))
+              .map(c -> verificationResultRepo.findByClaimIdAndSupersededAtIsNull(c.getId()))
               .filter(opt -> opt.isPresent() && opt.get().getTier() == 3)
               .count();
       assertThat(tier1ResultCount).isEqualTo(1L);
@@ -669,7 +671,8 @@ class VerificationPipelineIntegrationTest {
       var claims = claimRepo.findByArticleId(articleId);
       assertThat(claims).hasSize(1);
 
-      var verificationOpt = verificationResultRepo.findByClaimId(claims.get(0).getId());
+      var verificationOpt =
+          verificationResultRepo.findByClaimIdAndSupersededAtIsNull(claims.get(0).getId());
       assertThat(verificationOpt).isPresent();
       VerificationResult vr = verificationOpt.get();
       assertThat(vr.getTier()).isEqualTo((short) 3);

--- a/app/src/test/java/com/truthscope/web/service/ArticleVerificationServiceTest.java
+++ b/app/src/test/java/com/truthscope/web/service/ArticleVerificationServiceTest.java
@@ -202,7 +202,7 @@ class ArticleVerificationServiceTest {
       when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
       when(claimRepository.findByArticleIdOrderBySortOrderAsc(articleId))
           .thenReturn(List.of(claim));
-      when(verificationResultRepository.findByClaimIdIn(List.of(claimId)))
+      when(verificationResultRepository.findCurrentByClaimIdIn(List.of(claimId)))
           .thenReturn(List.of(result));
 
       ArticleVerificationResponse response = service.getVerification(articleId);
@@ -225,7 +225,7 @@ class ArticleVerificationServiceTest {
       when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
       when(claimRepository.findByArticleIdOrderBySortOrderAsc(articleId))
           .thenReturn(List.of(claim));
-      when(verificationResultRepository.findByClaimIdIn(List.of(claimId)))
+      when(verificationResultRepository.findCurrentByClaimIdIn(List.of(claimId)))
           .thenReturn(List.of(result));
 
       ArticleVerificationResponse response = service.getVerification(articleId);
@@ -249,7 +249,7 @@ class ArticleVerificationServiceTest {
       when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
       when(claimRepository.findByArticleIdOrderBySortOrderAsc(articleId))
           .thenReturn(List.of(claim));
-      when(verificationResultRepository.findByClaimIdIn(List.of(claimId)))
+      when(verificationResultRepository.findCurrentByClaimIdIn(List.of(claimId)))
           .thenReturn(List.of(result));
 
       // NPE가 발생하지 않아야 함
@@ -282,7 +282,7 @@ class ArticleVerificationServiceTest {
       when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
       when(claimRepository.findByArticleIdOrderBySortOrderAsc(articleId))
           .thenReturn(List.of(claim));
-      when(verificationResultRepository.findByClaimIdIn(List.of(claimId)))
+      when(verificationResultRepository.findCurrentByClaimIdIn(List.of(claimId)))
           .thenReturn(List.of(result));
 
       ArticleVerificationResponse response = service.getVerification(articleId);
@@ -304,7 +304,7 @@ class ArticleVerificationServiceTest {
       when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
       when(claimRepository.findByArticleIdOrderBySortOrderAsc(articleId))
           .thenReturn(List.of(claim));
-      when(verificationResultRepository.findByClaimIdIn(List.of(claimId)))
+      when(verificationResultRepository.findCurrentByClaimIdIn(List.of(claimId)))
           .thenReturn(List.of(result));
 
       ArticleVerificationResponse response = service.getVerification(articleId);
@@ -326,7 +326,7 @@ class ArticleVerificationServiceTest {
       when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
       when(claimRepository.findByArticleIdOrderBySortOrderAsc(articleId))
           .thenReturn(List.of(claim));
-      when(verificationResultRepository.findByClaimIdIn(List.of(claimId)))
+      when(verificationResultRepository.findCurrentByClaimIdIn(List.of(claimId)))
           .thenReturn(List.of(result));
 
       ArticleVerificationResponse response = service.getVerification(articleId);
@@ -352,7 +352,7 @@ class ArticleVerificationServiceTest {
       when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
       when(claimRepository.findByArticleIdOrderBySortOrderAsc(articleId))
           .thenReturn(List.of(claim));
-      when(verificationResultRepository.findByClaimIdIn(List.of(claimId)))
+      when(verificationResultRepository.findCurrentByClaimIdIn(List.of(claimId)))
           .thenReturn(List.of(result));
 
       ArticleVerificationResponse response = service.getVerification(articleId);
@@ -444,7 +444,8 @@ class ArticleVerificationServiceTest {
       when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
       when(claimRepository.findByArticleIdOrderBySortOrderAsc(articleId))
           .thenReturn(List.of(claim));
-      when(verificationResultRepository.findByClaimIdIn(List.of(claimId))).thenReturn(List.of());
+      when(verificationResultRepository.findCurrentByClaimIdIn(List.of(claimId)))
+          .thenReturn(List.of());
 
       ArticleVerificationResponse response = service.getVerification(articleId);
 

--- a/app/src/test/java/com/truthscope/web/service/ReVerifyServiceTest.java
+++ b/app/src/test/java/com/truthscope/web/service/ReVerifyServiceTest.java
@@ -1,0 +1,44 @@
+package com.truthscope.web.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.truthscope.web.dto.response.ReVerifyAcceptedResponse;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** ReVerifyService 단위 테스트. accept 가 target 을 그대로 asyncReVerifyService 에 전달하는지 검증. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReVerifyService 단위 테스트")
+class ReVerifyServiceTest {
+
+  @Mock private ReVerifyTransactionService txService;
+
+  @Mock private AsyncReVerifyService asyncReVerifyService;
+
+  @InjectMocks private ReVerifyService reVerifyService;
+
+  @Test
+  @DisplayName("accept — validateAndGet 반환값을 asyncReVerifyService.reverify 에 그대로 전달하고 ACCEPTED 응답")
+  void accept_delegatesTargetToAsyncService() {
+    UUID resultId = UUID.randomUUID();
+    UUID claimId = UUID.randomUUID();
+    ReVerifyTransactionService.ReVerifyTarget target =
+        new ReVerifyTransactionService.ReVerifyTarget(resultId, claimId);
+    when(txService.validateAndGet(resultId)).thenReturn(target);
+
+    ReVerifyAcceptedResponse response = reVerifyService.accept(resultId);
+
+    verify(txService).validateAndGet(resultId);
+    verify(asyncReVerifyService).reverify(resultId, claimId);
+    assertThat(response.getResultId()).isEqualTo(resultId);
+    assertThat(response.getClaimId()).isEqualTo(claimId);
+    assertThat(response.getStatus()).isEqualTo("ACCEPTED");
+  }
+}

--- a/app/src/test/java/com/truthscope/web/service/ReVerifyTransactionServiceTest.java
+++ b/app/src/test/java/com/truthscope/web/service/ReVerifyTransactionServiceTest.java
@@ -1,0 +1,282 @@
+package com.truthscope.web.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.truthscope.web.entity.Claim;
+import com.truthscope.web.entity.VerificationResult;
+import com.truthscope.web.exception.ConflictException;
+import com.truthscope.web.exception.NotFoundException;
+import com.truthscope.web.exception.TooManyRequestsException;
+import com.truthscope.web.repository.VerificationResultRepository;
+import com.truthscope.web.scoring.ClaimScoreStatus;
+import com.truthscope.web.scoring.ReVerifyPolicy;
+import com.truthscope.web.scoring.SourceTransparency;
+import jakarta.persistence.EntityManager;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * ReVerifyTransactionService 단위 테스트.
+ *
+ * <p>U6: 역도출 메서드 단위 검증 + validateAndGet 404/409/429 분기 커버. U7: 쿨다운 판정 — verifiedAt 9분 전 = 429, 11분
+ * 전 = 통과, lastConfirmedAt 이 더 최신이면 그 기준.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ReVerifyTransactionService 단위 테스트")
+class ReVerifyTransactionServiceTest {
+
+  @Mock private VerificationResultRepository verificationResultRepository;
+
+  @Mock private EntityManager entityManager;
+
+  private ReVerifyPolicy policy;
+  private ReVerifyTransactionService service;
+
+  @BeforeEach
+  void setUp() {
+    // 쿨다운 10분, scoreDriftThreshold=15, urlReplacementRatio=0.3
+    policy = new ReVerifyPolicy(Duration.ofMinutes(10), 15, 0.3);
+    // ReVerifyTransactionService는 추가 의존성이 있으나 validateAndGet 테스트만 필요한 것은 null-safe
+    service =
+        new ReVerifyTransactionService(
+            verificationResultRepository,
+            null, // verifySourceRepository — validateAndGet에서 미사용
+            null, // claimRepository — validateAndGet에서 미사용
+            null, // analysisSessionRepository — validateAndGet에서 미사용
+            null, // articleScorePolicy
+            null, // scoreBandPolicy
+            entityManager,
+            policy);
+  }
+
+  // ─── validateAndGet 분기 테스트 ──────────────────────────────────────────────
+
+  @Nested
+  @DisplayName("U6: validateAndGet — 404/409/429 분기")
+  class ValidateAndGetTest {
+
+    @Test
+    @DisplayName("결과가 존재하지 않으면 NotFoundException(404)")
+    void 결과_없으면_404() {
+      UUID resultId = UUID.randomUUID();
+      when(verificationResultRepository.findWithClaimById(resultId)).thenReturn(Optional.empty());
+
+      assertThatThrownBy(() -> service.validateAndGet(resultId))
+          .isInstanceOf(NotFoundException.class)
+          .hasMessageContaining("검증 결과를 찾을 수 없습니다");
+    }
+
+    @Test
+    @DisplayName("이미 supersede된 결과(isCurrent=false)이면 ConflictException(409)")
+    void 이미_정정된_결과면_409() {
+      UUID resultId = UUID.randomUUID();
+      VerificationResult supersededResult = buildSupersededResult(resultId);
+      when(verificationResultRepository.findWithClaimById(resultId))
+          .thenReturn(Optional.of(supersededResult));
+
+      assertThatThrownBy(() -> service.validateAndGet(resultId))
+          .isInstanceOf(ConflictException.class)
+          .hasMessageContaining("이미 정정된 결과");
+    }
+
+    @Test
+    @DisplayName("verifiedAt이 9분 전이면 쿨다운 미충족 — TooManyRequestsException(429)")
+    void verifiedAt_9분전_429() {
+      UUID resultId = UUID.randomUUID();
+      LocalDateTime nineMinutesAgo = LocalDateTime.now().minusMinutes(9);
+      VerificationResult result = buildCurrentResult(resultId, nineMinutesAgo, null);
+      when(verificationResultRepository.findWithClaimById(resultId))
+          .thenReturn(Optional.of(result));
+
+      assertThatThrownBy(() -> service.validateAndGet(resultId))
+          .isInstanceOf(TooManyRequestsException.class);
+    }
+
+    @Test
+    @DisplayName("verifiedAt이 11분 전이면 쿨다운 충족 — ReVerifyTarget 반환")
+    void verifiedAt_11분전_통과() {
+      UUID resultId = UUID.randomUUID();
+      LocalDateTime elevenMinutesAgo = LocalDateTime.now().minusMinutes(11);
+      VerificationResult result = buildCurrentResult(resultId, elevenMinutesAgo, null);
+      when(verificationResultRepository.findWithClaimById(resultId))
+          .thenReturn(Optional.of(result));
+
+      ReVerifyTransactionService.ReVerifyTarget target = service.validateAndGet(resultId);
+
+      assertThat(target.resultId()).isEqualTo(resultId);
+      assertThat(target.claimId()).isNotNull();
+    }
+  }
+
+  // ─── U7: 쿨다운 판정 — lastConfirmedAt 우선 ──────────────────────────────────
+
+  @Nested
+  @DisplayName("U7: 쿨다운 기준 — verifiedAt vs lastConfirmedAt 최신값")
+  class CooldownTest {
+
+    @Test
+    @DisplayName("lastConfirmedAt이 verifiedAt보다 최신이고 9분 전이면 429")
+    void lastConfirmedAt이_더_최신이고_9분전_429() {
+      UUID resultId = UUID.randomUUID();
+      // verifiedAt은 30분 전 (쿨다운 충족), lastConfirmedAt은 9분 전 (쿨다운 미충족)
+      LocalDateTime thirtyMinutesAgo = LocalDateTime.now().minusMinutes(30);
+      LocalDateTime nineMinutesAgo = LocalDateTime.now().minusMinutes(9);
+      VerificationResult result = buildCurrentResult(resultId, thirtyMinutesAgo, nineMinutesAgo);
+      when(verificationResultRepository.findWithClaimById(resultId))
+          .thenReturn(Optional.of(result));
+
+      assertThatThrownBy(() -> service.validateAndGet(resultId))
+          .isInstanceOf(TooManyRequestsException.class);
+    }
+
+    @Test
+    @DisplayName("lastConfirmedAt이 null이면 verifiedAt만 기준 — 11분 전이면 통과")
+    void lastConfirmedAt_null이면_verifiedAt_기준_통과() {
+      UUID resultId = UUID.randomUUID();
+      LocalDateTime elevenMinutesAgo = LocalDateTime.now().minusMinutes(11);
+      VerificationResult result = buildCurrentResult(resultId, elevenMinutesAgo, null);
+      when(verificationResultRepository.findWithClaimById(resultId))
+          .thenReturn(Optional.of(result));
+
+      ReVerifyTransactionService.ReVerifyTarget target = service.validateAndGet(resultId);
+
+      assertThat(target.resultId()).isEqualTo(resultId);
+    }
+
+    @Test
+    @DisplayName("verifiedAt이 최신이고 9분 전이면 429 — lastConfirmedAt이 더 오래됐어도")
+    void verifiedAt이_최신이고_9분전_429() {
+      UUID resultId = UUID.randomUUID();
+      // lastConfirmedAt은 30분 전, verifiedAt은 9분 전
+      LocalDateTime thirtyMinutesAgo = LocalDateTime.now().minusMinutes(30);
+      LocalDateTime nineMinutesAgo = LocalDateTime.now().minusMinutes(9);
+      VerificationResult result = buildCurrentResult(resultId, nineMinutesAgo, thirtyMinutesAgo);
+      when(verificationResultRepository.findWithClaimById(resultId))
+          .thenReturn(Optional.of(result));
+
+      assertThatThrownBy(() -> service.validateAndGet(resultId))
+          .isInstanceOf(TooManyRequestsException.class);
+    }
+  }
+
+  // ─── U6: 역도출 — ClaimVerificationSignal 생성 정합성 ──────────────────────────
+
+  @Nested
+  @DisplayName("U6: 역도출 메서드 단위 검증")
+  class ReverseDerivationTest {
+
+    @Test
+    @DisplayName("score 있는 결과 역도출 — status=SCORABLE, tier=1, transparency=EXPLICIT")
+    void 점수_있는_결과_역도출_SCORABLE() {
+      // score=80, tier=1 → SCORABLE, EXPLICIT
+      var signal =
+          ReVerifyTransactionService.deriveSignalFromResult(
+              (short) 1, (short) 80, null /* tier3Reason */);
+
+      assertThat(signal.status()).isEqualTo(ClaimScoreStatus.SCORABLE);
+      assertThat(signal.score()).isEqualTo(80);
+      assertThat(signal.tier()).isEqualTo((short) 1);
+      assertThat(signal.sourceTransparency()).isEqualTo(SourceTransparency.EXPLICIT);
+    }
+
+    @Test
+    @DisplayName("score 있는 결과 역도출 — tier=2, transparency=AMBIGUOUS")
+    void 점수_있는_결과_역도출_tier2_AMBIGUOUS() {
+      var signal = ReVerifyTransactionService.deriveSignalFromResult((short) 2, (short) 55, null);
+
+      assertThat(signal.status()).isEqualTo(ClaimScoreStatus.SCORABLE);
+      assertThat(signal.score()).isEqualTo(55);
+      assertThat(signal.sourceTransparency()).isEqualTo(SourceTransparency.AMBIGUOUS);
+    }
+
+    @Test
+    @DisplayName("score null + tier3Reason=INSUFFICIENT → status=INSUFFICIENT, NONE")
+    void score_null_INSUFFICIENT() {
+      var signal =
+          ReVerifyTransactionService.deriveSignalFromResult(
+              (short) 3, null, com.truthscope.web.entity.enums.Tier3Reason.INSUFFICIENT);
+
+      assertThat(signal.status()).isEqualTo(ClaimScoreStatus.INSUFFICIENT);
+      assertThat(signal.score()).isNull();
+      assertThat(signal.sourceTransparency()).isEqualTo(SourceTransparency.NONE);
+    }
+
+    @Test
+    @DisplayName("score null + tier3Reason=TIME_SENSITIVE → status=TIME_SENSITIVE")
+    void score_null_TIME_SENSITIVE() {
+      var signal =
+          ReVerifyTransactionService.deriveSignalFromResult(
+              (short) 3, null, com.truthscope.web.entity.enums.Tier3Reason.TIME_SENSITIVE);
+
+      assertThat(signal.status()).isEqualTo(ClaimScoreStatus.TIME_SENSITIVE);
+    }
+
+    @Test
+    @DisplayName("score null + tier3Reason=OUT_OF_SCOPE → status=OUT_OF_SCOPE")
+    void score_null_OUT_OF_SCOPE() {
+      var signal =
+          ReVerifyTransactionService.deriveSignalFromResult(
+              (short) 3, null, com.truthscope.web.entity.enums.Tier3Reason.OUT_OF_SCOPE);
+
+      assertThat(signal.status()).isEqualTo(ClaimScoreStatus.OUT_OF_SCOPE);
+    }
+
+    @Test
+    @DisplayName("score null + tier3Reason=null (레거시) → status=INSUFFICIENT 폴백")
+    void score_null_tier3Reason_null_레거시_폴백() {
+      var signal = ReVerifyTransactionService.deriveSignalFromResult((short) 3, null, null);
+
+      assertThat(signal.status()).isEqualTo(ClaimScoreStatus.INSUFFICIENT);
+    }
+  }
+
+  // ─── 헬퍼 메서드 ─────────────────────────────────────────────────────────────
+
+  /** 이미 supersede된 결과를 모킹 — isCurrent()=false */
+  private VerificationResult buildSupersededResult(UUID resultId) {
+    Claim claim = mock(Claim.class);
+    when(claim.getId()).thenReturn(UUID.randomUUID());
+
+    VerificationResult result = mock(VerificationResult.class);
+    when(result.getId()).thenReturn(resultId);
+    when(result.getClaim()).thenReturn(claim);
+    when(result.isCurrent()).thenReturn(false);
+    return result;
+  }
+
+  /**
+   * 현재 유효한 결과를 모킹. verifiedAt과 lastConfirmedAt을 지정한다.
+   *
+   * @param resultId 결과 ID
+   * @param verifiedAt 최초 검증 시각
+   * @param lastConfirmedAt 마지막 재확인 시각 (null 가능)
+   */
+  private VerificationResult buildCurrentResult(
+      UUID resultId, LocalDateTime verifiedAt, LocalDateTime lastConfirmedAt) {
+    Claim claim = mock(Claim.class);
+    when(claim.getId()).thenReturn(UUID.randomUUID());
+
+    VerificationResult result = mock(VerificationResult.class);
+    when(result.getId()).thenReturn(resultId);
+    when(result.getClaim()).thenReturn(claim);
+    when(result.isCurrent()).thenReturn(true);
+    when(result.getVerifiedAt()).thenReturn(verifiedAt);
+    when(result.getLastConfirmedAt()).thenReturn(lastConfirmedAt);
+    return result;
+  }
+}

--- a/core/src/main/java/com/truthscope/web/dto/response/ReVerifyAcceptedResponse.java
+++ b/core/src/main/java/com/truthscope/web/dto/response/ReVerifyAcceptedResponse.java
@@ -1,0 +1,24 @@
+package com.truthscope.web.dto.response;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 재검증 접수 응답 DTO */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReVerifyAcceptedResponse {
+
+  /** 재검증 접수된 기존 VerificationResult ID */
+  private UUID resultId;
+
+  /** 재검증 대상 Claim ID */
+  private UUID claimId;
+
+  /** 접수 상태 — 항상 "ACCEPTED" */
+  private String status;
+}

--- a/core/src/main/java/com/truthscope/web/entity/AnalysisSession.java
+++ b/core/src/main/java/com/truthscope/web/entity/AnalysisSession.java
@@ -74,6 +74,32 @@ public class AnalysisSession extends BaseTimeEntity {
   }
 
   /**
+   * 재검증 후 집계 필드만 갱신한다 — 최초 완료 시각 보존, ADR-009 이력 원칙.
+   *
+   * <p>status 와 completedAt 은 변경하지 않는다. ArticleFactScoreAggregator + CoverageAggregator 재실행 결과를 기존
+   * 세션에 덮어쓸 때 사용한다.
+   *
+   * @param totalScore Phase 55 ArticleFactScoreAggregator 결과 Short(0..100), 검증 가능 claim 없으면 null
+   * @param coverage CoverageAggregator 집계 결과 (non-null)
+   * @param tier1Count Tier 1 signal 수
+   * @param tier2Count Tier 2 signal 수
+   * @param tier3Count Tier 3 signal 수
+   */
+  public void updateAggregates(
+      Short totalScore,
+      CoverageSummary coverage,
+      Short tier1Count,
+      Short tier2Count,
+      Short tier3Count) {
+    this.totalScore = totalScore;
+    this.coverage = coverage;
+    this.tier1Count = tier1Count;
+    this.tier2Count = tier2Count;
+    this.tier3Count = tier3Count;
+    // status 와 completedAt 은 의도적으로 변경하지 않는다.
+  }
+
+  /**
    * Wave 2 cascade 영속화 완료 후 세션 집계 필드를 갱신하고 상태를 COMPLETED로 전이한다.
    *
    * <p>@Setter 없음 원칙 준수 — AnalysisTransactionService.persistCascadeResults 가 호출. totalScore /

--- a/core/src/main/java/com/truthscope/web/entity/VerificationResult.java
+++ b/core/src/main/java/com/truthscope/web/entity/VerificationResult.java
@@ -92,8 +92,8 @@ public class VerificationResult extends BaseTimeEntity {
   /**
    * 이 결과를 supersede 처리한다.
    *
-   * <p>영속 순서 제약: 반드시 flush 후 새 결과를 INSERT하고 그 다음 linkSupersededBy 호출.
-   * 마킹-flush-INSERT-link 순서를 어기면 partial unique(uq_vr_claim_current) 위반이 발생한다.
+   * <p>영속 순서 제약: 반드시 flush 후 새 결과를 INSERT하고 그 다음 linkSupersededBy 호출. 마킹-flush-INSERT-link 순서를 어기면
+   * partial unique(uq_vr_claim_current) 위반이 발생한다.
    *
    * @param reason 정정 사유 (ADR-009 4조건 OR)
    */

--- a/core/src/main/java/com/truthscope/web/entity/VerificationResult.java
+++ b/core/src/main/java/com/truthscope/web/entity/VerificationResult.java
@@ -1,5 +1,6 @@
 package com.truthscope.web.entity;
 
+import com.truthscope.web.entity.enums.SupersedeReason;
 import com.truthscope.web.entity.enums.Tier3Reason;
 import com.truthscope.web.entity.enums.Verdict;
 import jakarta.persistence.Column;
@@ -11,7 +12,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -33,8 +34,8 @@ public class VerificationResult extends BaseTimeEntity {
   @Column(name = "id", columnDefinition = "uuid")
   private UUID id;
 
-  @OneToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "claim_id", unique = true)
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "claim_id")
   private Claim claim;
 
   @Column(name = "tier")
@@ -67,4 +68,64 @@ public class VerificationResult extends BaseTimeEntity {
   @Enumerated(EnumType.STRING)
   @Column(name = "tier3_reason", length = 30)
   private Tier3Reason tier3Reason;
+
+  // ── Supersede 체인 컬럼 (ADR-009 rev.3 · V9 마이그레이션 정합) ──────────────
+
+  @Column(name = "superseded_at")
+  private LocalDateTime supersededAt;
+
+  @Column(name = "superseded_by_result_id", columnDefinition = "uuid")
+  private UUID supersededByResultId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "supersede_reason", length = 30)
+  private SupersedeReason supersedeReason;
+
+  @Column(name = "original_result_id", columnDefinition = "uuid")
+  private UUID originalResultId;
+
+  @Column(name = "last_confirmed_at")
+  private LocalDateTime lastConfirmedAt;
+
+  // ── 비즈니스 메서드 (@Setter 금지 — 변경은 비즈니스 메서드로만) ────────────────
+
+  /**
+   * 이 결과를 supersede 처리한다.
+   *
+   * <p>영속 순서 제약: 반드시 flush 후 새 결과를 INSERT하고 그 다음 linkSupersededBy 호출.
+   * 마킹-flush-INSERT-link 순서를 어기면 partial unique(uq_vr_claim_current) 위반이 발생한다.
+   *
+   * @param reason 정정 사유 (ADR-009 4조건 OR)
+   */
+  public void markSuperseded(SupersedeReason reason) {
+    this.supersededAt = LocalDateTime.now();
+    this.supersedeReason = reason;
+  }
+
+  /**
+   * 이 결과를 대체한 새 결과의 ID를 연결한다.
+   *
+   * @param byResultId 대체 결과 ID
+   */
+  public void linkSupersededBy(UUID byResultId) {
+    this.supersededByResultId = byResultId;
+  }
+
+  /**
+   * 재검증 수행 결과가 변경 없음으로 확인된 시각을 기록한다.
+   *
+   * <p>4조건 모두 미충족 시 호출. supersede 없이 확인 증거만 남긴다.
+   */
+  public void confirmRecheck() {
+    this.lastConfirmedAt = LocalDateTime.now();
+  }
+
+  /**
+   * 현재 유효한 결과인지 여부를 반환한다.
+   *
+   * @return superseded_at 이 NULL이면 현재 유효(true), 아니면 이미 정정된 결과(false)
+   */
+  public boolean isCurrent() {
+    return this.supersededAt == null;
+  }
 }

--- a/core/src/main/java/com/truthscope/web/entity/enums/SupersedeReason.java
+++ b/core/src/main/java/com/truthscope/web/entity/enums/SupersedeReason.java
@@ -1,0 +1,16 @@
+package com.truthscope.web.entity.enums;
+
+/**
+ * 재검증 supersede 사유 6종 (ADR-009 rev.3 — V9 CHECK 대문자 정합).
+ *
+ * <p>4조건 판별(SupersedeDecider) 산출 4종 + 트리거 출처 표기 2종(USER_REPORT, SCHEDULED_REVERIFY — UC-145/146
+ * 트리거 기록용, v1.x에서는 SCHEDULED_REVERIFY 미사용).
+ */
+public enum SupersedeReason {
+  LABEL_CHANGED,
+  SCORE_DRIFT,
+  URL_REPLACEMENT,
+  TIER_CHANGED,
+  USER_REPORT,
+  SCHEDULED_REVERIFY
+}

--- a/core/src/main/java/com/truthscope/web/entity/enums/SupersedeReason.java
+++ b/core/src/main/java/com/truthscope/web/entity/enums/SupersedeReason.java
@@ -3,8 +3,8 @@ package com.truthscope.web.entity.enums;
 /**
  * 재검증 supersede 사유 6종 (ADR-009 rev.3 — V9 CHECK 대문자 정합).
  *
- * <p>4조건 판별(SupersedeDecider) 산출 4종 + 트리거 출처 표기 2종(USER_REPORT, SCHEDULED_REVERIFY — UC-145/146
- * 트리거 기록용, v1.x에서는 SCHEDULED_REVERIFY 미사용).
+ * <p>4조건 판별(SupersedeDecider) 산출 4종 + 트리거 출처 표기 2종(USER_REPORT, SCHEDULED_REVERIFY — UC-145/146 트리거
+ * 기록용, v1.x에서는 SCHEDULED_REVERIFY 미사용).
  */
 public enum SupersedeReason {
   LABEL_CHANGED,

--- a/core/src/main/java/com/truthscope/web/exception/TooManyRequestsException.java
+++ b/core/src/main/java/com/truthscope/web/exception/TooManyRequestsException.java
@@ -1,0 +1,9 @@
+package com.truthscope.web.exception;
+
+/** 재검증 쿨다운 미충족 예외 — 429 상태 코드 */
+public class TooManyRequestsException extends AppException {
+
+  public TooManyRequestsException(String message) {
+    super(429, message);
+  }
+}

--- a/core/src/main/java/com/truthscope/web/factory/VerificationResultFactory.java
+++ b/core/src/main/java/com/truthscope/web/factory/VerificationResultFactory.java
@@ -1,0 +1,140 @@
+package com.truthscope.web.factory;
+
+import com.truthscope.web.entity.Claim;
+import com.truthscope.web.entity.VerificationResult;
+import com.truthscope.web.entity.enums.Tier3Reason;
+import com.truthscope.web.entity.enums.Verdict;
+import com.truthscope.web.scoring.ClaimScoreStatus;
+import com.truthscope.web.scoring.ClaimVerificationSignal;
+import com.truthscope.web.scoring.EvidenceSnapshot;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * ClaimVerificationSignal → VerificationResult 엔티티 변환 유틸리티.
+ *
+ * <p>AnalysisTransactionService 의 buildResult / mapVerdict / mapTier3Reason /
+ * isMajorityContradicted / buildReason 을 추출한 정적 팩토리 클래스다.
+ *
+ * <p>변환 규칙:
+ *
+ * <ul>
+ *   <li>score: Integer(0..100) → Short(0..100) 클램프 변환. null 이면 null 유지.
+ *   <li>disclaimer: Tier 2 에만 "AI 분석이며 기관 검증이 아닙니다. 참고 용도로만 활용하세요." 고정.
+ *   <li>verdict: SCORABLE 은 evidence stance 다수결(CONTRADICTED 과반 → CONTRADICTED, 그 외 → SUPPORTED).
+ *       비판정 3종은 각각 INSUFFICIENT/TIME_SENSITIVE/OUT_OF_SCOPE 그대로 매핑.
+ *   <li>tier3Reason: SCORABLE 이면 null, 비판정 3종은 각각 매핑.
+ *   <li>originalResultId: 재검증 시 이전 결과와의 체인 연결용. null 이면 최초 결과를 의미한다.
+ * </ul>
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class VerificationResultFactory {
+
+  /**
+   * ClaimVerificationSignal 과 evidence 목록으로 VerificationResult 엔티티를 생성한다.
+   *
+   * @param signal Tier Cascade 검증 결과 신호
+   * @param claim 연결할 Claim 엔티티
+   * @param evidence EvidenceSnapshot 목록 (Tier 3 는 빈 리스트)
+   * @return 영속 전 VerificationResult 엔티티 (ID 미생성 상태)
+   */
+  public static VerificationResult buildResult(
+      ClaimVerificationSignal signal, Claim claim, List<EvidenceSnapshot> evidence) {
+    return buildResult(signal, claim, evidence, null);
+  }
+
+  /**
+   * ClaimVerificationSignal 과 evidence 목록으로 VerificationResult 엔티티를 생성한다.
+   *
+   * <p>재검증 경로에서 originalResultId 를 지정할 때 이 메서드를 사용한다.
+   *
+   * @param signal Tier Cascade 검증 결과 신호
+   * @param claim 연결할 Claim 엔티티
+   * @param evidence EvidenceSnapshot 목록 (Tier 3 는 빈 리스트)
+   * @param originalResultId 재검증 체인의 원본 결과 ID. 최초 결과이면 null.
+   * @return 영속 전 VerificationResult 엔티티 (ID 미생성 상태)
+   */
+  public static VerificationResult buildResult(
+      ClaimVerificationSignal signal,
+      Claim claim,
+      List<EvidenceSnapshot> evidence,
+      UUID originalResultId) {
+    Short shortScore =
+        signal.score() == null ? null : (short) Math.min(100, Math.max(0, signal.score()));
+    String disclaimer = signal.tier() == 2 ? "AI 분석이며 기관 검증이 아닙니다. 참고 용도로만 활용하세요." : null;
+    return VerificationResult.builder()
+        .claim(claim)
+        .tier(signal.tier())
+        .score(shortScore)
+        .verdict(mapVerdict(signal.status(), evidence))
+        .tier3Reason(mapTier3Reason(signal.status()))
+        .reason(buildReason(signal))
+        .disclaimer(disclaimer)
+        .verifiedAt(LocalDateTime.now())
+        .originalResultId(originalResultId)
+        .build();
+  }
+
+  /**
+   * ClaimScoreStatus 를 Tier3Reason 으로 매핑한다.
+   *
+   * <p>SCORABLE(Tier 1/2) 은 tier3_reason = NULL (V6 CHECK 정합).
+   *
+   * @param status ClaimVerificationSignal 의 status
+   * @return Tier3Reason 또는 null (SCORABLE)
+   */
+  public static Tier3Reason mapTier3Reason(ClaimScoreStatus status) {
+    return switch (status) {
+      case INSUFFICIENT -> Tier3Reason.INSUFFICIENT;
+      case TIME_SENSITIVE -> Tier3Reason.TIME_SENSITIVE;
+      case OUT_OF_SCOPE -> Tier3Reason.OUT_OF_SCOPE;
+      case SCORABLE -> null;
+    };
+  }
+
+  /**
+   * status 와 evidence stance 를 Verdict 로 매핑한다.
+   *
+   * <p>SCORABLE 은 evidence 다수결: 반박이 뒷받침보다 많으면 CONTRADICTED, 그 외(동률·evidence 없음 포함)는 SUPPORTED.
+   * verdict 컬럼 NOT NULL 이라 모든 status 에 값을 반환한다.
+   */
+  public static Verdict mapVerdict(ClaimScoreStatus status, List<EvidenceSnapshot> evidence) {
+    return switch (status) {
+      case SCORABLE -> isMajorityContradicted(evidence) ? Verdict.CONTRADICTED : Verdict.SUPPORTED;
+      case INSUFFICIENT -> Verdict.INSUFFICIENT;
+      case TIME_SENSITIVE -> Verdict.TIME_SENSITIVE;
+      case OUT_OF_SCOPE -> Verdict.OUT_OF_SCOPE;
+    };
+  }
+
+  /**
+   * evidence stance 다수결 — CONTRADICTED 수가 SUPPORTED 수보다 많으면 true (null/빈 리스트는 false).
+   *
+   * <p>AnalysisTransactionService.isMajorityContradicted 위임 대상 메서드.
+   */
+  public static boolean isMajorityContradicted(List<EvidenceSnapshot> evidence) {
+    if (evidence == null || evidence.isEmpty()) {
+      return false;
+    }
+    long contradicted = evidence.stream().filter(e -> "CONTRADICTED".equals(e.stance())).count();
+    long supported = evidence.stream().filter(e -> "SUPPORTED".equals(e.stance())).count();
+    return contradicted > supported;
+  }
+
+  /**
+   * VerificationResult.reason (NOT NULL TEXT) 의 v1.x 기본 메시지를 생성한다.
+   *
+   * <p>Tier 1: 팩트체크 기관 매칭 / Tier 2: 다중 출처 cascade / Tier 3: Validator 미판정 사유.
+   */
+  public static String buildReason(ClaimVerificationSignal signal) {
+    return switch (signal.status()) {
+      case SCORABLE -> signal.tier() == 1 ? "Tier 1 팩트체크 기관 매칭 결과" : "Tier 2 다중 출처 cascade 검증 결과";
+      case INSUFFICIENT -> "Tier 3 검증 출처 부족";
+      case TIME_SENSITIVE -> "Tier 3 시점 의존성으로 검증 보류";
+      case OUT_OF_SCOPE -> "Tier 3 검증 범위 외 claim";
+    };
+  }
+}

--- a/core/src/main/java/com/truthscope/web/scoring/ReVerifyPolicy.java
+++ b/core/src/main/java/com/truthscope/web/scoring/ReVerifyPolicy.java
@@ -4,14 +4,16 @@ import java.time.Duration;
 import java.util.Objects;
 
 /** 재검증 정책 (UC-145). 쿨다운과 supersede 4조건 임계값 — production 값은 yml 주입(ADR-009 4조건). */
-public record ReVerifyPolicy(Duration cooldown, int scoreDriftThreshold, double urlReplacementRatio) {
+public record ReVerifyPolicy(
+    Duration cooldown, int scoreDriftThreshold, double urlReplacementRatio) {
   public ReVerifyPolicy {
     Objects.requireNonNull(cooldown, "cooldown은 null일 수 없다");
     if (cooldown.isNegative()) {
       throw new IllegalArgumentException("cooldown은 음수일 수 없다: " + cooldown);
     }
     if (scoreDriftThreshold < 0 || scoreDriftThreshold > 100) {
-      throw new IllegalArgumentException("scoreDriftThreshold는 0..100이어야 한다: " + scoreDriftThreshold);
+      throw new IllegalArgumentException(
+          "scoreDriftThreshold는 0..100이어야 한다: " + scoreDriftThreshold);
     }
     if (urlReplacementRatio < 0.0 || urlReplacementRatio > 1.0) {
       throw new IllegalArgumentException("urlReplacementRatio는 0..1이어야 한다: " + urlReplacementRatio);

--- a/core/src/main/java/com/truthscope/web/scoring/ReVerifyPolicy.java
+++ b/core/src/main/java/com/truthscope/web/scoring/ReVerifyPolicy.java
@@ -1,0 +1,20 @@
+package com.truthscope.web.scoring;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/** 재검증 정책 (UC-145). 쿨다운과 supersede 4조건 임계값 — production 값은 yml 주입(ADR-009 4조건). */
+public record ReVerifyPolicy(Duration cooldown, int scoreDriftThreshold, double urlReplacementRatio) {
+  public ReVerifyPolicy {
+    Objects.requireNonNull(cooldown, "cooldown은 null일 수 없다");
+    if (cooldown.isNegative()) {
+      throw new IllegalArgumentException("cooldown은 음수일 수 없다: " + cooldown);
+    }
+    if (scoreDriftThreshold < 0 || scoreDriftThreshold > 100) {
+      throw new IllegalArgumentException("scoreDriftThreshold는 0..100이어야 한다: " + scoreDriftThreshold);
+    }
+    if (urlReplacementRatio < 0.0 || urlReplacementRatio > 1.0) {
+      throw new IllegalArgumentException("urlReplacementRatio는 0..1이어야 한다: " + urlReplacementRatio);
+    }
+  }
+}

--- a/core/src/main/java/com/truthscope/web/scoring/SupersedeDecider.java
+++ b/core/src/main/java/com/truthscope/web/scoring/SupersedeDecider.java
@@ -16,12 +16,12 @@ import lombok.NoArgsConstructor;
  *   <li>LABEL_CHANGED: oldLabel != null &amp;&amp; newLabel != null &amp;&amp; oldLabel != newLabel
  *   <li>TIER_CHANGED: oldTier != newTier
  *   <li>SCORE_DRIFT: |newScore - oldScore| > scoreDriftThreshold (정확히 임계값이면 미발동 — "초과")
- *   <li>URL_REPLACEMENT: !oldUrls.isEmpty() &amp;&amp; 교체 비율 &gt;= urlReplacementRatio ("이상" —
- *       정확히 30%이면 발동)
+ *   <li>URL_REPLACEMENT: !oldUrls.isEmpty() &amp;&amp; 교체 비율 &gt;= urlReplacementRatio ("이상" — 정확히
+ *       30%이면 발동)
  * </ol>
  *
- * <p>경계 의미 비대칭: SCORE_DRIFT는 "초과"(임계값 미포함), URL_REPLACEMENT는 "이상"(임계값 포함). ADR-009
- * 원문("점수 차 15 초과" vs "30% 이상") 그대로 구현한다.
+ * <p>경계 의미 비대칭: SCORE_DRIFT는 "초과"(임계값 미포함), URL_REPLACEMENT는 "이상"(임계값 포함). ADR-009 원문("점수 차 15 초과"
+ * vs "30% 이상") 그대로 구현한다.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class SupersedeDecider {

--- a/core/src/main/java/com/truthscope/web/scoring/SupersedeDecider.java
+++ b/core/src/main/java/com/truthscope/web/scoring/SupersedeDecider.java
@@ -40,6 +40,7 @@ public final class SupersedeDecider {
    * @param policy 재검증 정책 (scoreDriftThreshold, urlReplacementRatio).
    * @return 첫 번째로 충족된 SupersedeReason, 전부 미충족이면 Optional.empty().
    */
+  // CHECKSTYLE:OFF
   public static Optional<SupersedeReason> decide(
       Integer oldScore,
       Integer newScore,
@@ -83,4 +84,5 @@ public final class SupersedeDecider {
 
     return Optional.empty();
   }
+  // CHECKSTYLE:ON
 }

--- a/core/src/main/java/com/truthscope/web/scoring/SupersedeDecider.java
+++ b/core/src/main/java/com/truthscope/web/scoring/SupersedeDecider.java
@@ -1,0 +1,86 @@
+package com.truthscope.web.scoring;
+
+import com.truthscope.web.entity.enums.SupersedeReason;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * 재검증 결과가 기존 판정을 supersede해야 하는지 여부를 판별하는 순수 함수(ADR-009 4조건 OR).
+ *
+ * <p>조건 우선순위 (첫 번째 충족 사유를 반환):
+ *
+ * <ol>
+ *   <li>LABEL_CHANGED: oldLabel != null &amp;&amp; newLabel != null &amp;&amp; oldLabel != newLabel
+ *   <li>TIER_CHANGED: oldTier != newTier
+ *   <li>SCORE_DRIFT: |newScore - oldScore| > scoreDriftThreshold (정확히 임계값이면 미발동 — "초과")
+ *   <li>URL_REPLACEMENT: !oldUrls.isEmpty() &amp;&amp; 교체 비율 &gt;= urlReplacementRatio ("이상" —
+ *       정확히 30%이면 발동)
+ * </ol>
+ *
+ * <p>경계 의미 비대칭: SCORE_DRIFT는 "초과"(임계값 미포함), URL_REPLACEMENT는 "이상"(임계값 포함). ADR-009
+ * 원문("점수 차 15 초과" vs "30% 이상") 그대로 구현한다.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class SupersedeDecider {
+
+  /**
+   * supersede 사유를 판별한다.
+   *
+   * @param oldScore 기존 판정 점수. 비판정(Tier 3)이면 null.
+   * @param newScore 재검증 점수. 비판정이면 null.
+   * @param oldTier 기존 tier (1, 2, 3).
+   * @param newTier 재검증 tier (1, 2, 3).
+   * @param oldLabel 기존 TruthLabel. 비판정이면 null.
+   * @param newLabel 재검증 TruthLabel. 비판정이면 null.
+   * @param oldUrls 기존 판정에 사용된 출처 URL 집합.
+   * @param newUrls 재검증에 사용된 출처 URL 집합.
+   * @param policy 재검증 정책 (scoreDriftThreshold, urlReplacementRatio).
+   * @return 첫 번째로 충족된 SupersedeReason, 전부 미충족이면 Optional.empty().
+   */
+  public static Optional<SupersedeReason> decide(
+      Integer oldScore,
+      Integer newScore,
+      short oldTier,
+      short newTier,
+      TruthLabel oldLabel,
+      TruthLabel newLabel,
+      Set<String> oldUrls,
+      Set<String> newUrls,
+      ReVerifyPolicy policy) {
+
+    Objects.requireNonNull(oldUrls, "oldUrls는 null일 수 없다");
+    Objects.requireNonNull(newUrls, "newUrls는 null일 수 없다");
+    Objects.requireNonNull(policy, "policy는 null일 수 없다");
+
+    // 1. LABEL_CHANGED: 라벨이 모두 존재하며 다를 때
+    if (oldLabel != null && newLabel != null && oldLabel != newLabel) {
+      return Optional.of(SupersedeReason.LABEL_CHANGED);
+    }
+
+    // 2. TIER_CHANGED: tier가 변경됐을 때
+    if (oldTier != newTier) {
+      return Optional.of(SupersedeReason.TIER_CHANGED);
+    }
+
+    // 3. SCORE_DRIFT: 점수 차가 임계값을 "초과"할 때 (정확히 임계값이면 미발동)
+    if (oldScore != null && newScore != null) {
+      if (Math.abs(oldScore - newScore) > policy.scoreDriftThreshold()) {
+        return Optional.of(SupersedeReason.SCORE_DRIFT);
+      }
+    }
+
+    // 4. URL_REPLACEMENT: 교체 비율이 urlReplacementRatio "이상"일 때 (정확히 임계값이면 발동)
+    if (!oldUrls.isEmpty()) {
+      long removedCount = oldUrls.stream().filter(url -> !newUrls.contains(url)).count();
+      double replacementRatio = (double) removedCount / oldUrls.size();
+      if (replacementRatio >= policy.urlReplacementRatio()) {
+        return Optional.of(SupersedeReason.URL_REPLACEMENT);
+      }
+    }
+
+    return Optional.empty();
+  }
+}

--- a/core/src/test/java/com/truthscope/web/scoring/SupersedeDeciderTest.java
+++ b/core/src/test/java/com/truthscope/web/scoring/SupersedeDeciderTest.java
@@ -1,0 +1,272 @@
+package com.truthscope.web.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.truthscope.web.entity.enums.SupersedeReason;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * SupersedeDecider 단위 테스트 (ADR-009 4조건 OR, 우선순위 순).
+ *
+ * <p>fixture ScoreBandPolicy(80,60,40,20): FACT=80이상, MOSTLY_FACT=60이상, PARTLY_FACT=40이상,
+ * MOSTLY_NOT_FACT=20이상, NOT_FACT=20미만.
+ */
+class SupersedeDeciderTest {
+
+  private static final ScoreBandPolicy BAND = new ScoreBandPolicy(80, 60, 40, 20);
+  private static final ReVerifyPolicy POLICY =
+      new ReVerifyPolicy(Duration.ofHours(24), 15, 0.30);
+
+  /** 테스트용 라벨 도출 도우미 — TruthLabelDeriver 직접 사용(프로덕션 코드와 동일 경로). */
+  private TruthLabel label(int score) {
+    return TruthLabelDeriver.deriveTruthLabel(score, BAND);
+  }
+
+  // U1 LABEL_CHANGED -----------------------------------------------------------------
+
+  // (U1a) oldLabel=FACT(score 90), newLabel=PARTLY_FACT(score 50), tier 동일, score 차=40(>15),
+  // URL 동일 → LABEL_CHANGED 반환 (우선순위 1위)
+  @Test
+  @DisplayName("U1a LABEL_CHANGED: 라벨 변경 시 LABEL_CHANGED 반환")
+  void decide_returnsLABEL_CHANGED_whenLabelDiffers() {
+    int oldScore = 90;
+    int newScore = 50;
+    Set<String> sameUrls = Set.of("http://a.com", "http://b.com");
+
+    Optional<SupersedeReason> result =
+        SupersedeDecider.decide(
+            oldScore, newScore,
+            (short) 2, (short) 2,
+            label(oldScore), label(newScore),
+            sameUrls, sameUrls,
+            POLICY);
+
+    assertThat(result).isPresent();
+    assertThat(result.get()).isEqualTo(SupersedeReason.LABEL_CHANGED);
+  }
+
+  // (U1b) oldLabel==newLabel(둘 다 FACT) → LABEL_CHANGED 미발동 (동일 라벨 조건 미충족)
+  @Test
+  @DisplayName("U1b LABEL_CHANGED: 동일 라벨이면 미발동")
+  void decide_doesNotReturnLABEL_CHANGED_whenSameLabel() {
+    int oldScore = 90;
+    int newScore = 85; // 둘 다 FACT (80 이상), 차 = 5(<= 15) → SCORE_DRIFT도 미발동
+    Set<String> sameUrls = Set.of("http://a.com");
+
+    Optional<SupersedeReason> result =
+        SupersedeDecider.decide(
+            oldScore, newScore,
+            (short) 2, (short) 2,
+            label(oldScore), label(newScore),
+            sameUrls, sameUrls,
+            POLICY);
+
+    assertThat(result).isEmpty();
+  }
+
+  // U2 SCORE_DRIFT 경계 --------------------------------------------------------------
+
+  // (U2a) old 95, new 80 → 둘 다 FACT, tier 동일(2), 차 = 15 (임계값 15 이하, 정확히 15 = 미발동)
+  // → empty (SCORE_DRIFT 미발동)
+  @Test
+  @DisplayName("U2a SCORE_DRIFT: 차이가 임계값(15)과 정확히 같으면 미발동(초과 조건)")
+  void decide_doesNotFireSCORE_DRIFT_whenDiffEqualsThreshold() {
+    int oldScore = 95;
+    int newScore = 80; // 차 = 15, 둘 다 FACT(라벨 동일), tier 동일
+    Set<String> sameUrls = Set.of("http://a.com");
+
+    Optional<SupersedeReason> result =
+        SupersedeDecider.decide(
+            oldScore, newScore,
+            (short) 2, (short) 2,
+            label(oldScore), label(newScore),
+            sameUrls, sameUrls,
+            POLICY);
+
+    assertThat(result).isEmpty();
+  }
+
+  // (U2b) old 96, new 80 → 둘 다 FACT, tier 동일(2), 차 = 16 (임계값 15 초과 → SCORE_DRIFT 발동)
+  @Test
+  @DisplayName("U2b SCORE_DRIFT: 차이가 임계값(15)을 초과(16)하면 발동")
+  void decide_returnsSCORE_DRIFT_whenDiffExceedsThreshold() {
+    int oldScore = 96;
+    int newScore = 80; // 차 = 16 > 15, 둘 다 FACT(라벨 동일), tier 동일
+    Set<String> sameUrls = Set.of("http://a.com");
+
+    Optional<SupersedeReason> result =
+        SupersedeDecider.decide(
+            oldScore, newScore,
+            (short) 2, (short) 2,
+            label(oldScore), label(newScore),
+            sameUrls, sameUrls,
+            POLICY);
+
+    assertThat(result).isPresent();
+    assertThat(result.get()).isEqualTo(SupersedeReason.SCORE_DRIFT);
+  }
+
+  // U3 URL_REPLACEMENT 경계 ----------------------------------------------------------
+
+  // (U3a) oldUrls 10개, newUrls에 없는 것 3개(30%) → 30% 이상이므로 URL_REPLACEMENT 발동
+  @Test
+  @DisplayName("U3a URL_REPLACEMENT: 교체 비율이 임계값(30%)과 정확히 같으면 발동(이상 조건)")
+  void decide_returnsURL_REPLACEMENT_whenRatioAtThreshold() {
+    // 라벨 동일(FACT), tier 동일, 차 <= 15 이므로 LABEL_CHANGED/TIER_CHANGED/SCORE_DRIFT 미발동
+    int oldScore = 90;
+    int newScore = 88; // 차=2, 둘 다 FACT
+    Set<String> oldUrls =
+        Set.of(
+            "http://1.com", "http://2.com", "http://3.com", "http://4.com", "http://5.com",
+            "http://6.com", "http://7.com", "http://8.com", "http://9.com", "http://10.com");
+    // new에는 1~7만 있고 8,9,10은 없음 → 없는 것 3개, 비율 3/10 = 30% (이상이므로 발동)
+    Set<String> newUrls =
+        Set.of(
+            "http://1.com", "http://2.com", "http://3.com", "http://4.com", "http://5.com",
+            "http://6.com", "http://7.com");
+
+    Optional<SupersedeReason> result =
+        SupersedeDecider.decide(
+            oldScore, newScore,
+            (short) 2, (short) 2,
+            label(oldScore), label(newScore),
+            oldUrls, newUrls,
+            POLICY);
+
+    assertThat(result).isPresent();
+    assertThat(result.get()).isEqualTo(SupersedeReason.URL_REPLACEMENT);
+  }
+
+  // (U3b) oldUrls 10개, newUrls에 없는 것 2개(20%) → 20% < 30%, URL_REPLACEMENT 미발동
+  // 주의: PLAN U3는 "29% 미발동"을 명시했으나 10개 URL 기준 정수 표현 불가(2.9개 = 불가).
+  // 정수로 표현 가능한 경계 바로 아래 값인 2개(20%)로 대체. 임계값(30%) 미만임은 동일하게 검증됨.
+  @Test
+  @DisplayName("U3b URL_REPLACEMENT: 교체 비율이 임계값(30%) 미만(20%)이면 미발동")
+  void decide_doesNotFireURL_REPLACEMENT_whenRatioBelowThreshold() {
+    int oldScore = 90;
+    int newScore = 88;
+    Set<String> oldUrls =
+        Set.of(
+            "http://1.com", "http://2.com", "http://3.com", "http://4.com", "http://5.com",
+            "http://6.com", "http://7.com", "http://8.com", "http://9.com", "http://10.com");
+    // new에는 1~8만 있고 9,10은 없음 → 없는 것 2개, 비율 2/10 = 20% (30% 미만이므로 미발동)
+    Set<String> newUrls =
+        Set.of(
+            "http://1.com", "http://2.com", "http://3.com", "http://4.com", "http://5.com",
+            "http://6.com", "http://7.com", "http://8.com");
+
+    Optional<SupersedeReason> result =
+        SupersedeDecider.decide(
+            oldScore, newScore,
+            (short) 2, (short) 2,
+            label(oldScore), label(newScore),
+            oldUrls, newUrls,
+            POLICY);
+
+    assertThat(result).isEmpty();
+  }
+
+  // (U3c) oldUrls 빈 집합 → URL_REPLACEMENT 미발동
+  @Test
+  @DisplayName("U3c URL_REPLACEMENT: oldUrls가 빈 집합이면 미발동")
+  void decide_doesNotFireURL_REPLACEMENT_whenOldUrlsEmpty() {
+    int oldScore = 90;
+    int newScore = 88;
+
+    Optional<SupersedeReason> result =
+        SupersedeDecider.decide(
+            oldScore, newScore,
+            (short) 2, (short) 2,
+            label(oldScore), label(newScore),
+            Set.of(), Set.of("http://a.com"),
+            POLICY);
+
+    assertThat(result).isEmpty();
+  }
+
+  // U4 TIER_CHANGED ------------------------------------------------------------------
+
+  // (U4a) tier 2 → 1 변경 → TIER_CHANGED 발동
+  @Test
+  @DisplayName("U4a TIER_CHANGED: tier가 변경되면 발동")
+  void decide_returnsTIER_CHANGED_whenTierDecreases() {
+    int oldScore = 70;
+    int newScore = 72; // 둘 다 MOSTLY_FACT(라벨 동일), 차=2(<= 15)
+    Set<String> sameUrls = Set.of("http://a.com");
+
+    Optional<SupersedeReason> result =
+        SupersedeDecider.decide(
+            oldScore, newScore,
+            (short) 2, (short) 1, // tier 2 → 1
+            label(oldScore), label(newScore),
+            sameUrls, sameUrls,
+            POLICY);
+
+    assertThat(result).isPresent();
+    assertThat(result.get()).isEqualTo(SupersedeReason.TIER_CHANGED);
+  }
+
+  // (U4b) oldScore null(비판정 — tier 3, oldLabel null), newLabel=MOSTLY_FACT(tier 3 → 2) → TIER_CHANGED
+  @Test
+  @DisplayName("U4b TIER_CHANGED: 비판정(null)에서 SCORABLE로 승격 시 발동")
+  void decide_returnsTIER_CHANGED_whenNewlyScorable() {
+    Set<String> sameUrls = Set.of("http://a.com");
+
+    Optional<SupersedeReason> result =
+        SupersedeDecider.decide(
+            null, 70,    // oldScore null = 비판정
+            (short) 3, (short) 2, // tier 3 → 2
+            null, label(70),     // oldLabel null = 비판정
+            sameUrls, sameUrls,
+            POLICY);
+
+    assertThat(result).isPresent();
+    assertThat(result.get()).isEqualTo(SupersedeReason.TIER_CHANGED);
+  }
+
+  // U5 전부 미충족 / 우선순위 -----------------------------------------------------------
+
+  // (U5a) 4조건 전부 미충족 → empty
+  @Test
+  @DisplayName("U5a: 4조건 전부 미충족이면 Optional.empty() 반환")
+  void decide_returnsEmpty_whenNoConditionMet() {
+    int oldScore = 90;
+    int newScore = 88; // 둘 다 FACT, tier 동일, 차=2(<= 15), URL 동일
+    Set<String> sameUrls = Set.of("http://a.com");
+
+    Optional<SupersedeReason> result =
+        SupersedeDecider.decide(
+            oldScore, newScore,
+            (short) 2, (short) 2,
+            label(oldScore), label(newScore),
+            sameUrls, sameUrls,
+            POLICY);
+
+    assertThat(result).isEmpty();
+  }
+
+  // (U5b) LABEL_CHANGED + SCORE_DRIFT 동시 충족 → LABEL_CHANGED 반환 (우선순위 1위)
+  @Test
+  @DisplayName("U5b 우선순위: LABEL_CHANGED와 SCORE_DRIFT 동시 충족 시 LABEL_CHANGED 반환")
+  void decide_returnsLABEL_CHANGED_overSCORE_DRIFT_whenBothMet() {
+    // old 90(FACT) → new 50(PARTLY_FACT): 라벨 변경 + 차=40(>15)
+    int oldScore = 90;
+    int newScore = 50;
+    Set<String> sameUrls = Set.of("http://a.com");
+
+    Optional<SupersedeReason> result =
+        SupersedeDecider.decide(
+            oldScore, newScore,
+            (short) 2, (short) 2,
+            label(oldScore), label(newScore),
+            sameUrls, sameUrls,
+            POLICY);
+
+    assertThat(result).isPresent();
+    assertThat(result.get()).isEqualTo(SupersedeReason.LABEL_CHANGED);
+  }
+}

--- a/core/src/test/java/com/truthscope/web/scoring/SupersedeDeciderTest.java
+++ b/core/src/test/java/com/truthscope/web/scoring/SupersedeDeciderTest.java
@@ -18,8 +18,7 @@ import org.junit.jupiter.api.Test;
 class SupersedeDeciderTest {
 
   private static final ScoreBandPolicy BAND = new ScoreBandPolicy(80, 60, 40, 20);
-  private static final ReVerifyPolicy POLICY =
-      new ReVerifyPolicy(Duration.ofHours(24), 15, 0.30);
+  private static final ReVerifyPolicy POLICY = new ReVerifyPolicy(Duration.ofHours(24), 15, 0.30);
 
   /** 테스트용 라벨 도출 도우미 — TruthLabelDeriver 직접 사용(프로덕션 코드와 동일 경로). */
   private TruthLabel label(int score) {
@@ -39,10 +38,14 @@ class SupersedeDeciderTest {
 
     Optional<SupersedeReason> result =
         SupersedeDecider.decide(
-            oldScore, newScore,
-            (short) 2, (short) 2,
-            label(oldScore), label(newScore),
-            sameUrls, sameUrls,
+            oldScore,
+            newScore,
+            (short) 2,
+            (short) 2,
+            label(oldScore),
+            label(newScore),
+            sameUrls,
+            sameUrls,
             POLICY);
 
     assertThat(result).isPresent();
@@ -59,10 +62,14 @@ class SupersedeDeciderTest {
 
     Optional<SupersedeReason> result =
         SupersedeDecider.decide(
-            oldScore, newScore,
-            (short) 2, (short) 2,
-            label(oldScore), label(newScore),
-            sameUrls, sameUrls,
+            oldScore,
+            newScore,
+            (short) 2,
+            (short) 2,
+            label(oldScore),
+            label(newScore),
+            sameUrls,
+            sameUrls,
             POLICY);
 
     assertThat(result).isEmpty();
@@ -81,10 +88,14 @@ class SupersedeDeciderTest {
 
     Optional<SupersedeReason> result =
         SupersedeDecider.decide(
-            oldScore, newScore,
-            (short) 2, (short) 2,
-            label(oldScore), label(newScore),
-            sameUrls, sameUrls,
+            oldScore,
+            newScore,
+            (short) 2,
+            (short) 2,
+            label(oldScore),
+            label(newScore),
+            sameUrls,
+            sameUrls,
             POLICY);
 
     assertThat(result).isEmpty();
@@ -100,10 +111,14 @@ class SupersedeDeciderTest {
 
     Optional<SupersedeReason> result =
         SupersedeDecider.decide(
-            oldScore, newScore,
-            (short) 2, (short) 2,
-            label(oldScore), label(newScore),
-            sameUrls, sameUrls,
+            oldScore,
+            newScore,
+            (short) 2,
+            (short) 2,
+            label(oldScore),
+            label(newScore),
+            sameUrls,
+            sameUrls,
             POLICY);
 
     assertThat(result).isPresent();
@@ -121,20 +136,37 @@ class SupersedeDeciderTest {
     int newScore = 88; // 차=2, 둘 다 FACT
     Set<String> oldUrls =
         Set.of(
-            "http://1.com", "http://2.com", "http://3.com", "http://4.com", "http://5.com",
-            "http://6.com", "http://7.com", "http://8.com", "http://9.com", "http://10.com");
+            "http://1.com",
+            "http://2.com",
+            "http://3.com",
+            "http://4.com",
+            "http://5.com",
+            "http://6.com",
+            "http://7.com",
+            "http://8.com",
+            "http://9.com",
+            "http://10.com");
     // new에는 1~7만 있고 8,9,10은 없음 → 없는 것 3개, 비율 3/10 = 30% (이상이므로 발동)
     Set<String> newUrls =
         Set.of(
-            "http://1.com", "http://2.com", "http://3.com", "http://4.com", "http://5.com",
-            "http://6.com", "http://7.com");
+            "http://1.com",
+            "http://2.com",
+            "http://3.com",
+            "http://4.com",
+            "http://5.com",
+            "http://6.com",
+            "http://7.com");
 
     Optional<SupersedeReason> result =
         SupersedeDecider.decide(
-            oldScore, newScore,
-            (short) 2, (short) 2,
-            label(oldScore), label(newScore),
-            oldUrls, newUrls,
+            oldScore,
+            newScore,
+            (short) 2,
+            (short) 2,
+            label(oldScore),
+            label(newScore),
+            oldUrls,
+            newUrls,
             POLICY);
 
     assertThat(result).isPresent();
@@ -151,20 +183,38 @@ class SupersedeDeciderTest {
     int newScore = 88;
     Set<String> oldUrls =
         Set.of(
-            "http://1.com", "http://2.com", "http://3.com", "http://4.com", "http://5.com",
-            "http://6.com", "http://7.com", "http://8.com", "http://9.com", "http://10.com");
+            "http://1.com",
+            "http://2.com",
+            "http://3.com",
+            "http://4.com",
+            "http://5.com",
+            "http://6.com",
+            "http://7.com",
+            "http://8.com",
+            "http://9.com",
+            "http://10.com");
     // new에는 1~8만 있고 9,10은 없음 → 없는 것 2개, 비율 2/10 = 20% (30% 미만이므로 미발동)
     Set<String> newUrls =
         Set.of(
-            "http://1.com", "http://2.com", "http://3.com", "http://4.com", "http://5.com",
-            "http://6.com", "http://7.com", "http://8.com");
+            "http://1.com",
+            "http://2.com",
+            "http://3.com",
+            "http://4.com",
+            "http://5.com",
+            "http://6.com",
+            "http://7.com",
+            "http://8.com");
 
     Optional<SupersedeReason> result =
         SupersedeDecider.decide(
-            oldScore, newScore,
-            (short) 2, (short) 2,
-            label(oldScore), label(newScore),
-            oldUrls, newUrls,
+            oldScore,
+            newScore,
+            (short) 2,
+            (short) 2,
+            label(oldScore),
+            label(newScore),
+            oldUrls,
+            newUrls,
             POLICY);
 
     assertThat(result).isEmpty();
@@ -179,10 +229,14 @@ class SupersedeDeciderTest {
 
     Optional<SupersedeReason> result =
         SupersedeDecider.decide(
-            oldScore, newScore,
-            (short) 2, (short) 2,
-            label(oldScore), label(newScore),
-            Set.of(), Set.of("http://a.com"),
+            oldScore,
+            newScore,
+            (short) 2,
+            (short) 2,
+            label(oldScore),
+            label(newScore),
+            Set.of(),
+            Set.of("http://a.com"),
             POLICY);
 
     assertThat(result).isEmpty();
@@ -200,17 +254,22 @@ class SupersedeDeciderTest {
 
     Optional<SupersedeReason> result =
         SupersedeDecider.decide(
-            oldScore, newScore,
-            (short) 2, (short) 1, // tier 2 → 1
-            label(oldScore), label(newScore),
-            sameUrls, sameUrls,
+            oldScore,
+            newScore,
+            (short) 2,
+            (short) 1, // tier 2 → 1
+            label(oldScore),
+            label(newScore),
+            sameUrls,
+            sameUrls,
             POLICY);
 
     assertThat(result).isPresent();
     assertThat(result.get()).isEqualTo(SupersedeReason.TIER_CHANGED);
   }
 
-  // (U4b) oldScore null(비판정 — tier 3, oldLabel null), newLabel=MOSTLY_FACT(tier 3 → 2) → TIER_CHANGED
+  // (U4b) oldScore null(비판정 — tier 3, oldLabel null), newLabel=MOSTLY_FACT(tier 3 → 2) →
+  // TIER_CHANGED
   @Test
   @DisplayName("U4b TIER_CHANGED: 비판정(null)에서 SCORABLE로 승격 시 발동")
   void decide_returnsTIER_CHANGED_whenNewlyScorable() {
@@ -218,11 +277,10 @@ class SupersedeDeciderTest {
 
     Optional<SupersedeReason> result =
         SupersedeDecider.decide(
-            null, 70,    // oldScore null = 비판정
+            null, 70, // oldScore null = 비판정
             (short) 3, (short) 2, // tier 3 → 2
-            null, label(70),     // oldLabel null = 비판정
-            sameUrls, sameUrls,
-            POLICY);
+            null, label(70), // oldLabel null = 비판정
+            sameUrls, sameUrls, POLICY);
 
     assertThat(result).isPresent();
     assertThat(result.get()).isEqualTo(SupersedeReason.TIER_CHANGED);
@@ -240,10 +298,14 @@ class SupersedeDeciderTest {
 
     Optional<SupersedeReason> result =
         SupersedeDecider.decide(
-            oldScore, newScore,
-            (short) 2, (short) 2,
-            label(oldScore), label(newScore),
-            sameUrls, sameUrls,
+            oldScore,
+            newScore,
+            (short) 2,
+            (short) 2,
+            label(oldScore),
+            label(newScore),
+            sameUrls,
+            sameUrls,
             POLICY);
 
     assertThat(result).isEmpty();
@@ -260,10 +322,14 @@ class SupersedeDeciderTest {
 
     Optional<SupersedeReason> result =
         SupersedeDecider.decide(
-            oldScore, newScore,
-            (short) 2, (short) 2,
-            label(oldScore), label(newScore),
-            sameUrls, sameUrls,
+            oldScore,
+            newScore,
+            (short) 2,
+            (short) 2,
+            label(oldScore),
+            label(newScore),
+            sameUrls,
+            sameUrls,
             POLICY);
 
     assertThat(result).isPresent();


### PR DESCRIPTION
<!-- SAFE_OP_START -->
Assumptions: 없음
Scope: app/src/main/resources/db/migration/V9, core entity(VerificationResult, SupersedeReason, AnalysisSession), core/scoring(ReVerifyPolicy, SupersedeDecider), core/factory(VerificationResultFactory), core/exception(TooManyRequestsException), core/dto/response(ReVerifyAcceptedResponse), app repository(VerificationResultRepository), app service(ReVerifyTransactionService, ReVerifyService, AsyncReVerifyService, AnalysisTransactionService 위임 추출), app controller(ReVerifyController), app config(ScoringPolicyConfig), application.yml, 관련 테스트
Out-of-scope: UC-146 스케줄 재검증, FE supersede chain UI, Bucket4j 일일 한도, user_reactions 정리(기능 제거 결정 별 트랙), 발행일 영속화
<!-- SAFE_OP_END -->

## 개요

ADR-009(오보 피드백 루프 — supersede 정정 정책)를 코드로 구현한다. UC-145 사용자 재검증.

- verification_results를 1:1에서 supersede 체인 1:N으로 전환(V9: 5컬럼 + partial unique `claim_id WHERE superseded_at IS NULL`)
- `POST /api/v1/verification-results/{id}/re-verify` — 202 접수 후 @Async cascade 재실행, 4조건(라벨 반전 / 점수 차 15 초과 / URL 30% 이상 교체 / Tier 변경) 충족 시에만 INSERT-only supersede, 미충족이면 last_confirmed_at만 갱신
- 동시성: 간이 쿨다운(PT10M, 429) + pg_try_advisory_xact_lock(no-op 직렬화) + partial unique 최후 방어선
- 기사 점수: 세션 집계를 updateAggregates로 재계산(completedAt 보존 — 정정 이력 투명성)
- 조회 경로는 current 전용(findCurrent 계열)으로 교체 — superseded 행은 화면에 미노출

## Done

요구사항 (AC):
- 재검증 요청이 202로 접수되고 비동기 완료 후 기존 GET 폴링으로 새 결과 확인 가능
- 4조건 미충족 시 행 수 불변 + last_confirmed_at 갱신 (이력 증식 방지)
- supersede 후 기존 결과는 삭제되지 않고 superseded_at, superseded_by_result_id, supersede_reason, original_result_id로 체인 보존 (IFCN 원칙 5)
- 에러 계약: 404(부재) / 409(superseded 행 재요청) / 429(쿨다운 10분)
- 동시 2요청 시 supersede 1건만 발생, 늦은 쪽 no-op

산출물: V9 마이그레이션, 엔티티·enum, SupersedeDecider, ReVerifyPolicy(yml 주입), ReVerify 서비스 3종 + 컨트롤러 + DTO + 429 예외, current 전용 repository

수용 테스트:
- 단위: SupersedeDecider 경계 11건(차 15 미발동·16 발동, 30% 발동·29% 미발동 등), ReVerifyTransactionService 13건, 컨트롤러 5건(202/404/409/429/400)
- 통합(Testcontainers): I1-I7 — supersede 체인·세션 재집계, no-op 분기, 쿨다운 429 실경로, 조회 회귀(옛 결과 미반환), CountDownLatch 동시성
- 전체 618 테스트 0 failure + spotless/checkstyle/spotbugs/build GREEN

## 회귀 시뮬레이션 ABC (무력화-FAIL-복구 실측, .plans/72-reverify-supersede/regression-sim/ 6로그)

- A(state) markSuperseded의 supersededAt 세팅 제거: I1/I4/I6/I7 FAIL — `duplicate key value violates unique constraint "uq_vr_claim_current"` (partial unique 방어선 실증) / 복구 후 BUILD SUCCESSFUL
- B(logic) SCORE_DRIFT 경계 `>`를 `>=`로: U2a FAIL — `AssertionError` (경계 15 미발동 검증) / 복구 후 BUILD SUCCESSFUL
- C(contract) 경로 re-verify를 reverify로: 컨트롤러 테스트 5건 FAIL(404) / 복구 후 BUILD SUCCESSFUL

## 참조

- 설계 정본: context/decisions/ADR-009-correction-policy.md (rev.3 — 타입·케이스 구현 정합 정정 포함)
- 계획·리뷰 이력: .plans/72-reverify-supersede/ (DISCUSS, PLAN rev.2 — Claude+codex 교차 plan-review 2라운드 수렴, CHECKLIST)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 검증 결과 재검증 API 엔드포인트(`POST /api/v1/verification-results/{id}/re-verify`) 추가
  * 재검증 결과에 따라 기존 검증 결과를 자동으로 정정하는 체인 시스템 구현
  * 점수 변동, 라벨 변경, URL 교체, 티어 변경 등의 조건에 따른 자동 슈퍼시드 처리

* **Configuration**
  * 재검증 쿨다운, 점수 드리프트 임계값, URL 교체 비율 설정 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->