### PR TITLE
📝docs(verification): 네이버 보조 출처 Tier 표기를 코드 정본(Tier 2)으로 정정

### DIFF
--- a/app/src/main/java/com/truthscope/web/adapter/datasource/NaverSearchAdapter.java
+++ b/app/src/main/java/com/truthscope/web/adapter/datasource/NaverSearchAdapter.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
 /**
- * Naver News Search API 어댑터 (Phase 72 보조 Tier-1 출처).
+ * Naver News Search API 어댑터 (Tier 2 보조 출처 — 독립 언론 보도 교차 확인용).
  *
  * <p>plain @Component, @Transactional 없음 (RC-01). 실패 시 빈 리스트 반환 (Tier 3 안전강하). 인증키:
  * truthscope.datasource.naver-client-id / naver-client-secret (application-local.yml 주입). 빈 키이면 API

--- a/app/src/main/java/com/truthscope/web/service/verification/HybridCascadeService.java
+++ b/app/src/main/java/com/truthscope/web/service/verification/HybridCascadeService.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Service;
  * 미접근.
  *
  * <p>흐름: 1) EvidenceWindowResolver 로 날짜 윈도우 결정. 2) DataGoKrAdapter.fetchPolicyItems 로 정책뉴스/보도자료 수집.
- * 2b) NaverSearchAdapter.search 로 보조 Tier-1 출처 수집 후 URL dedupe 병합. 3) EvidencePrefilter.top 으로
+ * 2b) NaverSearchAdapter.search 로 Tier 2 보조 출처 수집 후 URL dedupe 병합. 3) EvidencePrefilter.top 으로
  * claim 핵심어 기반 top-8 후보 추출. 4) FidelityClassifierPort.classify 로 SUPPORTED/CONTRADICTED +
  * matchedFields 보유분만 반환. 예외/빈결과 시 빈 List (Tier 3 안전강하).
  */
@@ -71,7 +71,7 @@ public class HybridCascadeService {
       // 2) data.go.kr 정책뉴스 + 보도자료 수집 (날짜 덤프)
       List<DataGoKrPolicyItem> items = dataGoKrAdapter.fetchPolicyItems(from, to);
 
-      // 2b) Naver 뉴스 검색 (보조 Tier-1 출처) — URL 기준 dedupe 병합.
+      // 2b) Naver 뉴스 검색 (Tier 2 보조 출처) — URL 기준 dedupe 병합.
       // Naver 는 날짜 윈도우 밖 post-retrieval 병합 경로이므로 window 미적용이 아키텍처상 정상이다.
       List<DataGoKrPolicyItem> naverItems = naverSearchAdapter.search(claimText);
       LinkedHashMap<String, DataGoKrPolicyItem> mergeMap = new LinkedHashMap<>();


### PR DESCRIPTION
## Done

요구사항: 주석의 "보조 Tier-1" 표기 3곳을 확정 Tier 정의(Tier 1 = factcheck_cache 기관 캐시 게이트, Naver = Tier 2 보조 출처)로 정정 / 변경: app/src/main/java/com/truthscope/web/adapter/datasource/NaverSearchAdapter.java, app/src/main/java/com/truthscope/web/service/verification/HybridCascadeService.java / 검증: 기존 테스트 통과 (로컬 spotlessApply, checkstyleMain, spotbugsMain, test, build 전체 GREEN)

<!-- SAFE_OP_START -->
Assumptions: 없음
Scope: app/src/main/java/com/truthscope/web/adapter/datasource/NaverSearchAdapter.java, app/src/main/java/com/truthscope/web/service/verification/HybridCascadeService.java
Out-of-scope: 동작 코드 전체 (주석만 변경, 3 LOC), application-local.yml (git 미추적)
<!-- SAFE_OP_END -->

## 배경

2026-06-12 점수 트랙 결정으로 Tier 정의가 코드 정본으로 확정됨: Tier 1은 factcheck_cache 기관 팩트체크 캐시 게이트(VerificationCascadeService.cascadeOne에서 적중 시 score 100 즉시 반환), data.go.kr와 Naver 수집 경로는 전부 tier=2로 기록. v1.8 제출 문서 일괄 정정(정오표 본문 흡수, codex 3라운드 교차 검증 PROCEED)과 동일 기준으로 코드 주석의 구표기 "보조 Tier-1" 잔존 3곳을 정합화한다. 동작 무변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 검색 데이터 출처 분류에 관한 문서 내용을 갱신했습니다. 기존 분류 체계를 명확하게 재정의하여 출처 신뢰도 기준을 개선했습니다.

* **Chores**
  * 검증 관련 프로세스 문서의 단계별 설명을 최신화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->